### PR TITLE
Always run the unit job for capbm.

### DIFF
--- a/prow/config/config.yaml
+++ b/prow/config/config.yaml
@@ -114,7 +114,7 @@ presubmits:
         image: koalaman/shellcheck-alpine:stable
         imagePullPolicy: Always
   - name: unit
-    always_run: false
+    always_run: true
     decorate: true
     spec:
       containers:


### PR DESCRIPTION
This job is now working, so turn it on by default.