### PR TITLE
Reduce feature tests CI timeout time.

### DIFF
--- a/jenkins/jobs/integration_tests.pipeline
+++ b/jenkins/jobs/integration_tests.pipeline
@@ -7,7 +7,7 @@ def TIMEOUT = 5400
 
 if (env.TESTS_FOR) {
   if ( (env.TESTS_FOR).startsWith('feature_tests') ) {
-    TIMEOUT = 36000
+    TIMEOUT = 12600
   }
 }
 


### PR DESCRIPTION
Feature tests CI jobs timeout is set to 10 hours, which is unnecessary.  In case of failed CI jobs, they are consuming resources in citycloud for longer period of time.  In successful run the CI jobs always are completed within 3 hours.  This PR will reduce the timeout to 3.5 hours.