### PR TITLE
prow: Use OWNERS file to determine reviewers

### DIFF
--- a/prow/config/plugins.yaml
+++ b/prow/config/plugins.yaml
@@ -1,3 +1,10 @@
+owners:
+  # By default, prow will use github org membership as the list of who is allowed to
+  # /lgtm PRs.  This configuration setting tells it to use the OWNERS file only and
+  # can be applied to a specific repo or entire github org.
+  skip_collaborators:
+    - "metal3-io"
+
 plugins:
   metal3-io:
   - approve


### PR DESCRIPTION
Prow was previously configured to use its default behavior of looking
at public membership of the metal3-io github org to determine who was
an allowed reviewer (who can /lgtm a PR).  This change switches to
using the OWNERS files in each repository, instead.

For more information, see:
 - https://github.com/metal3-io/metal3-docs/pull/93
 - https://github.com/metal3-io/metal3-docs/pull/94