### PR TITLE
Update prow config for CAPM3 jobs

### DIFF
--- a/prow/config/config.yaml
+++ b/prow/config/config.yaml
@@ -75,10 +75,10 @@ branch-protection:
           branches:
             master:
               required_status_checks:
-                contexts: ["test-v1a4-integration"]
+                contexts: ["test-integration"]
             release-0.3:
               required_status_checks:
-                contexts: ["test-integration"]
+                contexts: ["test-v1a3-integration"]
         ironic-image:
           required_status_checks:
             contexts: ["test-integration"]


### PR DESCRIPTION
After the CAPM3 v1a4 release, we have changed or main jobs to v1a4. We need to adapt the prow config to reflect the change in CAPM3