### PR TITLE
Jenkins, fetch m3-dev-env console logs during log gathering

### DIFF
--- a/jenkins/scripts/files/run_fetch_logs.sh
+++ b/jenkins/scripts/files/run_fetch_logs.sh
@@ -43,4 +43,8 @@ do
   2> "${LOGS_DIR}/${CONTAINER_RUNTIME}/${LOCAL_CONTAINER}/stderr.log"
 done
 
+mkdir -p "${LOGS_DIR}/qemu"
+sudo cp -r /var/log/libvirt/qemu/* "${LOGS_DIR}/qemu/"
+sudo chown -R ${USER}:${USER} "${LOGS_DIR}/qemu"
+
 tar -cvzf "$LOGS_TARBALL" ${LOGS_DIR}/*


### PR DESCRIPTION
Following https://github.com/metal3-io/metal3-dev-env/pull/330 we can fetch the vm console logs as part of the log fetching process in the metal3-dev-env tests.