### PR TITLE
Jenkins: use random characters in vm names

### DIFF
--- a/jenkins/jobs/integration_tests.pipeline
+++ b/jenkins/jobs/integration_tests.pipeline
@@ -23,7 +23,9 @@ script {
   }
   def date = new Date()
   def dateFormat = new SimpleDateFormat("yyyyMMddHHmmss")
-  VM_NAME = "ci-test-vm-" + dateFormat.format(date)
+  def rand = new Random()
+  VM_KEY = (1..4).collect { ('a'..'z').join("")[ rand.nextInt( 26 ) ] }.join("")
+  VM_NAME = "ci-test-vm-" + dateFormat.format(date) + "-" + VM_KEY
 }
 
 pipeline {

--- a/jenkins/scripts/integration_clean.sh
+++ b/jenkins/scripts/integration_clean.sh
@@ -20,8 +20,9 @@ CI_DIR="$(dirname "$(readlink -f "${0}")")"
 source "${CI_DIR}/utils.sh"
 
 VM_LIST=$(openstack server list -f json | jq -r '.[] | select(.Name |
-  startswith("ci-test-vm-")) | select((.Name | ltrimstr("ci-test-vm-") |
-  strptime("%Y%m%d%H%M%S") | mktime) < (now - 21600)) | .ID ')
+  startswith("ci-test-vm-")) | select((.Name | ltrimstr("ci-test-vm-") | 
+  split("-") | .[0] | strptime("%Y%m%d%H%M%S") | mktime) < (now - 21600)) 
+  | .ID ')
 
 echo "Cleaning old resources"
 


### PR DESCRIPTION
to prevent collisions when two tests are started at the same time