### PR TITLE
CI: reduce feature_test timeout

### DIFF
--- a/jenkins/jobs/integration_tests.pipeline
+++ b/jenkins/jobs/integration_tests.pipeline
@@ -7,7 +7,7 @@ def TIMEOUT = 5400
 
 if (env.TESTS_FOR) {
   if ( (env.TESTS_FOR).startsWith('feature_tests') ) {
-    TIMEOUT = 36000
+    TIMEOUT = 21600
   }
 }
 


### PR DESCRIPTION
Based on experience the timeout value used by
pivoting, remediation and upgrade can be reduced
from 36000 sec (10 hours) to 21600 sec (6 hours)