### PR TITLE
Remove v1alpha1 integration test caller

### DIFF
--- a/jenkins/scripts/files/run_integration_tests.sh
+++ b/jenkins/scripts/files/run_integration_tests.sh
@@ -81,11 +81,5 @@ else
   git checkout "${METAL3BRANCH}"
 fi
 make
-
-if [ "${CAPI_VERSION}" == v1alpha1 ]; then
-  make test_v1a1
-else
-  make test
-fi
-
+make test
 make clean


### PR DESCRIPTION
Remove v1alpha1 integration test caller since it going to be deprecated in [#292](https://github.com/metal3-io/metal3-dev-env/pull/292)