### PR TITLE
Tide : Get required jobs from branch protection

### DIFF
--- a/prow/config/config.yaml
+++ b/prow/config/config.yaml
@@ -43,6 +43,9 @@ tide:
     - do-not-merge/hold
     - do-not-merge/invalid-owners-file
     - do-not-merge/work-in-progress
+  context_options:
+    # Use branch protection options to define required and optional contexts
+    from-branch-protection: true
 
 deck:
   spyglass:


### PR DESCRIPTION
That prevents having a PR blocking the merge pool because the
requirements are not fulfilled for merging in Github