### PR TITLE
Jenkins: fix upgrade test caller

### DIFF
--- a/jenkins/scripts/files/run_integration_tests.sh
+++ b/jenkins/scripts/files/run_integration_tests.sh
@@ -121,9 +121,11 @@ else
   git checkout "${METAL3BRANCH}"
 fi
 
-if [[ "${TESTS_FOR}" == "feature_tests"* ]]
+if [[ "${TESTS_FOR}" == "feature_tests_upgrade"* ]]
 then
-  make ${TESTS_FOR}
+  make "${TESTS_FOR}"
+elif [[ "${TESTS_FOR}" == "feature_tests" || "${TESTS_FOR}" == "feature_tests_centos" ]]
+  make feature_tests
 else
   make
   make test


### PR DESCRIPTION
Centos based upgrade & feature tests are failing due to incorrect utilization of TESTS_FOR variable.

This should be merged after https://gerrit.nordix.org/c/infra/cicd/+/6021 gets in.