### PR TITLE
Jenkins: do not build BMO and CAPM3 images for each m3-dev-env PRs

### DIFF
--- a/jenkins/scripts/files/run_integration_tests.sh
+++ b/jenkins/scripts/files/run_integration_tests.sh
@@ -53,47 +53,57 @@ fi
 
 if [ "${REPO_NAME}" == "metal3-dev-env" ]
 then
-   export METAL3REPO="${UPDATED_REPO}"
-   export METAL3BRANCH="${UPDATED_BRANCH}"
-   export BAREMETAL_OPERATOR_LOCAL_IMAGE="https://github.com/metal3-io/baremetal-operator.git"
-   export CAPM3_LOCAL_IMAGE="https://github.com/metal3-io/cluster-api-provider-metal3.git"
-   if [ "${CAPI_VERSION}" == "v1alpha3" ]
-   then
-     export CAPM3_LOCAL_IMAGE_BRANCH="release-0.3"
-   else
-     export CAPM3_LOCAL_IMAGE_BRANCH="master"
-   fi
+  export METAL3REPO="${UPDATED_REPO}"
+  export METAL3BRANCH="${UPDATED_BRANCH}"
+
+  # If the target repo and branch are the same as the source repo and branch
+  # we're running a master test, that is not for a PR, so we build the image
+  # for CAPM3 to verify the process (not BMO due to the build time for BMO image)
+  if [[ "${UPDATED_BRANCH}" == "${REPO_BRANCH}" ]] && [[ "${UPDATED_REPO}" != *"${REPO_ORG}/${REPO_NAME}"* ]]; then
+    export CAPM3_LOCAL_IMAGE="https://github.com/metal3-io/cluster-api-provider-metal3.git"
+    if [ "${CAPI_VERSION}" == "v1alpha3" ]
+    then
+      export CAPM3_LOCAL_IMAGE_BRANCH="release-0.3"
+    else
+      export CAPM3_LOCAL_IMAGE_BRANCH="master"
+    fi
+  fi
+
 elif [ "${REPO_NAME}" == "baremetal-operator" ]
 then
-   export BMOREPO="${UPDATED_REPO}"
-   export BMOBRANCH="${UPDATED_BRANCH}"
-   export BMOPATH="/home/${USER}/tested_repo"
-   export BAREMETAL_OPERATOR_LOCAL_IMAGE="${BMOPATH}"
+  export BMOREPO="${UPDATED_REPO}"
+  export BMOBRANCH="${UPDATED_BRANCH}"
+  export BMOPATH="/home/${USER}/tested_repo"
+  export BAREMETAL_OPERATOR_LOCAL_IMAGE="${BMOPATH}"
+
 elif [ "${REPO_NAME}" == "ironic-image" ]
 then
-   export IRONIC_LOCAL_IMAGE="/home/${USER}/tested_repo"
+  export IRONIC_LOCAL_IMAGE="/home/${USER}/tested_repo"
+
 elif [ "${REPO_NAME}" == "ironic-inspector-image" ]
 then
-   export IRONIC_INSPECTOR_LOCAL_IMAGE="/home/${USER}/tested_repo"
+  export IRONIC_INSPECTOR_LOCAL_IMAGE="/home/${USER}/tested_repo"
+
 elif [ "${REPO_NAME}" == "ironic-ipa-downloader" ]
 then
-   export IPA_DOWNLOADER_LOCAL_IMAGE="/home/${USER}/tested_repo"
+  export IPA_DOWNLOADER_LOCAL_IMAGE="/home/${USER}/tested_repo"
+
 elif [[ "${REPO_NAME}" == "cluster-api-provider-"* ]]
 then
-   export CAPM3REPO="${UPDATED_REPO}"
-   export CAPM3BRANCH="${UPDATED_BRANCH}"
-   export CAPM3PATH="/home/${USER}/tested_repo"
-   export CAPM3_LOCAL_IMAGE="/home/${USER}/tested_repo"
+  export CAPM3REPO="${UPDATED_REPO}"
+  export CAPM3BRANCH="${UPDATED_BRANCH}"
+  export CAPM3PATH="/home/${USER}/tested_repo"
+  export CAPM3_LOCAL_IMAGE="/home/${USER}/tested_repo"
+
 elif [[ "${REPO_NAME}" == "project-infra" ]]
 then
-   export BAREMETAL_OPERATOR_LOCAL_IMAGE="https://github.com/metal3-io/baremetal-operator.git"
-   export CAPM3_LOCAL_IMAGE="https://github.com/metal3-io/cluster-api-provider-metal3.git"
-   if [ "${CAPI_VERSION}" == "v1alpha3" ]
-   then
-     export CAPM3_LOCAL_IMAGE_BRANCH="release-0.3"
-   else
-     export CAPM3_LOCAL_IMAGE_BRANCH="master"
-   fi
+  export CAPM3_LOCAL_IMAGE="https://github.com/metal3-io/cluster-api-provider-metal3.git"
+  if [ "${CAPI_VERSION}" == "v1alpha3" ]
+  then
+    export CAPM3_LOCAL_IMAGE_BRANCH="release-0.3"
+  else
+    export CAPM3_LOCAL_IMAGE_BRANCH="master"
+  fi
 fi
 
 export GITHUB_TOKEN="${GITHUB_TOKEN}"


### PR DESCRIPTION
Avoid building BMO image due to the time it requires during the
metal3-dev-env runs. Avoid building CAPM3 images if it is a PR
in metal3-dev-env. Keep building metal3-dev-env image for master
jobs