### PR TITLE
jenkins: Add fetching container logs from metal3-dev-env

### DIFF
--- a/jenkins/jobs/integration_tests.pipeline
+++ b/jenkins/jobs/integration_tests.pipeline
@@ -38,6 +38,8 @@ pipeline {
     OS_IDENTITY_API_VERSION=3
     TEST_EXECUTER_VM_NAME = "${VM_NAME}"
     BUILD_URL = "${env.BUILD_URL}"
+    BUILD_NUMBER = "${env.BUILD_NUMBER}"
+    JOB_NAME = "${env.JOB_BASE_NAME}"
     PR_ID = "${ghprbPullId}"
     DISTRIBUTION = "${DISTRIBUTION}"
     CAPI_VERSION = "${CAPI_VERSION}"
@@ -94,18 +96,25 @@ pipeline {
               echo "${err}"
               currentBuild.result = 'FAILURE'
           }
+          finally {
+            withCredentials([usernamePassword(credentialsId: 'airshipci_city_cloud_openstack_credentials', usernameVariable: 'OS_USERNAME', passwordVariable: 'OS_PASSWORD')]) {
+              withCredentials([sshUserPrivateKey(credentialsId: 'airshipci_city_cloud_ssh_keypair', keyFileVariable: 'AIRSHIP_CI_USER_KEY')]){
+                sh "./jenkins/scripts/fetch_logs.sh"
+              }
+            }
+            archiveArtifacts "logs_${env.JOB_BASE_NAME}_${env.BUILD_NUMBER}.tgz"
+          }
         }
       }
     }
   }
   post {
-    always {
+    success {
       withCredentials([usernamePassword(credentialsId: 'airshipci_city_cloud_openstack_credentials', usernameVariable: 'OS_USERNAME', passwordVariable: 'OS_PASSWORD')]) {
         withCredentials([sshUserPrivateKey(credentialsId: 'airshipci_city_cloud_ssh_keypair', keyFileVariable: 'AIRSHIP_CI_USER_KEY')]){
-          sh "./jenkins/scripts/fetch_logs_clean.sh"
+          sh "./jenkins/scripts/integration_test_clean.sh"
         }
       }
-      archiveArtifacts 'metal3-dev-env_logs.tgz'
     }
     cleanup {
       script {

--- a/jenkins/jobs/integration_tests.pipeline
+++ b/jenkins/jobs/integration_tests.pipeline
@@ -99,6 +99,14 @@ pipeline {
     }
   }
   post {
+    always {
+      withCredentials([usernamePassword(credentialsId: 'airshipci_city_cloud_openstack_credentials', usernameVariable: 'OS_USERNAME', passwordVariable: 'OS_PASSWORD')]) {
+        withCredentials([sshUserPrivateKey(credentialsId: 'airshipci_city_cloud_ssh_keypair', keyFileVariable: 'AIRSHIP_CI_USER_KEY')]){
+          sh "./jenkins/scripts/fetch_logs_clean.sh"
+        }
+      }
+      archiveArtifacts 'metal3-dev-env_logs.tgz'
+    }
     cleanup {
       script {
         CURRENT_BUILD_TIME = System.currentTimeMillis()

--- a/jenkins/jobs/integration_tests.pipeline
+++ b/jenkins/jobs/integration_tests.pipeline
@@ -2,6 +2,7 @@ import java.text.SimpleDateFormat
 
 ci_git_credential_id = "metal3-jenkins-github-token"
 def TIMEOUT = 5400
+def CLEAN_TIMEOUT = 600
 
 script {
   if ("${PROJECT_REPO_ORG}" == "metal3-io" && "${PROJECT_REPO_NAME}" == "project-infra") {
@@ -37,8 +38,7 @@ pipeline {
     OS_AUTH_VERSION=3
     OS_IDENTITY_API_VERSION=3
     TEST_EXECUTER_VM_NAME = "${VM_NAME}"
-    BUILD_URL = "${env.BUILD_URL}"
-    BUILD_NUMBER = "${env.BUILD_NUMBER}"
+    BUILD_TAG = "${env.BUILD_TAG}"
     JOB_NAME = "${env.JOB_BASE_NAME}"
     PR_ID = "${ghprbPullId}"
     DISTRIBUTION = "${DISTRIBUTION}"
@@ -62,7 +62,9 @@ pipeline {
                  submoduleCfg: [],
                  userRemoteConfigs: [[credentialsId: ci_git_credential_id,
                  url: ci_git_url]]])
-
+        script {
+          CURRENT_START_TIME = System.currentTimeMillis()
+        }
       }
     }
     stage('Run integration test') {
@@ -70,40 +72,30 @@ pipeline {
         timeout(time: TIMEOUT, unit: 'SECONDS')
       }
       steps {
-        script {
-          CURRENT_START_TIME = System.currentTimeMillis()
-          try {
-            withCredentials([usernamePassword(credentialsId: 'airshipci_city_cloud_openstack_credentials', usernameVariable: 'OS_USERNAME', passwordVariable: 'OS_PASSWORD')]) {
-              withCredentials([sshUserPrivateKey(credentialsId: 'airshipci_city_cloud_ssh_keypair', keyFileVariable: 'AIRSHIP_CI_USER_KEY')]) {
-                withCredentials([string(credentialsId: 'metal3-clusterctl-github-token', variable: 'GITHUB_TOKEN')]) {
-                  sh "./jenkins/scripts/integration_test.sh"
-                }
-              }
+        withCredentials([usernamePassword(credentialsId: 'airshipci_city_cloud_openstack_credentials', usernameVariable: 'OS_USERNAME', passwordVariable: 'OS_PASSWORD')]) {
+          withCredentials([sshUserPrivateKey(credentialsId: 'airshipci_city_cloud_ssh_keypair', keyFileVariable: 'AIRSHIP_CI_USER_KEY')]) {
+            withCredentials([string(credentialsId: 'metal3-clusterctl-github-token', variable: 'GITHUB_TOKEN')]) {
+              sh "./jenkins/scripts/integration_test.sh"
             }
           }
-          catch (org.hidetake.groovy.ssh.session.BadExitStatusException err) {
-              echo "Caught: ssh error"
-              echo "${err}"
+        }
+      }
+      post {
+        always {
+          script {
+            CURRENT_END_TIME = System.currentTimeMillis()
+            if ((((CURRENT_END_TIME - CURRENT_START_TIME)/1000) - TIMEOUT) > 0) {
+              echo "Failed due to timeout"
               currentBuild.result = 'FAILURE'
-          }
-          catch (org.jenkinsci.plugins.workflow.steps.FlowInterruptedException err) {
-              echo "Caught: timeout error"
-              echo "${err}"
-              currentBuild.result = 'FAILURE'
-          }
-          catch (err) {
-              echo "Caught: runtime error"
-              echo "${err}"
-              currentBuild.result = 'FAILURE'
-          }
-          finally {
-            withCredentials([usernamePassword(credentialsId: 'airshipci_city_cloud_openstack_credentials', usernameVariable: 'OS_USERNAME', passwordVariable: 'OS_PASSWORD')]) {
-              withCredentials([sshUserPrivateKey(credentialsId: 'airshipci_city_cloud_ssh_keypair', keyFileVariable: 'AIRSHIP_CI_USER_KEY')]){
-                sh "./jenkins/scripts/fetch_logs.sh"
-              }
             }
-            archiveArtifacts "logs_${env.JOB_BASE_NAME}_${env.BUILD_NUMBER}.tgz"
           }
+          withCredentials([usernamePassword(credentialsId: 'airshipci_city_cloud_openstack_credentials', usernameVariable: 'OS_USERNAME', passwordVariable: 'OS_PASSWORD')]) {
+            withCredentials([sshUserPrivateKey(credentialsId: 'airshipci_city_cloud_ssh_keypair', keyFileVariable: 'AIRSHIP_CI_USER_KEY')]){
+              sh "./jenkins/scripts/fetch_logs.sh"
+            }
+          }
+          archiveArtifacts "logs-${env.BUILD_TAG}.tgz"
+
         }
       }
     }
@@ -117,13 +109,6 @@ pipeline {
       }
     }
     cleanup {
-      script {
-        CURRENT_BUILD_TIME = System.currentTimeMillis()
-        if ((((CURRENT_BUILD_TIME - CURRENT_START_TIME)/1000) - TIMEOUT) > 0) {
-          echo "Failed due to timeout"
-          currentBuild.result = 'FAILURE'
-        }
-      }
       withCredentials([usernamePassword(credentialsId: 'airshipci_city_cloud_openstack_credentials', usernameVariable: 'OS_USERNAME', passwordVariable: 'OS_PASSWORD')]) {
         withCredentials([sshUserPrivateKey(credentialsId: 'airshipci_city_cloud_ssh_keypair', keyFileVariable: 'AIRSHIP_CI_USER_KEY')]){
           sh "./jenkins/scripts/integration_delete.sh"

--- a/jenkins/scripts/fetch_logs.sh
+++ b/jenkins/scripts/fetch_logs.sh
@@ -11,9 +11,9 @@ set -eu
 #
 
 CI_DIR="$(dirname "$(readlink -f "${0}")")"
+JOB_NAME="${JOB_NAME:-integration-tests}"
+BUILD_NUMBER="${BUILD_NUMBER:-0}"
 
-REPO_NAME="${REPO_NAME:-metal3-dev-env}"
-DISTRIBUTION="${DISTRIBUTION:-ubuntu}"
 
 # shellcheck disable=SC1090
 source "${CI_DIR}/utils.sh"
@@ -32,14 +32,6 @@ scp \
   "${CI_DIR}/files/run_fetch_logs.sh" \
   "${AIRSHIP_CI_USER}@${TEST_EXECUTER_IP}:/tmp/" > /dev/null
 
-# Send Remote script to Executer
-scp \
-  -o StrictHostKeyChecking=no \
-  -o UserKnownHostsFile=/dev/null \
-  -i "${AIRSHIP_CI_USER_KEY}" \
-  "${CI_DIR}/files/run_clean.sh" \
-  "${AIRSHIP_CI_USER}@${TEST_EXECUTER_IP}:/tmp/" > /dev/null
-
 echo "Fetching logs"
 # Execute remote script
 # shellcheck disable=SC2029
@@ -50,24 +42,13 @@ ssh \
   -i "${AIRSHIP_CI_USER_KEY}" \
   "${AIRSHIP_CI_USER}"@"${TEST_EXECUTER_IP}" \
   PATH=/usr/local/bin:/usr/bin:/usr/local/sbin:/usr/sbin:/sbin:/bin \
-  /tmp/run_fetch_logs.sh "metal3-dev-env_logs.tgz"
+  /tmp/run_fetch_logs.sh "logs_${JOB_NAME}_${BUILD_NUMBER}.tgz" \
+  "logs_${JOB_NAME}_${BUILD_NUMBER}"
 
 # fetch logs tarball
 scp \
   -o StrictHostKeyChecking=no \
   -o UserKnownHostsFile=/dev/null \
   -i "${AIRSHIP_CI_USER_KEY}" \
-  "${AIRSHIP_CI_USER}@${TEST_EXECUTER_IP}:metal3-dev-env_logs.tgz" \
+  "${AIRSHIP_CI_USER}@${TEST_EXECUTER_IP}:logs_${JOB_NAME}_${BUILD_NUMBER}.tgz" \
   "./" > /dev/null
-
-echo "Cleaning"
-# Execute remote cleaning script
-# shellcheck disable=SC2029
-ssh \
-  -o StrictHostKeyChecking=no \
-  -o UserKnownHostsFile=/dev/null \
-  -o ServerAliveInterval=15 \
-  -i "${AIRSHIP_CI_USER_KEY}" \
-  "${AIRSHIP_CI_USER}"@"${TEST_EXECUTER_IP}" \
-  PATH=/usr/local/bin:/usr/bin:/usr/local/sbin:/usr/sbin:/sbin:/bin \
-  /tmp/run_clean.sh "${REPO_NAME}" "${DISTRIBUTION}"

--- a/jenkins/scripts/fetch_logs.sh
+++ b/jenkins/scripts/fetch_logs.sh
@@ -11,8 +11,7 @@ set -eu
 #
 
 CI_DIR="$(dirname "$(readlink -f "${0}")")"
-JOB_NAME="${JOB_NAME:-integration-tests}"
-BUILD_NUMBER="${BUILD_NUMBER:-0}"
+BUILD_TAG="${BUILD_TAG:-logs_integration_tests}"
 
 
 # shellcheck disable=SC1090
@@ -42,13 +41,13 @@ ssh \
   -i "${AIRSHIP_CI_USER_KEY}" \
   "${AIRSHIP_CI_USER}"@"${TEST_EXECUTER_IP}" \
   PATH=/usr/local/bin:/usr/bin:/usr/local/sbin:/usr/sbin:/sbin:/bin \
-  /tmp/run_fetch_logs.sh "logs_${JOB_NAME}_${BUILD_NUMBER}.tgz" \
-  "logs_${JOB_NAME}_${BUILD_NUMBER}"
+  /tmp/run_fetch_logs.sh "logs-${BUILD_TAG}.tgz" \
+  "logs-${BUILD_TAG}"
 
 # fetch logs tarball
 scp \
   -o StrictHostKeyChecking=no \
   -o UserKnownHostsFile=/dev/null \
   -i "${AIRSHIP_CI_USER_KEY}" \
-  "${AIRSHIP_CI_USER}@${TEST_EXECUTER_IP}:logs_${JOB_NAME}_${BUILD_NUMBER}.tgz" \
+  "${AIRSHIP_CI_USER}@${TEST_EXECUTER_IP}:logs-${BUILD_TAG}.tgz" \
   "./" > /dev/null

--- a/jenkins/scripts/fetch_logs_clean.sh
+++ b/jenkins/scripts/fetch_logs_clean.sh
@@ -1,0 +1,73 @@
+#! /usr/bin/env bash
+
+set -eu
+
+# Description:
+#   Cleans the executer vm after integration tests
+#   Requires:
+#     - source stackrc file
+# Usage:
+#  integration_delete.sh
+#
+
+CI_DIR="$(dirname "$(readlink -f "${0}")")"
+
+REPO_NAME="${REPO_NAME:-metal3-dev-env}"
+DISTRIBUTION="${DISTRIBUTION:-ubuntu}"
+
+# shellcheck disable=SC1090
+source "${CI_DIR}/utils.sh"
+
+TEST_EXECUTER_PORT_NAME="${TEST_EXECUTER_PORT_NAME:-${TEST_EXECUTER_VM_NAME}-int-port}"
+
+# Get the IP
+TEST_EXECUTER_IP="$(openstack port show -f json "${TEST_EXECUTER_PORT_NAME}" \
+  | jq -r '.fixed_ips[0].ip_address')"
+
+# Send Remote script to Executer
+scp \
+  -o StrictHostKeyChecking=no \
+  -o UserKnownHostsFile=/dev/null \
+  -i "${AIRSHIP_CI_USER_KEY}" \
+  "${CI_DIR}/files/run_fetch_logs.sh" \
+  "${AIRSHIP_CI_USER}@${TEST_EXECUTER_IP}:/tmp/" > /dev/null
+
+# Send Remote script to Executer
+scp \
+  -o StrictHostKeyChecking=no \
+  -o UserKnownHostsFile=/dev/null \
+  -i "${AIRSHIP_CI_USER_KEY}" \
+  "${CI_DIR}/files/run_clean.sh" \
+  "${AIRSHIP_CI_USER}@${TEST_EXECUTER_IP}:/tmp/" > /dev/null
+
+echo "Fetching logs"
+# Execute remote script
+# shellcheck disable=SC2029
+ssh \
+  -o StrictHostKeyChecking=no \
+  -o UserKnownHostsFile=/dev/null \
+  -o ServerAliveInterval=15 \
+  -i "${AIRSHIP_CI_USER_KEY}" \
+  "${AIRSHIP_CI_USER}"@"${TEST_EXECUTER_IP}" \
+  PATH=/usr/local/bin:/usr/bin:/usr/local/sbin:/usr/sbin:/sbin:/bin \
+  /tmp/run_fetch_logs.sh "metal3-dev-env_logs.tgz"
+
+# fetch logs tarball
+scp \
+  -o StrictHostKeyChecking=no \
+  -o UserKnownHostsFile=/dev/null \
+  -i "${AIRSHIP_CI_USER_KEY}" \
+  "${AIRSHIP_CI_USER}@${TEST_EXECUTER_IP}:metal3-dev-env_logs.tgz" \
+  "./" > /dev/null
+
+echo "Cleaning"
+# Execute remote cleaning script
+# shellcheck disable=SC2029
+ssh \
+  -o StrictHostKeyChecking=no \
+  -o UserKnownHostsFile=/dev/null \
+  -o ServerAliveInterval=15 \
+  -i "${AIRSHIP_CI_USER_KEY}" \
+  "${AIRSHIP_CI_USER}"@"${TEST_EXECUTER_IP}" \
+  PATH=/usr/local/bin:/usr/bin:/usr/local/sbin:/usr/sbin:/sbin:/bin \
+  /tmp/run_clean.sh "${REPO_NAME}" "${DISTRIBUTION}"

--- a/jenkins/scripts/files/run_clean.sh
+++ b/jenkins/scripts/files/run_clean.sh
@@ -1,0 +1,21 @@
+#!/bin/bash
+
+set -eux
+
+REPO_NAME="${1:-metal3-dev-env}"
+DISTRIBUTION="${2:-ubuntu}"
+
+if [ "${DISTRIBUTION}" == "ubuntu" ]; then
+  export CONTAINER_RUNTIME="docker"
+  export EPHEMERAL_CLUSTER="kind"
+else
+  export EPHEMERAL_CLUSTER="minikube"
+fi
+
+if [ "${REPO_NAME}" == "metal3-dev-env" ]
+then
+  pushd tested_repo
+else
+  pushd metal3
+fi
+make clean

--- a/jenkins/scripts/files/run_fetch_logs.sh
+++ b/jenkins/scripts/files/run_fetch_logs.sh
@@ -1,6 +1,7 @@
 #!/bin/bash
 
-set -eu
+#Do not fail on error (for example k8s cluster not available)
+set -u
 
 LOGS_TARBALL=${1:-container_logs.tgz}
 LOGS_DIR="${2:-logs}"

--- a/jenkins/scripts/files/run_fetch_logs.sh
+++ b/jenkins/scripts/files/run_fetch_logs.sh
@@ -1,0 +1,37 @@
+#!/bin/bash
+
+set -eu
+
+LOGS_TARBALL=${1:-container_logs.tgz}
+mkdir -p logs
+
+NAMESPACES="$(kubectl get namespace -o json | jq -r '.items[].metadata.name')"
+mkdir -p logs/k8s
+for NAMESPACE in $NAMESPACES
+do
+  mkdir -p "logs/k8s/${NAMESPACE}"
+  PODS="$(kubectl get pods -n "$NAMESPACE" -o json | jq -r '.items[].metadata.name')"
+  for POD in $PODS
+  do
+    mkdir -p "logs/k8s/${NAMESPACE}/${POD}"
+    CONTAINERS="$(kubectl get pods -n "$NAMESPACE" "$POD" -o json | jq -r '.spec.containers[].name')"
+    for CONTAINER in $CONTAINERS
+    do
+      mkdir -p "logs/k8s/${NAMESPACE}/${POD}/${CONTAINER}"
+      kubectl logs -n "$NAMESPACE" "$POD" "$CONTAINER" \
+      > "logs/k8s/${NAMESPACE}/${POD}/${CONTAINER}/stdout.log"\
+      2> "logs/k8s/${NAMESPACE}/${POD}/${CONTAINER}/stderr.log"
+    done
+  done
+done
+
+mkdir -p logs/docker
+DOCKER_CONTAINERS="$(docker ps --format "{{json .}}" | jq -r '.Names')"
+for DOCKER_CONTAINER in $DOCKER_CONTAINERS
+do
+  mkdir -p "logs/docker/${DOCKER_CONTAINER}"
+  docker logs "$DOCKER_CONTAINER" > "logs/docker/${DOCKER_CONTAINER}/stdout.log" \
+  2> "logs/docker/${DOCKER_CONTAINER}/stderr.log"
+done
+
+tar -cvzf "$LOGS_TARBALL" logs/*

--- a/jenkins/scripts/files/run_integration_tests.sh
+++ b/jenkins/scripts/files/run_integration_tests.sh
@@ -103,4 +103,3 @@ else
 fi
 make
 make test
-make clean

--- a/jenkins/scripts/integration_test_clean.sh
+++ b/jenkins/scripts/integration_test_clean.sh
@@ -1,0 +1,45 @@
+#! /usr/bin/env bash
+
+set -eu
+
+# Description:
+#   Cleans the executer vm after integration tests
+#   Requires:
+#     - source stackrc file
+# Usage:
+#  integration_delete.sh
+#
+
+CI_DIR="$(dirname "$(readlink -f "${0}")")"
+
+REPO_NAME="${REPO_NAME:-metal3-dev-env}"
+DISTRIBUTION="${DISTRIBUTION:-ubuntu}"
+
+# shellcheck disable=SC1090
+source "${CI_DIR}/utils.sh"
+
+TEST_EXECUTER_PORT_NAME="${TEST_EXECUTER_PORT_NAME:-${TEST_EXECUTER_VM_NAME}-int-port}"
+
+# Get the IP
+TEST_EXECUTER_IP="$(openstack port show -f json "${TEST_EXECUTER_PORT_NAME}" \
+  | jq -r '.fixed_ips[0].ip_address')"
+
+# Send Remote script to Executer
+scp \
+  -o StrictHostKeyChecking=no \
+  -o UserKnownHostsFile=/dev/null \
+  -i "${AIRSHIP_CI_USER_KEY}" \
+  "${CI_DIR}/files/run_clean.sh" \
+  "${AIRSHIP_CI_USER}@${TEST_EXECUTER_IP}:/tmp/" > /dev/null
+
+echo "Cleaning"
+# Execute remote cleaning script
+# shellcheck disable=SC2029
+ssh \
+  -o StrictHostKeyChecking=no \
+  -o UserKnownHostsFile=/dev/null \
+  -o ServerAliveInterval=15 \
+  -i "${AIRSHIP_CI_USER_KEY}" \
+  "${AIRSHIP_CI_USER}"@"${TEST_EXECUTER_IP}" \
+  PATH=/usr/local/bin:/usr/bin:/usr/local/sbin:/usr/sbin:/sbin:/bin \
+  /tmp/run_clean.sh "${REPO_NAME}" "${DISTRIBUTION}"


### PR DESCRIPTION
This PR modifies the pipeline and the scripts running the metal3-dev-env integration tests to fetch the logs from all containers at the end of the run, they will be saved as artifacts for that run