### PR TITLE
require the operator-sdk-generate job for baremetal-operator repository

### DIFF
--- a/prow/config/config.yaml
+++ b/prow/config/config.yaml
@@ -259,7 +259,7 @@ presubmits:
         image: registry.hub.docker.com/library/golang:1.13.7
         imagePullPolicy: Always
   - name: operator-sdk-generate
-    always_run: false
+    always_run: true
     decorate: true
     spec:
       containers:


### PR DESCRIPTION
Now that the tools are in place [1] we should run the job on every PR.

[1] https://github.com/metal3-io/baremetal-operator/pull/497