### PR TITLE
Add stbenjam and maelk to OWNERS

### DIFF
--- a/OWNERS
+++ b/OWNERS
@@ -2,7 +2,5 @@
 
 approvers:
  - russellb
-
-reviewers:
+ - maelk
  - stbenjam
- - hardys


### PR DESCRIPTION
It's best if I'm not the only approver, and stbenjam and maelk are the
next two that have probably looked at the CI infra the most.