### PR TITLE
Jenkins: Add conditions to trigger pivot/upgrade/remediation tests

### DIFF
--- a/jenkins/jobs/integration_tests.pipeline
+++ b/jenkins/jobs/integration_tests.pipeline
@@ -1,8 +1,15 @@
 import java.text.SimpleDateFormat
 
 ci_git_credential_id = "metal3-jenkins-github-token"
-def TIMEOUT = 5400
+
 def CLEAN_TIMEOUT = 600
+def TIMEOUT = 5400
+
+if (env.TESTS_FOR) {
+  if ("${TESTS_FOR}" == "feature_tests") {
+    TIMEOUT = 14400
+  }
+}
 
 script {
   if ("${PROJECT_REPO_ORG}" == "metal3-io" && "${PROJECT_REPO_NAME}" == "project-infra") {
@@ -44,6 +51,8 @@ pipeline {
     CAPI_VERSION = "${CAPI_VERSION}"
     IMAGE_OS = "${TARGET_NODE_OS}"
     DEFAULT_HOSTS_MEMORY = "${TARGET_NODE_MEMORY}"
+    NUM_NODES="${NUM_NODES}"
+    TESTS_FOR="${TESTS_FOR}"
   }
   stages {
     stage('SCM') {

--- a/jenkins/scripts/files/run_integration_tests.sh
+++ b/jenkins/scripts/files/run_integration_tests.sh
@@ -12,6 +12,13 @@ export IMAGE_OS="${7:-Ubuntu}"
 export DEFAULT_HOSTS_MEMORY="${8:-4096}"
 DISTRIBUTION="${9:-ubuntu}"
 GITHUB_TOKEN="${10}"
+export NUM_NODES="${11:-2}"
+TESTS_FOR="${12:-integration_test}"
+
+if [ "${NUM_NODES}" == "null" ]
+then
+  unset NUM_NODES
+fi
 
 # Since we take care of the repo tested here (to merge the PR), do not update
 # the repo in metal3-dev-env 03_launch_mgmt_cluster.sh
@@ -102,5 +109,11 @@ else
   pushd metal3
   git checkout "${METAL3BRANCH}"
 fi
-make
-make test
+
+if [ "${TESTS_FOR}" == "feature_tests" ]
+then
+  make feature_tests
+else
+  make
+  make test
+fi

--- a/jenkins/scripts/integration_test.sh
+++ b/jenkins/scripts/integration_test.sh
@@ -35,6 +35,8 @@ REPO_BRANCH="${REPO_BRANCH:-master}"
 UPDATED_REPO="${UPDATED_REPO:-https://github.com/${REPO_ORG}/${REPO_NAME}.git}"
 UPDATED_BRANCH="${UPDATED_BRANCH:-master}"
 CAPI_VERSION="${CAPI_VERSION:-v1alpha3}"
+NUM_NODES="${NUM_NODES:-2}"
+TESTS_FOR="${TESTS_FOR:-integration_test}"
 
 DEFAULT_HOSTS_MEMORY="8192"
 
@@ -91,4 +93,5 @@ ssh \
   PATH=/usr/local/bin:/usr/bin:/usr/local/sbin:/usr/sbin:/sbin:/bin \
   /tmp/run_integration_tests.sh "${REPO_ORG}" "${REPO_NAME}" "${REPO_BRANCH}" \
   "${UPDATED_REPO}" "${UPDATED_BRANCH}" "${CAPI_VERSION}" "${IMAGE_OS}" \
-  "${DEFAULT_HOSTS_MEMORY}" "${DISTRIBUTION}" "${GITHUB_TOKEN}"
+  "${DEFAULT_HOSTS_MEMORY}" "${DISTRIBUTION}" "${GITHUB_TOKEN}" "${NUM_NODES}" \
+  "${TESTS_FOR}"


### PR DESCRIPTION
This adds `NUM_NODES `and `TESTS_FOR` variables that will be used in Metal3-dev-env for testing pivoting, upgrade and remediation tests in Metal3-dev-env.