### PR TITLE
Add retry conditions to volume creation and resizing steps

### DIFF
--- a/jenkins/scripts/utils.sh
+++ b/jenkins/scripts/utils.sh
@@ -44,3 +44,93 @@ wait_for_ssh() {
 
   echo "SSH connection to host[${SERVER}] is up."
 }
+
+# Description:
+# Creates Openstack test executer volume.
+#
+# Usage:
+#   create_test_executer_volume <base_volume_name_id> <test_executer_vm_name>
+#
+create_test_executer_volume() {
+  local BASE_VOLUME_NAME_ID TEST_EXECUTER_VM_NAME
+
+  BASE_VOLUME_NAME_ID="${1:?}"
+  TEST_EXECUTER_VM_NAME="${2:?}"
+    
+  openstack volume create \
+    --source "${BASE_VOLUME_NAME_ID}" \
+    "${TEST_EXECUTER_VM_NAME}"
+}
+
+# Description:
+# Waits for Openstack test executer volume to be available and if not
+# retry volume creation again only once.
+#
+# Usage:
+#   wait_for_volume <base_volume_name_id> <test_executer_vm_name>
+#
+wait_for_volume() {
+  local BASE_VOLUME_NAME_ID TEST_EXECUTER_VM_NAME
+
+  BASE_VOLUME_NAME_ID="${1:?}"
+  TEST_EXECUTER_VM_NAME="${2:?}"
+
+  retry=0
+  until openstack volume show "${TEST_EXECUTER_VM_NAME}" -f json \
+      | jq .status | grep "available"
+  do
+    sleep 10
+    # Check if test executer volume creation is failed
+    if [[ "$(openstack volume show "${TEST_EXECUTER_VM_NAME}" -f json \
+      | jq .status)" == "error"* ]];
+    then
+      # If test executer volume creation is failed, then retry volume creation only once
+      if [ $retry -eq 0 ]; then
+        openstack volume delete "${TEST_EXECUTER_VM_NAME}"
+        create_test_executer_volume "${BASE_VOLUME_NAME_ID}" "${TEST_EXECUTER_VM_NAME}"
+        retry=1
+      else
+        exit 1
+      fi
+      continue
+    fi
+  done
+}
+
+# Description:
+# Waits for Openstack resized test executer volume to be available and if not
+# retry volume resizing again only once.
+#
+# Usage:
+#   wait_for_resized_volume <base_volume_name_id> <test_executer_vm_name> <resized_vm_size>
+#
+wait_for_resized_volume() {
+  local BASE_VOLUME_NAME_ID TEST_EXECUTER_VM_NAME RESIZED_VM_SIZE
+
+  BASE_VOLUME_NAME_ID="${1:?}"
+  TEST_EXECUTER_VM_NAME="${2:?}"
+  RESIZED_VM_SIZE="${3:?}"
+
+  resize_retry=0
+  until openstack volume show "${TEST_EXECUTER_VM_NAME}" -f json \
+    | jq .size | grep "${RESIZED_VM_SIZE}"
+  do
+    sleep 10
+    if [[ "$(openstack volume show "${TEST_EXECUTER_VM_NAME}" -f json \
+      | jq .status)" == "error"* ]];
+    then
+      echo "Volume resizing is failed, retrying volume creation and resizing once again."
+      # If volume resizing is failed, then retry volume creation and resizing only once
+      if [ $resize_retry -eq 0 ]; then
+        openstack volume delete "${TEST_EXECUTER_VM_NAME}"
+        create_test_executer_volume "${BASE_VOLUME_NAME_ID}" "${TEST_EXECUTER_VM_NAME}"
+        wait_for_volume "${BASE_VOLUME_NAME_ID}" "${TEST_EXECUTER_VM_NAME}"
+        openstack volume set --size "${RESIZED_VM_SIZE}" "${TEST_EXECUTER_VM_NAME}"
+        resize_retry=1
+      else
+        exit 1
+      fi
+      continue
+    fi
+  done
+}


### PR DESCRIPTION
When test executor volume creation or resizing it fails, it will stay in an infinitive loop trying to create or resize volume. This PR avoids infinitive looping and adds retrying in case of above mentioned failures. 