### PR TITLE
Get Ironic Python Agent from Artifactory

### DIFF
--- a/jenkins/scripts/files/run_integration_tests.sh
+++ b/jenkins/scripts/files/run_integration_tests.sh
@@ -119,6 +119,10 @@ fi
 
 export GITHUB_TOKEN="${GITHUB_TOKEN}"
 
+# Make the ipa-downloader pull the ironic-python-agent from Artifactory to
+# reduce dependency on upstream services and improve build times
+export IPA_BASEURI="https://artifactory.nordix.org/artifactory/airship/ironic-python-agent"
+
 METAL3REPO="${METAL3REPO:-https://github.com/metal3-io/metal3-dev-env.git}"
 METAL3BRANCH="${METAL3BRANCH:-master}"
 


### PR DESCRIPTION
In order to reduce dependency on upstream services (e.g. in the event of network degradation between Sweden and US West, where the default Ironic Python Agent tarball is hosted), set IPA_BAREURI to download IPA from Nordix Artifactory in CI. 

This has the added benefit of potentially reducing build times, because we'll be downloading from the same infrastructure on which the CI is hosted.