### PR TITLE
Increase timeout for feature test

### DIFF
--- a/jenkins/jobs/integration_tests.pipeline
+++ b/jenkins/jobs/integration_tests.pipeline
@@ -7,7 +7,7 @@ def TIMEOUT = 5400
 
 if (env.TESTS_FOR) {
   if ("${TESTS_FOR}" == "feature_tests") {
-    TIMEOUT = 14400
+    TIMEOUT = 36000
   }
 }
 


### PR DESCRIPTION
Increase timeout for feature tests to 10 hours since now the upgrade tests will also be running. 