### PR TITLE
Add CI jobs for cluster-api-provider-baremetal.

### DIFF
--- a/prow/config/config.yaml
+++ b/prow/config/config.yaml
@@ -56,6 +56,78 @@ deck:
       - "buildlog"
 
 presubmits:
+  metal3-io/cluster-api-provider-baremetal:
+  - name: gofmt
+    always_run: true
+    decorate: true
+    spec:
+      containers:
+      - args:
+        - ./hack/gofmt.sh
+        command:
+        - sh
+        env:
+        - name: IS_CONTAINER
+          value: "TRUE"
+        image: registry.hub.docker.com/library/golang:1.12
+        imagePullPolicy: Always
+  - name: govet
+    always_run: true
+    decorate: true
+    spec:
+      containers:
+      - args:
+        - ./hack/govet.sh
+        command:
+        - sh
+        env:
+        - name: IS_CONTAINER
+          value: "TRUE"
+        image: registry.hub.docker.com/library/golang:1.12
+        imagePullPolicy: Always
+  - name: markdownlint
+    always_run: true
+    decorate: true
+    spec:
+      containers:
+      - args:
+        - ./hack/markdownlint.sh
+        command:
+        - sh
+        env:
+        - name: IS_CONTAINER
+          value: "TRUE"
+        image: registry.hub.docker.com/pipelinecomponents/markdownlint:latest
+        imagePullPolicy: Always
+  - name: shellcheck
+    always_run: true
+    decorate: true
+    spec:
+      containers:
+      - args:
+        - ./hack/shellcheck.sh
+        command:
+        - sh
+        env:
+        - name: IS_CONTAINER
+          value: "TRUE"
+        image: koalaman/shellcheck-alpine:stable
+        imagePullPolicy: Always
+  - name: unit
+    always_run: true
+    decorate: true
+    spec:
+      containers:
+      - args:
+        - ./hack/unit.sh
+        command:
+        - sh
+        env:
+        - name: IS_CONTAINER
+          value: "TRUE"
+        image: registry.hub.docker.com/library/golang:1.12
+        imagePullPolicy: Always
+
   metal3-io/metal3-dev-env:
   - name: shellcheck
     always_run: true


### PR DESCRIPTION
This adds jobs to run shellcheck, markdownlint, go vet, go fmt, and go
test.

This also replaces everything we were doing on this repo with
travis-ci.

Part of issue #18