### PR TITLE
prow: Update use of deprecated config entry

### DIFF
--- a/prow/config/config.yaml
+++ b/prow/config/config.yaml
@@ -4,16 +4,17 @@ pod_namespace: test-pods
 plank:
   job_url_prefix_config:
     '*': https://prow.apps.ci.metal3.io/view/gcs/
-  default_decoration_config:
-    utility_images:
-      clonerefs: "gcr.io/k8s-prow/clonerefs:v20191219-ecbeba384"
-      initupload: "gcr.io/k8s-prow/initupload:v20191219-ecbeba384"
-      entrypoint: "gcr.io/k8s-prow/entrypoint:v20191219-ecbeba384"
-      sidecar: "gcr.io/k8s-prow/sidecar:v20191219-ecbeba384"
-    gcs_configuration:
-      bucket: metal3-prow-artifacts
-      path_strategy: explicit
-    gcs_credentials_secret: gcs-credentials
+  default_decoration_configs:
+    '*':
+      utility_images:
+        clonerefs: "gcr.io/k8s-prow/clonerefs:v20191219-ecbeba384"
+        initupload: "gcr.io/k8s-prow/initupload:v20191219-ecbeba384"
+        entrypoint: "gcr.io/k8s-prow/entrypoint:v20191219-ecbeba384"
+        sidecar: "gcr.io/k8s-prow/sidecar:v20191219-ecbeba384"
+      gcs_configuration:
+        bucket: metal3-prow-artifacts
+        path_strategy: explicit
+      gcs_credentials_secret: gcs-credentials
 
 tide:
   merge_method:


### PR DESCRIPTION
default_decoration_config has been deprecated according to the config
validation tool (make validate).  Replace it with the new equivalent
option.