### PR TITLE
Jenkins: Use Ubuntu volume instead of image

### DIFF
--- a/jenkins/scripts/integration_delete.sh
+++ b/jenkins/scripts/integration_delete.sh
@@ -21,4 +21,27 @@ TEST_EXECUTER_PORT_NAME="${TEST_EXECUTER_PORT_NAME:-${TEST_EXECUTER_VM_NAME}-int
 echo "Deleting executer VM."
 openstack server delete "${TEST_EXECUTER_VM_NAME}"
 
+
+DISTRIBUTION="${DISTRIBUTION:-ubuntu}"
+if [ "${DISTRIBUTION}" == "ubuntu" ]
+then
+    echo "Waiting until volume status is available, to proceed with proper volume deletion."
+    until openstack volume show "${TEST_EXECUTER_VM_NAME}" -f json \
+        | jq .status | grep "available"
+    do
+        sleep 10
+        if [[ "$(openstack volume show "${TEST_EXECUTER_VM_NAME}" -f json \
+            | jq .status)" == "error" ]];
+        then
+            exit 1
+        fi
+    done
+
+    # Delete executer volume
+    echo "Deleting executer volume."
+    openstack volume delete "${TEST_EXECUTER_VM_NAME}"
+fi
+
+# Delete executer VM port
+echo "Deleting executer VM port."
 openstack port delete "${TEST_EXECUTER_PORT_NAME}"


### PR DESCRIPTION
This PR only adds using Ubuntu volume instead of Ubuntu images in Jenkins, while Centos based setup remains same