### PR TITLE
Test sushy-tools/vbmc in metal3-dev-env CI

### DIFF
--- a/jenkins/scripts/files/run_integration_tests.sh
+++ b/jenkins/scripts/files/run_integration_tests.sh
@@ -53,6 +53,9 @@ if [ "${REPO_NAME}" == "metal3-dev-env" ]
 then
   export METAL3REPO="${UPDATED_REPO}"
   export METAL3BRANCH="${UPDATED_BRANCH}"
+  # Build/test the sushy-tools/vbmc images, since they are defined in this repo
+  export SUSHY_TOOLS_LOCAL_IMAGE="/home/${USER}/tested_repo/resources/sushy-tools"
+  export VBMC_LOCAL_IMAGE="/home/${USER}/tested_repo/resources/vbmc"
 
   # If the target repo and branch are the same as the source repo and branch
   # we're running a master test, that is not for a PR, so we build the image


### PR DESCRIPTION
These container images are defined in the metal3-dev-env repo
but currently aren't tested in CI, leading to potential regressions
such as https://github.com/metal3-io/metal3-dev-env/pull/609

We should always build/test these for metal3-dev-env CI, to catch
issues before changes to the Dockerfiles land.