### PR TITLE
spyglass: Configure some artifact viewers.

### DIFF
--- a/prow/config/config.yaml
+++ b/prow/config/config.yaml
@@ -45,6 +45,16 @@ tide:
     - do-not-merge/invalid-owners-file
     - do-not-merge/work-in-progress
 
+deck:
+  spyglass:
+    viewers:
+      "started.json|finished.json":
+      - "metadata"
+      "build-log.txt":
+      - "build-log"
+      "clone-log.txt":
+      - "clone-log"
+
 presubmits:
   metal3-io/metal3-dev-env:
   - name: shellcheck


### PR DESCRIPTION
This should let us see the build log, start/end time, and the log of
cloning the source for the job.

Part of issue #15 