### PR TITLE
✨Add using volume instead of image to integration tests

### DIFF
--- a/jenkins/scripts/integration_clean.sh
+++ b/jenkins/scripts/integration_clean.sh
@@ -28,11 +28,22 @@ echo "Cleaning old resources"
 
 for VM_NAME in $VM_LIST
 do
-  # Delete executer vm
+  # Delete executer VM
   echo "Deleting executer VM ${VM_NAME}."
   openstack server delete "${VM_NAME}"
 done
 
+VOLUME_LIST=$(openstack volume list -f json | jq -r '.[] | select(.Name |
+  startswith("ci-test-volume-")) | select((.Name | ltrimstr("ci-test-volume-") |
+  split("-") | .[0] | strptime("%Y%m%d%H%M%S") | mktime) < (now - 21600))
+  | .ID ')
+
+for VOLUME_NAME in $VOLUME_LIST
+do
+  # Delete executer volume
+  echo "Deleting executer volume ${VOLUME_NAME}."
+  openstack volume delete --force "${VOLUME_NAME}"
+done
 
 PORT_LIST=$(openstack port list -f json | jq -r '.[] | select(.Name |
   startswith("ci-test-vm-")) | select((.Name | ltrimstr("ci-test-vm-") |
@@ -41,7 +52,7 @@ PORT_LIST=$(openstack port list -f json | jq -r '.[] | select(.Name |
 
 for PORT_NAME in $PORT_LIST
 do
-  # Delete executer vm
+  # Delete executer VM port
   echo "Deleting executer VM port ${PORT_NAME}."
   openstack port delete "${PORT_NAME}"
 done

--- a/jenkins/scripts/integration_delete.sh
+++ b/jenkins/scripts/integration_delete.sh
@@ -17,8 +17,26 @@ source "${CI_DIR}/utils.sh"
 
 TEST_EXECUTER_PORT_NAME="${TEST_EXECUTER_PORT_NAME:-${TEST_EXECUTER_VM_NAME}-int-port}"
 
-# Delete executer vm
+# Delete executer VM
 echo "Deleting executer VM."
 openstack server delete "${TEST_EXECUTER_VM_NAME}"
 
+echo "Waiting until volume status is available, to proceed with proper volume deletion."
+until openstack volume show "${TEST_EXECUTER_VM_NAME}" -f json \
+  | jq .status | grep "available"
+do
+  sleep 10
+  if [[ "$(openstack volume show "${TEST_EXECUTER_VM_NAME}" -f json \
+    | jq .status)" == "error" ]];
+  then
+    exit 1
+  fi
+done
+
+# Delete executer volume
+echo "Deleting executer volume."
+openstack volume delete "${TEST_EXECUTER_VM_NAME}"
+
+# Delete executer VM port
+echo "Deleting executer VM port."
 openstack port delete "${TEST_EXECUTER_PORT_NAME}"

--- a/jenkins/scripts/integration_test.sh
+++ b/jenkins/scripts/integration_test.sh
@@ -23,8 +23,10 @@ DISTRIBUTION="${DISTRIBUTION:-ubuntu}"
 if [ "${DISTRIBUTION}" == "ubuntu" ]
 then
   IMAGE_NAME="${CI_METAL3_IMAGE}"
+  BASE_VOLUME_NAME="metal3-ubuntu"
 else
   IMAGE_NAME="${CI_METAL3_CENTOS_IMAGE}"
+  BASE_VOLUME_NAME="metal3-centos"
 fi
 
 REPO_ORG="${REPO_ORG:-metal3-io}"
@@ -47,30 +49,50 @@ if [ "${TESTS_FOR}" == "feature_tests" ]
 then
   TEST_EXECUTER_FLAVOR="${TEST_EXECUTER_FLAVOR:-8C-32GB-300GB}"
 fi
-
 TEST_EXECUTER_FLAVOR="${TEST_EXECUTER_FLAVOR:-4C-16GB-200GB}"
 
-echo "Creating new executer VM."
-
-# Creating new port, needed to immediately get the ip
+# Create new port, needed to immediately get the ip
+echo "Creating a new port to get an IP address."
 EXT_PORT_ID="$(openstack port create -f json \
   --network "${CI_EXT_NET}" \
   --fixed-ip subnet="$(get_subnet_name "${CI_EXT_NET}")" \
   "${TEST_EXECUTER_PORT_NAME}" | jq -r '.id')"
 
-# Create new executer vm
-openstack server create -f json \
-  --image "${IMAGE_NAME}" \
+# Get the base volume
+echo "Getting the base volume."
+BASE_VOLUME_NAME_ID="$(openstack volume show -f json \
+  "${BASE_VOLUME_NAME}" | jq -r '.id')"
+
+# Create test executer volume from copy of base volume
+echo "Creating a test executer volume from copy of base volume."
+TEST_EXECUTER_VOLUME_ID="$(openstack volume create -f json \
+  --source "${BASE_VOLUME_NAME_ID}" \
+  --size 200 \
+  "${TEST_EXECUTER_VM_NAME}" | jq -r '.id')"
+
+# Wait for a test executer volume to be available...
+echo "Waiting for a test executer volume to be available."
+until openstack volume show "${TEST_EXECUTER_VM_NAME}" -f json \
+  | jq .status | grep "available"
+do
+  sleep 10
+done
+
+# Create a test executer VM from copy of the test executer volume
+echo "Creating a test executer VM from the test executer volume."
+openstack server create \
+  --volume "${TEST_EXECUTER_VOLUME_ID}" \
   --flavor "${TEST_EXECUTER_FLAVOR}" \
   --port "${EXT_PORT_ID}" \
-  "${TEST_EXECUTER_VM_NAME}" | jq -r '.id'
+  "${TEST_EXECUTER_VM_NAME}"
 
 # Get the IP
+echo "Getting the IP address of a test executer VM."
 TEST_EXECUTER_IP="$(openstack port show -f json "${TEST_EXECUTER_PORT_NAME}" \
   | jq -r '.fixed_ips[0].ip_address')"
 
-echo "Waiting for the host ${TEST_EXECUTER_VM_NAME} to come up"
-#Wait for the host to come up
+# Wait for the host to come up
+echo "Waiting for the host ${TEST_EXECUTER_VM_NAME} to come up."
 wait_for_ssh "${AIRSHIP_CI_USER}" "${AIRSHIP_CI_USER_KEY}" "${TEST_EXECUTER_IP}"
 
 cat <<-EOF > "${CI_DIR}/files/vars.sh"
@@ -89,6 +111,7 @@ TESTS_FOR="${TESTS_FOR}"
 EOF
 
 # Send Remote script to Executer
+echo "Copying run_integration_tests.sh script to test executer VM."
 scp \
   -o StrictHostKeyChecking=no \
   -o UserKnownHostsFile=/dev/null \
@@ -97,9 +120,9 @@ scp \
   "${CI_DIR}/files/vars.sh" \
   "${AIRSHIP_CI_USER}@${TEST_EXECUTER_IP}:/tmp/" > /dev/null
 
-echo "Running the tests"
 # Execute remote script
 # shellcheck disable=SC2029
+echo "Running the tests."
 ssh \
   -o StrictHostKeyChecking=no \
   -o UserKnownHostsFile=/dev/null \


### PR DESCRIPTION
This patch takes the volumes created in [airship-dev-tools/pull/210](https://github.com/Nordix/airship-dev-tools/pull/210)
in use, by cloning the volume and starting the VM in CI with the cloned base volumes

Related to this patch:

-  [airship-dev-tools/pull/219](https://github.com/Nordix/airship-dev-tools/pull/219)