### PR TITLE
Add notes on how SSL certificates are managed.

### DIFF
--- a/prow/README.md
+++ b/prow/README.md
@@ -2,10 +2,14 @@
 
 Prow dashboard: http://prow.apps.ci.metal3.io
 
-## Cluster
+## Prow Setup
+
+Prow was set up by following these instructions: https://github.com/kubernetes/test-infra/blob/master/prow/getting_started_deploy.md
+
+## Cluster Setup
 
 Prow is running on an OpenShift cluster running on servers provided to the metal3.io project by [packet.net](https://packet.net).
 
-## Setup
+### SSL
 
-Prow was set up by following these instructions: https://github.com/kubernetes/test-infra/blob/master/prow/getting_started_deploy.md
+SSL certificates for applications (\*.apps.ci.metal3.io) and the API (api.ci.metal3.io) are managed by [cert-manager](https://github.com/jetstack/cert-manager) and issued by [letsencrypt](https://letsencrypt.org/).


### PR DESCRIPTION
Split the README between notes on the cluster that runs prow and prow
itself.  For the cluster, add a section that points to cert-manager,
which the cluster is running to manage its SSL certificates.