### PR TITLE
spyglass: Fix lenses for viewing log files.

### DIFF
--- a/prow/config/config.yaml
+++ b/prow/config/config.yaml
@@ -51,9 +51,9 @@ deck:
       "started.json|finished.json":
       - "metadata"
       "build-log.txt":
-      - "build-log"
+      - "buildlog"
       "clone-log.txt":
-      - "clone-log"
+      - "buildlog"
 
 presubmits:
   metal3-io/metal3-dev-env:


### PR DESCRIPTION
I misinterpreted the config here.  The build log and and clone log
should use the "buildlog" lense, which shows a log file.

More docs here:

https://github.com/kubernetes/test-infra/tree/master/prow/spyglass

Part of issue #15 