### PR TITLE
prow: Fix branch protection for CAPM3

### DIFF
--- a/prow/config/config.yaml
+++ b/prow/config/config.yaml
@@ -70,14 +70,13 @@ branch-protection:
           required_status_checks:
             contexts: ["test-integration"]
         cluster-api-provider-metal3:
-          # You can specify a default set of required status contexts
-          # for a repo, and then override that list for a specific branch.
-          required_status_checks:
-            contexts: ["test-integration"]
           branches:
             master:
               required_status_checks:
                 contexts: ["test-v1a4-integration"]
+            release-0.3:
+              required_status_checks:
+                contexts: ["test-integration"]
         ironic-image:
           required_status_checks:
             contexts: ["test-integration"]


### PR DESCRIPTION
This fixes branch protection settings for cluster-api-provider-metal3.
The previous configuration made master require both "test-integration"
and "test-v1a4-integration".  The requirements are the union of parent
and child lists, instead of only the child list.

Instead, we now specify the required contexts for this repo on a per
branch basis.

Reported-by: maelk <mael.kimmerlin@est.tech>