### PR TITLE
Fix volume deletion

### DIFF
--- a/jenkins/scripts/integration_clean.sh
+++ b/jenkins/scripts/integration_clean.sh
@@ -37,7 +37,7 @@ DISTRIBUTION="${DISTRIBUTION:-ubuntu}"
 if [ "${DISTRIBUTION}" == "ubuntu" ]
 then
   VOLUME_LIST=$(openstack volume list -f json | jq -r '.[] | select(.Name |
-    startswith("ci-test-volume-")) | select((.Name | ltrimstr("ci-test-volume-") |
+    startswith("ci-test-vm-")) | select((.Name | ltrimstr("ci-test-vm-") |
     split("-") | .[0] | strptime("%Y%m%d%H%M%S") | mktime) < (now - 21600))
     | .ID ')
 


### PR DESCRIPTION
This PR fixes volume deletion name problem, where the cleanup job script looks for volumes starting with `ci-test-volume-` but volume names start with `ci-test-vm-` making unused volumes packed in CityCloud.
List of volumes in CityCloud is [here](https://citycontrolpanel.com/openstack#volumes)