### PR TITLE
Add label_sync tool from kuberenetes to sync labels

### DIFF
--- a/label_sync/.gitignore
+++ b/label_sync/.gitignore
@@ -1,0 +1,4 @@
+config_*.sh
+!config_example.sh
+token--*
+test-infra/

--- a/label_sync/Makefile
+++ b/label_sync/Makefile
@@ -1,0 +1,10 @@
+.PHONY: all default confirm
+
+all: default
+
+default:
+	./sync_labels.sh
+
+confirm:
+	export LABEL_SYNC_CONFIRM="--confirm"
+	./sync_labels.sh

--- a/label_sync/Makefile
+++ b/label_sync/Makefile
@@ -6,5 +6,4 @@ default:
 	./sync_labels.sh
 
 confirm:
-	export LABEL_SYNC_CONFIRM="--confirm"
-	./sync_labels.sh
+	./sync_labels.sh confirm

--- a/label_sync/README.md
+++ b/label_sync/README.md
@@ -1,0 +1,8 @@
+# Label Sync
+
+This makes use of kubernetes test-infra to setup the labels on our
+repos.  Copy config_example.sh and edit the values with the
+configuration you desire, and then run `make` to see a *dry run* of what
+it would do.
+
+To apply the changes, run `make confirm`

--- a/label_sync/config_example.sh
+++ b/label_sync/config_example.sh
@@ -1,0 +1,11 @@
+# Which file to read the labels.yaml from
+export LABEL_SYNC_CONFIG=labels.yaml
+
+# GitHub oauth token here:
+export LABEL_SYNC_GITHUB_TOKEN=""
+
+# Which GitHub org to run this against
+export LABEL_SYNC_GITHUB_ORG="metal3-io"
+
+# A comma-separated list of repos to skip
+# export LABEL_SYNC_SKIP="metal3-io/example1,metal3-io/example2"

--- a/label_sync/labels.yaml
+++ b/label_sync/labels.yaml
@@ -1,0 +1,285 @@
+# default: global configuration to be applied to all repos
+# repos: list of repos with specific configuration to be applied in addition to default
+#   labels: list of labels - keys for each item: color, description, name, target, deleteAfter, previously
+#     deleteAfter: 2006-01-02T15:04:05Z (rfc3339)
+#     previously: list of previous labels (color name deleteAfter, previously)
+#     target: one of issues, prs, or both (also TBD)
+#     addedBy: human? prow plugin? other?
+---
+default:
+  labels:
+    - color: 0ffa16
+      description: Indicates a PR has been approved by an approver from all required OWNERS files.
+      name: approved
+      target: prs
+      prowPlugin: approve
+      addedBy: approvers
+    - color: fef2c0
+      description: Indicates a cherry-pick PR into a release branch has been approved by the release branch manager. # Consumed by the kubernetes/kubernetes cherry-pick-queue.
+      name: cherry-pick-approved
+      target: prs
+      addedBy: humans
+      previously:
+        - name: cherrypick-approved
+    - color: e11d21
+      description: Indicates that a PR should not merge because it touches files in blocked paths.
+      name: do-not-merge/blocked-paths
+      target: prs
+      prowPlugin: blockade
+      addedBy: prow
+    - color: e11d21
+      description: Indicates that a PR is not yet approved to merge into a release branch.
+      name: do-not-merge/cherry-pick-not-approved
+      target: prs
+      addedBy: prow
+      prowPlugin: cherrypickunapproved
+    - color: e11d21
+      description: Indicates that a PR should not merge because someone has issued a /hold command.
+      name: do-not-merge/hold
+      target: prs
+      prowPlugin: hold
+      addedBy: anyone
+    - color: e11d21
+      description: Indicates that a PR should not merge because it has an invalid commit message.
+      name: do-not-merge/invalid-commit-message
+      target: prs
+      prowPlugin: invalidcommitmsg
+      addedBy: prow
+    - color: e11d21
+      description: Indicates that a PR should not merge because it has an invalid OWNERS file in it.
+      name: do-not-merge/invalid-owners-file
+      target: prs
+      prowPlugin: verify-owners
+      addedBy: prow
+    - color: e11d21
+      description: Indicates that a PR should not merge because it's missing one of the release note labels.
+      name: do-not-merge/release-note-label-needed
+      previously:
+        - name: release-note-label-needed
+      target: prs
+      prowPlugin: releasenote
+      addedBy: prow
+    - color: e11d21
+      description: Indicates that a PR should not merge because it is a work in progress.
+      name: do-not-merge/work-in-progress
+      target: prs
+      prowPlugin: wip
+      addedBy: prow
+    - color: 7057ff
+      description: Denotes an issue ready for a new contributor, according to the "help wanted" guidelines.
+      name: 'good first issue'
+      previously:
+        - name: for-new-contributors
+      target: issues
+      prowPlugin: help
+      addedBy: anyone
+    - color: 006b75
+      description: Denotes an issue that needs help from a contributor. Must meet "help wanted" guidelines.
+      name: 'help wanted'
+      previously:
+        - name: help-wanted
+      target: issues
+      prowPlugin: help
+      addedBy: anyone
+    - color: e11d21
+      description: Categorizes issue or PR as related to adding, removing, or otherwise changing an API
+      name: kind/api-change
+      previously:
+        - name: kind/new-api
+      target: both
+      prowPlugin: label
+      addedBy: anyone
+    - color: e11d21
+      description: Categorizes issue or PR as related to a bug.
+      name: kind/bug
+      previously:
+        - name: bug
+      target: both
+      prowPlugin: label
+      addedBy: anyone
+    - color: c7def8
+      description: Categorizes issue or PR as related to cleaning up code, process, or technical debt.
+      name: kind/cleanup
+      previously:
+        - name: kind/friction
+        - name: kind/technical-debt
+      target: both
+      prowPlugin: label
+      addedBy: anyone
+    - color: c7def8
+      description: Categorizes issue or PR as related to design.
+      name: kind/design
+      target: both
+      prowPlugin: label
+      addedBy: anyone
+    - color: c7def8
+      description: Categorizes issue or PR as related to documentation.
+      name: kind/documentation
+      previously:
+        - name: kind/old-docs
+      target: both
+      prowPlugin: label
+      addedBy: anyone
+    - color: e11d21
+      description: Categorizes issue or PR as related to a consistently or frequently failing test.
+      name: kind/failing-test
+      previously:
+        - name: priority/failing-test
+        - name: kind/e2e-test-failure
+        - name: kind/upgrade-test-failure
+      target: both
+      prowPlugin: label
+      addedBy: anyone
+    - color: c7def8
+      description: Categorizes issue or PR as related to a new feature.
+      name: kind/feature
+      previously:
+        - name: enhancement
+        - name: kind/enhancement
+      target: both
+      prowPlugin: label
+      addedBy: anyone
+    - color: f7c6c7
+      description: Categorizes issue or PR as related to a flaky test.
+      name: kind/flake
+      target: both
+      prowPlugin: label
+      addedBy: anyone
+    - color: 15dd18
+      description: Indicates that a PR is ready to be merged.
+      name: lgtm
+      target: prs
+      prowPlugin: lgtm
+      addedBy: reviewers or members
+    - color: b60205
+      description: Indicates a PR that requires an org member to verify it is safe to test. # This is to prevent spam/abuse of our CI system, and can be circumvented by becoming an org member. Org members can remove this label with the `/ok-to-test` command.
+      name: needs-ok-to-test
+      target: prs
+      prowPlugin: trigger
+      addedBy: prow
+    - color: e11d21
+      description: Indicates a PR cannot be merged because it has merge conflicts with HEAD.
+      name: needs-rebase
+      target: prs
+      prowPlugin: needs-rebase
+      addedBy: prow
+    - color: 15dd18
+      description: Indicates a non-member PR verified by an org member that is safe to test. # This is the opposite of needs-ok-to-test and should be mutually exclusive.
+      name: ok-to-test
+      target: prs
+      prowPlugin: trigger
+      addedBy: prow
+    - color: fef2c0
+      description: Lowest priority. Possibly useful, but not yet enough support to actually get it done. # These are mostly place-holders for potentially good ideas, so that they don't get completely forgotten, and can be referenced /deduped every time they come up.
+      name: priority/awaiting-more-evidence
+      target: both
+      prowPlugin: label
+      addedBy: anyone
+    - color: fbca04
+      description: Higher priority than priority/awaiting-more-evidence. # There appears to be general agreement that this would be good to have, but we may not have anyone available to work on it right now or in the immediate future. Community contributions would be most welcome in the mean time (although it might take a while to get them reviewed if reviewers are fully occupied with higher priority issues, for example immediately before a release).
+      name: priority/backlog
+      target: both
+      prowPlugin: label
+      addedBy: anyone
+    - color: e11d21
+      description: Highest priority. Must be actively worked on as someone's top priority right now. # Stuff is burning. If it's not being actively worked on, someone is expected to drop what they're doing immediately to work on it. Team leaders are responsible for making sure that all the issues, labeled with this priority, in their area are being actively worked on. Examples include user-visible bugs in core features, broken builds or tests and critical security issues.
+      name: priority/critical-urgent
+      target: both
+      prowPlugin: label
+      addedBy: anyone
+    - color: eb6420
+      description: Important over the long term, but may not be staffed and/or may need multiple releases to complete.
+      name: priority/important-longterm
+      target: both
+      prowPlugin: label
+      addedBy: anyone
+    - color: eb6420
+      description: Must be staffed and worked on either currently, or very soon, ideally in time for the next release.
+      name: priority/important-soon
+      target: both
+      prowPlugin: label
+      addedBy: anyone
+    - color: c2e0c6
+      description: Denotes a PR that will be considered when it comes time to generate release notes.
+      name: release-note
+      target: prs
+      prowPlugin: releasenote
+      addedBy: prow
+    - color: c2e0c6
+      description: Denotes a PR that introduces potentially breaking changes that require user action. # These actions will be specifically called out when it comes time to generate release notes.
+      name: release-note-action-required
+      target: prs
+      prowPlugin: releasenote
+      addedBy: prow
+    - color: c2e0c6
+      description: Denotes a PR that doesn't merit a release note. # will be ignored when it comes time to generate release notes.
+      name: release-note-none
+      target: prs
+      prowPlugin: releasenote
+      addedBy: prow or member or author
+    - color: ee9900
+      description: Denotes a PR that changes 100-499 lines, ignoring generated files.
+      name: size/L
+      target: prs
+      prowPlugin: size
+      addedBy: prow
+    - color: eebb00
+      description: Denotes a PR that changes 30-99 lines, ignoring generated files.
+      name: size/M
+      target: prs
+      prowPlugin: size
+      addedBy: prow
+    - color: 77bb00
+      description: Denotes a PR that changes 10-29 lines, ignoring generated files.
+      name: size/S
+      target: prs
+      prowPlugin: size
+      addedBy: prow
+    - color: ee5500
+      description: Denotes a PR that changes 500-999 lines, ignoring generated files.
+      name: size/XL
+      target: prs
+      prowPlugin: size
+      addedBy: prow
+    - color: "009900"
+      description: Denotes a PR that changes 0-9 lines, ignoring generated files.
+      name: size/XS
+      target: prs
+      prowPlugin: size
+      addedBy: prow
+    - color: ee0000
+      description: Denotes a PR that changes 1000+ lines, ignoring generated files.
+      name: size/XXL
+      target: prs
+      prowPlugin: size
+      addedBy: prow
+    - color: ffaa00
+      description: Denotes a PR that should be squashed by tide when it merges.
+      name: tide/merge-method-squash
+      target: prs
+      addedBy: humans
+      previously:
+        - name: tide/squash
+    - color: ffaa00
+      description: Denotes a PR that should be rebased by tide when it merges.
+      name: tide/merge-method-rebase
+      target: prs
+      addedBy: humans
+    - color: ffaa00
+      description: Denotes a PR that should use a standard merge by tide when it merges.
+      name: tide/merge-method-merge
+      target: prs
+      addedBy: humans
+    - color: e11d21
+      description: Denotes an issue that blocks the tide merge queue for a branch while it is open.
+      name: tide/merge-blocker
+      target: issues
+      addedBy: humans
+      previously:
+        - name: merge-blocker
+    - color: f9d0c4
+      description: ¯\\\_(ツ)_/¯
+      name: "¯\\_(ツ)_/¯"
+      target: both
+      prowPlugin: shrug
+      addedBy: humans

--- a/label_sync/sync_labels.sh
+++ b/label_sync/sync_labels.sh
@@ -1,0 +1,66 @@
+#!/bin/bash
+set -ex
+
+# Clean-up in case we exit
+function clean {
+  cd "$SCRIPTDIR"
+  rm token--*
+}
+trap clean EXIT
+
+# Find out where we're executed from
+SCRIPTDIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+
+# Get variables from the config file
+if [ -z "${CONFIG:-}" ]; then
+    # See if there's a config_$USER.sh in the SCRIPTDIR
+    if [ -f "${SCRIPTDIR}/config_${USER}.sh" ]; then
+        echo "Using CONFIG ${SCRIPTDIR}/config_${USER}.sh"
+        CONFIG="${SCRIPTDIR}/config_${USER}.sh"
+    else
+        echo "Please run with a configuration environment set."
+        echo "eg CONFIG=config_example.sh ./sync_labels.sh"
+        exit 1
+    fi
+fi
+source $CONFIG
+
+# Ensure we have the minimum variables to run
+REQUIRED_VARS="LABEL_SYNC_CONFIG LABEL_SYNC_GITHUB_TOKEN LABEL_SYNC_GITHUB_ORG"
+for var in $REQUIRED_VARS
+do
+ if [ -z "${!var}" ]
+ then
+   echo "Missing required variable: $var"
+   exit 1
+ fi
+done
+
+# Ensure this is a fully qualified path
+LABEL_SYNC_CONFIG=$(realpath "$LABEL_SYNC_CONFIG")
+[ -f "$LABEL_SYNC_CONFIG" ] || exit 1
+
+# Clone k8s test-infra which has label_sync repo
+if [ ! -d test-infra ]
+then
+  git clone https://github.com/kubernetes/test-infra.git
+else
+  cd test-infra || exit 1
+  git checkout master
+  git pull origin master
+  cd .. || exit 1
+fi
+
+# Write token to a file
+token_file=$(mktemp "token--XXXXXXXXXX")
+echo "$LABEL_SYNC_GITHUB_TOKEN" > "$token_file"
+
+pushd .
+cd test-infra
+bazel run //label_sync -- \
+  --config "$LABEL_SYNC_CONFIG" \
+  --token "$SCRIPTDIR/$token_file" \
+  --orgs "$LABEL_SYNC_GITHUB_ORG" $LABEL_SYNC_CONFIRM
+popd
+
+echo "Success!"

--- a/label_sync/sync_labels.sh
+++ b/label_sync/sync_labels.sh
@@ -8,6 +8,11 @@ function clean {
 }
 trap clean EXIT
 
+if [ "$1" == "confirm" ]
+then
+  LABEL_SYNC_CONFIRM="--confirm"
+fi
+
 # Find out where we're executed from
 SCRIPTDIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 
@@ -55,12 +60,17 @@ fi
 token_file=$(mktemp "token--XXXXXXXXXX")
 echo "$LABEL_SYNC_GITHUB_TOKEN" > "$token_file"
 
+if [ -n "$LABEL_SYNC_SKIP" ]
+then
+  LABEL_SYNC_SKIP_REPOS="--skip $LABEL_SYNC_SKIP"
+fi
+
 pushd .
 cd test-infra
 bazel run //label_sync -- \
   --config "$LABEL_SYNC_CONFIG" \
   --token "$SCRIPTDIR/$token_file" \
-  --orgs "$LABEL_SYNC_GITHUB_ORG" $LABEL_SYNC_CONFIRM
+  --orgs "$LABEL_SYNC_GITHUB_ORG" $LABEL_SYNC_CONFIRM $LABEL_SYNC_SKIP_REPOS
 popd
 
 echo "Success!"


### PR DESCRIPTION
This makes use of kubernetes test-infra to setup the labels on our
repos.  Copy config_example.sh and edit the values with the
configuration you desire, and then run `make` to see a *dry run* of what
it would do.

To apply the changes, run `make confirm`