### PR TITLE
Start working on Prow upgrades

### DIFF
--- a/clusters/ci/imagepruner.yaml
+++ b/clusters/ci/imagepruner.yaml
@@ -1,0 +1,6 @@
+apiVersion: imageregistry.operator.openshift.io/v1
+kind: ImagePruner
+metadata:
+  name: cluster
+spec:
+  suspend: false

--- a/prow/config/config.yaml
+++ b/prow/config/config.yaml
@@ -165,6 +165,57 @@ periodics:
      - name: token
        secret:
          secretName: oauth-token
+ - name: ci-prow-autobump
+   # https://github.com/kubernetes/test-infra/tree/master/prow/cmd/autobump#prow-autobump
+   # https://github.com/kubernetes/test-infra/blob/master/prow/cmd/autobump/example-periodic.yaml
+   cron: "05 15-23 * * 1-5"  # Run at 7:05-15:05 PST (15:05 UTC) Mon-Fri
+   decorate: true
+   extra_refs:
+   # Check out the repo containing the config and deployment files for your Prow instance.
+   - org: metal3-io
+     repo: project-infra
+     base_ref: master
+   spec:
+     containers:
+     - image: gcr.io/k8s-prow/autobump # TODO: add a tag once we've push this the first time.
+       command:
+       - /autobump.sh
+       args:
+       - /etc/github-token/token
+       # Make the bot name and email match the user data of the provided token's user.
+       - "metal3-io-bot"
+       - metal3.io.bot@gmail.com
+       volumeMounts:
+       - name: github
+         mountPath: /etc/github-token
+         readOnly: true
+       env:
+     # autobump.sh args
+       # GitHub org containing the repo where the Prow config and component files live.
+       - name: GH_ORG
+         value: project-infra
+       # GitHub repo where the Prow config and component deployment files live.
+       - name: GH_REPO
+         value: project-infra
+       # Repo relative path of the `plank` component k8s deployment file.
+       - name: PLANK_DEPLOYMENT_FILE
+         value: prow/manifests/plank-deployment.yaml
+     # bump.sh args
+       # Directory (or comma-delimited list of directories) containing k8s deployment YAMLs for Prow components.
+       - name: COMPONENT_FILE_DIR
+         value: prow/manifests
+       # Repo relative path of the core Prow config file (config.yaml).
+       - name: CONFIG_PATH
+         value: prow/configs/config.yaml
+       # Repo relative path of the ProwJob config file or directory.
+       # Omit this if ProwJobs are only defined in config.yaml (or are not configured at all).
+       #- name: JOB_CONFIG_PATH
+       #  value: config/jobs
+     volumes:
+     - name: github
+       secret:
+         # Secret containing a GitHub user access token with `repo` scope for creating PRs.
+         secretName: oauth-token
 
 presubmits:
   metal3-io/baremetal-operator:

--- a/prow/manifests/deck-deployment.yaml
+++ b/prow/manifests/deck-deployment.yaml
@@ -1,0 +1,94 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  labels:
+    app: deck
+  name: deck
+  namespace: default
+spec:
+  progressDeadlineSeconds: 600
+  replicas: 2
+  revisionHistoryLimit: 10
+  selector:
+    matchLabels:
+      app: deck
+  strategy:
+    rollingUpdate:
+      maxSurge: 1
+      maxUnavailable: 1
+    type: RollingUpdate
+  template:
+    metadata:
+      creationTimestamp: null
+      labels:
+        app: deck
+    spec:
+      containers:
+      - args:
+        - --config-path=/etc/config/config.yaml
+        - --plugin-config=/etc/plugins/plugins.yaml
+        - --tide-url=http://tide/
+        - --hook-url=http://hook:8888/plugin-help
+        - --github-token-path=/etc/github/oauth
+        - --plugin-config=/etc/plugins/plugins.yaml
+        - --spyglass
+        image: gcr.io/k8s-prow/deck:v20191219-ecbeba384
+        imagePullPolicy: IfNotPresent
+        livenessProbe:
+          failureThreshold: 3
+          httpGet:
+            path: /healthz
+            port: 8081
+            scheme: HTTP
+          initialDelaySeconds: 3
+          periodSeconds: 3
+          successThreshold: 1
+          timeoutSeconds: 1
+        name: deck
+        ports:
+        - containerPort: 8080
+          name: http
+          protocol: TCP
+        readinessProbe:
+          failureThreshold: 3
+          httpGet:
+            path: /healthz/ready
+            port: 8081
+            scheme: HTTP
+          initialDelaySeconds: 10
+          periodSeconds: 3
+          successThreshold: 1
+          timeoutSeconds: 600
+        resources: {}
+        terminationMessagePath: /dev/termination-log
+        terminationMessagePolicy: File
+        volumeMounts:
+        - mountPath: /etc/config
+          name: config
+          readOnly: true
+        - mountPath: /etc/github
+          name: oauth
+          readOnly: true
+        - mountPath: /etc/plugins
+          name: plugins
+          readOnly: true
+      dnsPolicy: ClusterFirst
+      restartPolicy: Always
+      schedulerName: default-scheduler
+      securityContext: {}
+      serviceAccount: deck
+      serviceAccountName: deck
+      terminationGracePeriodSeconds: 30
+      volumes:
+      - configMap:
+          defaultMode: 420
+          name: config
+        name: config
+      - name: oauth
+        secret:
+          defaultMode: 420
+          secretName: oauth-token
+      - configMap:
+          defaultMode: 420
+          name: plugins
+        name: plugins

--- a/prow/manifests/hook-deployment.yaml
+++ b/prow/manifests/hook-deployment.yaml
@@ -1,0 +1,96 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  labels:
+    app: hook
+  name: hook
+  namespace: default
+spec:
+  progressDeadlineSeconds: 600
+  replicas: 2
+  revisionHistoryLimit: 10
+  selector:
+    matchLabels:
+      app: hook
+  strategy:
+    rollingUpdate:
+      maxSurge: 1
+      maxUnavailable: 1
+    type: RollingUpdate
+  template:
+    metadata:
+      creationTimestamp: null
+      labels:
+        app: hook
+    spec:
+      containers:
+      - args:
+        - --dry-run=false
+        - --config-path=/etc/config/config.yaml
+        image: gcr.io/k8s-prow/hook:v20191219-ecbeba384
+        imagePullPolicy: Always
+        livenessProbe:
+          failureThreshold: 3
+          httpGet:
+            path: /healthz
+            port: 8081
+            scheme: HTTP
+          initialDelaySeconds: 3
+          periodSeconds: 3
+          successThreshold: 1
+          timeoutSeconds: 1
+        name: hook
+        ports:
+        - containerPort: 8888
+          name: http
+          protocol: TCP
+        readinessProbe:
+          failureThreshold: 3
+          httpGet:
+            path: /healthz/ready
+            port: 8081
+            scheme: HTTP
+          initialDelaySeconds: 10
+          periodSeconds: 3
+          successThreshold: 1
+          timeoutSeconds: 600
+        resources: {}
+        terminationMessagePath: /dev/termination-log
+        terminationMessagePolicy: File
+        volumeMounts:
+        - mountPath: /etc/webhook
+          name: hmac
+          readOnly: true
+        - mountPath: /etc/github
+          name: oauth
+          readOnly: true
+        - mountPath: /etc/config
+          name: config
+          readOnly: true
+        - mountPath: /etc/plugins
+          name: plugins
+          readOnly: true
+      dnsPolicy: ClusterFirst
+      restartPolicy: Always
+      schedulerName: default-scheduler
+      securityContext: {}
+      serviceAccount: hook
+      serviceAccountName: hook
+      terminationGracePeriodSeconds: 180
+      volumes:
+      - name: hmac
+        secret:
+          defaultMode: 420
+          secretName: hmac-token
+      - name: oauth
+        secret:
+          defaultMode: 420
+          secretName: oauth-token
+      - configMap:
+          defaultMode: 420
+          name: config
+        name: config
+      - configMap:
+          defaultMode: 420
+          name: plugins
+        name: plugins

--- a/prow/manifests/horologium-deployment.yaml
+++ b/prow/manifests/horologium-deployment.yaml
@@ -1,0 +1,47 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  labels:
+    app: horologium
+  name: horologium
+  namespace: default
+spec:
+  progressDeadlineSeconds: 600
+  replicas: 1
+  revisionHistoryLimit: 10
+  selector:
+    matchLabels:
+      app: horologium
+  strategy:
+    type: Recreate
+  template:
+    metadata:
+      creationTimestamp: null
+      labels:
+        app: horologium
+    spec:
+      containers:
+      - args:
+        - --config-path=/etc/config/config.yaml
+        image: gcr.io/k8s-prow/horologium:v20191219-ecbeba384
+        imagePullPolicy: IfNotPresent
+        name: horologium
+        resources: {}
+        terminationMessagePath: /dev/termination-log
+        terminationMessagePolicy: File
+        volumeMounts:
+        - mountPath: /etc/config
+          name: config
+          readOnly: true
+      dnsPolicy: ClusterFirst
+      restartPolicy: Always
+      schedulerName: default-scheduler
+      securityContext: {}
+      serviceAccount: horologium
+      serviceAccountName: horologium
+      terminationGracePeriodSeconds: 30
+      volumes:
+      - configMap:
+          defaultMode: 420
+          name: config
+        name: config

--- a/prow/manifests/plank-deployment.yaml
+++ b/prow/manifests/plank-deployment.yaml
@@ -1,0 +1,55 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  labels:
+    app: plank
+  name: plank
+  namespace: default
+spec:
+  progressDeadlineSeconds: 600
+  replicas: 1
+  revisionHistoryLimit: 10
+  selector:
+    matchLabels:
+      app: plank
+  strategy:
+    type: Recreate
+  template:
+    metadata:
+      creationTimestamp: null
+      labels:
+        app: plank
+    spec:
+      containers:
+      - args:
+        - --dry-run=false
+        - --config-path=/etc/config/config.yaml
+        image: gcr.io/k8s-prow/plank:v20191219-ecbeba384
+        imagePullPolicy: IfNotPresent
+        name: plank
+        resources: {}
+        terminationMessagePath: /dev/termination-log
+        terminationMessagePolicy: File
+        volumeMounts:
+        - mountPath: /etc/github
+          name: oauth
+          readOnly: true
+        - mountPath: /etc/config
+          name: config
+          readOnly: true
+      dnsPolicy: ClusterFirst
+      restartPolicy: Always
+      schedulerName: default-scheduler
+      securityContext: {}
+      serviceAccount: plank
+      serviceAccountName: plank
+      terminationGracePeriodSeconds: 30
+      volumes:
+      - name: oauth
+        secret:
+          defaultMode: 420
+          secretName: oauth-token
+      - configMap:
+          defaultMode: 420
+          name: config
+        name: config

--- a/prow/manifests/sinker-deployment.yaml
+++ b/prow/manifests/sinker-deployment.yaml
@@ -1,0 +1,50 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  labels:
+    app: sinker
+  name: sinker
+  namespace: default
+spec:
+  progressDeadlineSeconds: 600
+  replicas: 1
+  revisionHistoryLimit: 10
+  selector:
+    matchLabels:
+      app: sinker
+  strategy:
+    rollingUpdate:
+      maxSurge: 25%
+      maxUnavailable: 25%
+    type: RollingUpdate
+  template:
+    metadata:
+      creationTimestamp: null
+      labels:
+        app: sinker
+    spec:
+      containers:
+      - args:
+        - --config-path=/etc/config/config.yaml
+        image: gcr.io/k8s-prow/sinker:v20191219-ecbeba384
+        imagePullPolicy: IfNotPresent
+        name: sinker
+        resources: {}
+        terminationMessagePath: /dev/termination-log
+        terminationMessagePolicy: File
+        volumeMounts:
+        - mountPath: /etc/config
+          name: config
+          readOnly: true
+      dnsPolicy: ClusterFirst
+      restartPolicy: Always
+      schedulerName: default-scheduler
+      securityContext: {}
+      serviceAccount: sinker
+      serviceAccountName: sinker
+      terminationGracePeriodSeconds: 30
+      volumes:
+      - configMap:
+          defaultMode: 420
+          name: config
+        name: config

--- a/prow/manifests/statusreconciler-deployment.yaml
+++ b/prow/manifests/statusreconciler-deployment.yaml
@@ -1,0 +1,68 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  labels:
+    app: statusreconciler
+  name: statusreconciler
+  namespace: default
+spec:
+  progressDeadlineSeconds: 600
+  replicas: 1
+  revisionHistoryLimit: 10
+  selector:
+    matchLabels:
+      app: statusreconciler
+  strategy:
+    rollingUpdate:
+      maxSurge: 25%
+      maxUnavailable: 25%
+    type: RollingUpdate
+  template:
+    metadata:
+      creationTimestamp: null
+      labels:
+        app: statusreconciler
+    spec:
+      containers:
+      - args:
+        - --dry-run=false
+        - --continue-on-error=true
+        - --plugin-config=/etc/plugins/plugins.yaml
+        - --config-path=/etc/config/config.yaml
+        - --github-token-path=/etc/github/oauth
+        image: gcr.io/k8s-prow/status-reconciler:v20191219-ecbeba384
+        imagePullPolicy: IfNotPresent
+        name: statusreconciler
+        resources: {}
+        terminationMessagePath: /dev/termination-log
+        terminationMessagePolicy: File
+        volumeMounts:
+        - mountPath: /etc/github
+          name: oauth
+          readOnly: true
+        - mountPath: /etc/config
+          name: config
+          readOnly: true
+        - mountPath: /etc/plugins
+          name: plugins
+          readOnly: true
+      dnsPolicy: ClusterFirst
+      restartPolicy: Always
+      schedulerName: default-scheduler
+      securityContext: {}
+      serviceAccount: statusreconciler
+      serviceAccountName: statusreconciler
+      terminationGracePeriodSeconds: 180
+      volumes:
+      - name: oauth
+        secret:
+          defaultMode: 420
+          secretName: oauth-token
+      - configMap:
+          defaultMode: 420
+          name: config
+        name: config
+      - configMap:
+          defaultMode: 420
+          name: plugins
+        name: plugins

--- a/prow/manifests/tide-deployment.yaml
+++ b/prow/manifests/tide-deployment.yaml
@@ -1,0 +1,59 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  labels:
+    app: tide
+  name: tide
+  namespace: default
+spec:
+  progressDeadlineSeconds: 600
+  replicas: 1
+  revisionHistoryLimit: 10
+  selector:
+    matchLabels:
+      app: tide
+  strategy:
+    type: Recreate
+  template:
+    metadata:
+      creationTimestamp: null
+      labels:
+        app: tide
+    spec:
+      containers:
+      - args:
+        - --dry-run=false
+        - --config-path=/etc/config/config.yaml
+        image: gcr.io/k8s-prow/tide:v20191219-ecbeba384
+        imagePullPolicy: IfNotPresent
+        name: tide
+        ports:
+        - containerPort: 8888
+          name: http
+          protocol: TCP
+        resources: {}
+        terminationMessagePath: /dev/termination-log
+        terminationMessagePolicy: File
+        volumeMounts:
+        - mountPath: /etc/github
+          name: oauth
+          readOnly: true
+        - mountPath: /etc/config
+          name: config
+          readOnly: true
+      dnsPolicy: ClusterFirst
+      restartPolicy: Always
+      schedulerName: default-scheduler
+      securityContext: {}
+      serviceAccount: tide
+      serviceAccountName: tide
+      terminationGracePeriodSeconds: 30
+      volumes:
+      - name: oauth
+        secret:
+          defaultMode: 420
+          secretName: oauth-token
+      - configMap:
+          defaultMode: 420
+          name: config
+        name: config


### PR DESCRIPTION
I haven't upgraded prow since it was deployed several months ago.  I now want to get upgrades automated.  This PR is the first step.  It adds a periodic job that automatically generates PRs with manifest updates.

Once this piece is working smoothly, I will add another job that automatically applies the updated manifests to the cluster after PRs merge that change them.

The PR also includes one other unrelated CI cluster manifest (ImagePruner) that I had sitting in my working copy.