### PR TITLE
:bug: Temporarily disabling kind usage as management cluster

### DIFF
--- a/jenkins/scripts/files/run_integration_tests.sh
+++ b/jenkins/scripts/files/run_integration_tests.sh
@@ -37,7 +37,7 @@ cd "/home/${USER}"
 
 if [ "${DISTRIBUTION}" == "ubuntu" ]; then
   export CONTAINER_RUNTIME="docker"
-  export EPHEMERAL_CLUSTER="kind"
+  export EPHEMERAL_CLUSTER="minikube"
 else
   export EPHEMERAL_CLUSTER="minikube"
 fi


### PR DESCRIPTION
Due to the problem found in kind using local registry in case of local image patch testing, kind usage disabled temporarily, until fix found.