### PR TITLE
Restore the operator-sdk-generate job on the baremetal-operator repository

### DIFF
--- a/prow/config/config.yaml
+++ b/prow/config/config.yaml
@@ -260,7 +260,7 @@ presubmits:
         image: registry.hub.docker.com/library/golang:1.13.7
         imagePullPolicy: Always
   - name: operator-sdk-generate
-    always_run: false
+    always_run: true
     decorate: true
     spec:
       containers:


### PR DESCRIPTION
This reverts commit be7f3e67d8ae6a242b625f074267bcc73b47d340.