### PR TITLE
CI: Run upgrade test with latest CAPI release.

### DIFF
--- a/jenkins/scripts/files/run_integration_tests.sh
+++ b/jenkins/scripts/files/run_integration_tests.sh
@@ -132,7 +132,6 @@ if [[ "${TESTS_FOR}" == "feature_tests_upgrade"* ]]
 then
   export IRONIC_BASIC_AUTH="false"
   export IRONIC_TLS_SETUP="false"
-  export CAPIRELEASE="v0.3.10"
   export NODE_DRAIN_TIMEOUT="300s"
   make "${TESTS_FOR}"
 elif [[ "${TESTS_FOR}" == "feature_tests" || "${TESTS_FOR}" == "feature_tests_centos" ]]


### PR DESCRIPTION
We are using CAPI release version 3.10 for upgrade test. This PR will enable to use the latest CAPI release.