### PR TITLE
Jenkins: Increase integration CI timeout

### DIFF
--- a/jenkins/jobs/integration_tests.pipeline
+++ b/jenkins/jobs/integration_tests.pipeline
@@ -3,7 +3,7 @@ import java.text.SimpleDateFormat
 ci_git_credential_id = "metal3-jenkins-github-token"
 
 def CLEAN_TIMEOUT = 600
-def TIMEOUT = 5400
+def TIMEOUT = 7200
 
 if (env.TESTS_FOR) {
   if ( (env.TESTS_FOR).startsWith('feature_tests') ) {


### PR DESCRIPTION
Currently, integration CI is failing mostly due to the timeout. This is a temporary fix until we really find the reason for the CI to be slow.