### PR TITLE
Add manifest linting job to prow as a new CI check

### DIFF
--- a/prow/config/config.yaml
+++ b/prow/config/config.yaml
@@ -363,6 +363,20 @@ presubmits:
           value: "TRUE"
         image: quay.io/metal3-io/golint:latest
         imagePullPolicy: Always
+  - name: manifestlint
+    always_run: true
+    decorate: true
+    spec:
+      containers:
+      - args:
+        - ./hack/manifestlint.sh
+        command:
+        - sh
+        env:
+        - name: IS_CONTAINER
+          value: "TRUE"
+        image: garethr/kubeval:latest
+        imagePullPolicy: Always
 
   metal3-io/cluster-api-provider-metal3:
   - name: gofmt
@@ -462,6 +476,20 @@ presubmits:
         - name: IS_CONTAINER
           value: "TRUE"
         image: quay.io/metal3-io/capm3-unit:master
+        imagePullPolicy: Always
+  - name: manifestlint
+    always_run: true
+    decorate: true
+    spec:
+      containers:
+      - args:
+        - ./hack/manifestlint.sh
+        command:
+        - sh
+        env:
+        - name: IS_CONTAINER
+          value: "TRUE"
+        image: garethr/kubeval:latest
         imagePullPolicy: Always
 
   metal3-io/metal3-dev-env:
@@ -612,6 +640,20 @@ presubmits:
           value: "TRUE"
         image: quay.io/metal3-io/capm3-unit:master
         imagePullPolicy: Always
+  - name: manifestlint
+    always_run: true
+    decorate: true
+    spec:
+      containers:
+      - args:
+        - ./hack/manifestlint.sh
+        command:
+        - sh
+        env:
+        - name: IS_CONTAINER
+          value: "TRUE"
+        image: garethr/kubeval:latest
+        imagePullPolicy: Always
 
   metal3-io/hardware-classification-controller:
   - name: gofmt
@@ -683,4 +725,18 @@ presubmits:
         - name: IS_CONTAINER
           value: "TRUE"
         image: quay.io/metal3-io/capm3-unit:master
+        imagePullPolicy: Always
+  - name: manifestlint
+    always_run: true
+    decorate: true
+    spec:
+      containers:
+      - args:
+        - ./hack/manifestlint.sh
+        command:
+        - sh
+        env:
+        - name: IS_CONTAINER
+          value: "TRUE"
+        image: garethr/kubeval:latest
         imagePullPolicy: Always


### PR DESCRIPTION
This adds a new manifestlint job to the prow configuration so the
manifestlint.sh script gets triggered for every pull request in
BMO, CAPM3, IPAM, HWCC repos. The task of the manifestlint.sh is
to validate only core types based manifests within those repos and
report if they don’t match Kubernetes OpenAPI specification.