### PR TITLE
Address issues encountered with prow upgrade

### DIFF
--- a/prow/config/config.yaml
+++ b/prow/config/config.yaml
@@ -98,9 +98,7 @@ deck:
     viewers:
       "started.json|finished.json":
       - "metadata"
-      "build-log.txt":
-      - "buildlog"
-      "clone-log.txt":
+      "build-log.txt|clone-log.txt":
       - "buildlog"
 
 periodics:

--- a/prow/manifests/horologium-deployment.yaml
+++ b/prow/manifests/horologium-deployment.yaml
@@ -23,6 +23,7 @@ spec:
       containers:
       - args:
         - --config-path=/etc/config/config.yaml
+        - --deck-url=https://https://prow.apps.ci.metal3.io/
         image: gcr.io/k8s-prow/horologium:v20200518-8da074ad4
         imagePullPolicy: IfNotPresent
         name: horologium


### PR DESCRIPTION
After merging and applying #103 to our CI cluster, two prow components failed to start.  One needed a new argument and another needed a tweak to configuration.