### PR TITLE
Add jobs for baremetal-operator

### DIFF
--- a/prow/config/config.yaml
+++ b/prow/config/config.yaml
@@ -56,6 +56,86 @@ deck:
       - "buildlog"
 
 presubmits:
+  metal3-io/baremetal-operator:
+  - name: gofmt
+    always_run: false
+    decorate: true
+    spec:
+      containers:
+      - args:
+        - ./hack/gofmt.sh
+        command:
+        - sh
+        env:
+        - name: IS_CONTAINER
+          value: "TRUE"
+        image: registry.hub.docker.com/library/golang:1.12
+        imagePullPolicy: Always
+  - name: govet
+    always_run: false
+    decorate: true
+    spec:
+      containers:
+      - args:
+        - ./hack/govet.sh
+        command:
+        - sh
+        env:
+        - name: IS_CONTAINER
+          value: "TRUE"
+        image: registry.hub.docker.com/library/golang:1.12
+        imagePullPolicy: Always
+  - name: markdownlint
+    always_run: false
+    decorate: true
+    spec:
+      containers:
+      - args:
+        - ./hack/markdownlint.sh
+        command:
+        - sh
+        env:
+        - name: IS_CONTAINER
+          value: "TRUE"
+        image: registry.hub.docker.com/pipelinecomponents/markdownlint:latest
+        imagePullPolicy: Always
+  - name: shellcheck
+    always_run: false
+    decorate: true
+    spec:
+      containers:
+      - args:
+        - ./hack/shellcheck.sh
+        command:
+        - sh
+        env:
+        - name: IS_CONTAINER
+          value: "TRUE"
+        image: koalaman/shellcheck-alpine:stable
+        imagePullPolicy: Always
+  - name: unit
+    always_run: false
+    decorate: true
+    spec:
+      containers:
+      - args:
+        - ./hack/unit.sh
+        command:
+        - sh
+        env:
+        - name: IS_CONTAINER
+          value: "TRUE"
+        - name: DEPLOY_KERNEL_URL
+          value: "http://172.22.0.1/images/ironic-python-agent.kernel"
+        - name: DEPLOY_RAMDISK_URL
+          value: "http://172.22.0.1/images/ironic-python-agent.initramfs"
+        - name: IRONIC_ENDPOINT
+          value: "http://localhost:6385/v1/"
+        - name: IRONIC_INSPECTOR_ENDPOINT
+          value: "http://localhost:5050/v1/"
+        image: registry.hub.docker.com/library/golang:1.12
+        imagePullPolicy: Always
+
   metal3-io/cluster-api-provider-baremetal:
   - name: gofmt
     always_run: true


### PR DESCRIPTION
This adds govet, markdownlint, shellcheck, gofmt, and unit jobs for
baremetal-operator.  They will currently not run by default, and will
only run if specifically requested.

This depends on https://github.com/metal3-io/baremetal-operator/pull/321