### PR TITLE
Revert "require the operator-sdk-generate job for baremetal-operator repository"

### DIFF
--- a/prow/config/config.yaml
+++ b/prow/config/config.yaml
@@ -259,7 +259,7 @@ presubmits:
         image: registry.hub.docker.com/library/golang:1.13.7
         imagePullPolicy: Always
   - name: operator-sdk-generate
-    always_run: true
+    always_run: false
     decorate: true
     spec:
       containers:


### PR DESCRIPTION
This reverts commit 2e57c4af8eeecb3b974cc58f4836950d57098166.

We need to wait for
https://github.com/metal3-io/baremetal-operator/pull/504 before making
this job required.