### PR TITLE
Add a kind/ci label

### DIFF
--- a/label_sync/labels.yaml
+++ b/label_sync/labels.yaml
@@ -131,6 +131,12 @@ default:
       prowPlugin: label
       addedBy: anyone
     - color: c7def8
+      description: Categorizes issue or PR as related to CI or testing.
+      name: kind/ci
+      target: both
+      prowPlugin: label
+      addedBy: anyone
+    - color: c7def8
       description: Categorizes issue or PR as related to a new feature.
       name: kind/feature
       previously:


### PR DESCRIPTION
During recent triage, we identified the need to mark an issue as related
to CI/testing, this adds that label.  We'll need to run the sync script
again.