### PR TITLE
Jenkins: base runtime on metal3-dev-env OS distribution

### DIFF
--- a/jenkins/scripts/files/run_integration_tests.sh
+++ b/jenkins/scripts/files/run_integration_tests.sh
@@ -9,8 +9,9 @@ UPDATED_REPO="${4:-https://github.com/${REPO_ORG}/${REPO_NAME}.git}"
 export CAPI_VERSION="${5:-v1alpha3}"
 export IMAGE_OS="${6:-Ubuntu}"
 export DEFAULT_HOSTS_MEMORY="${7:-4096}"
+DISTRIBUTION="${8:-ubuntu}"
 
-if [ "${IMAGE_OS}" == "Ubuntu" ]; then
+if [ "${DISTRIBUTION}" == "ubuntu" ]; then
   export CONTAINER_RUNTIME="docker"
 fi
 

--- a/jenkins/scripts/integration_test.sh
+++ b/jenkins/scripts/integration_test.sh
@@ -83,4 +83,5 @@ ssh \
   "${AIRSHIP_CI_USER}"@"${TEST_EXECUTER_IP}" \
   PATH=/usr/local/bin:/usr/bin:/usr/local/sbin:/usr/sbin:/sbin:/bin \
   /tmp/run_integration_tests.sh "${REPO_ORG}" "${REPO_NAME}" "${REPO_BRANCH}" \
-  "${UPDATED_REPO}" "${CAPI_VERSION}" "${IMAGE_OS}" "${DEFAULT_HOSTS_MEMORY}"
+  "${UPDATED_REPO}" "${CAPI_VERSION}" "${IMAGE_OS}" "${DEFAULT_HOSTS_MEMORY}" \
+  "${DISTRIBUTION}"


### PR DESCRIPTION
It was based before on the target OS, instead of metal3-dev-env OS