### PR TITLE
Fetch also exited container logs

### DIFF
--- a/jenkins/scripts/files/run_fetch_logs.sh
+++ b/jenkins/scripts/files/run_fetch_logs.sh
@@ -49,7 +49,7 @@ done
 fetch_k8s_logs "management_cluster" "/home/airshipci/.kube/config"
 
 mkdir -p "${LOGS_DIR}/${CONTAINER_RUNTIME}"
-LOCAL_CONTAINERS="$(sudo "${CONTAINER_RUNTIME}" ps --format "{{.Names}}")"
+LOCAL_CONTAINERS="$(sudo "${CONTAINER_RUNTIME}" ps -a --format "{{.Names}}")"
 for LOCAL_CONTAINER in $LOCAL_CONTAINERS
 do
   mkdir -p "${LOGS_DIR}/${CONTAINER_RUNTIME}/${LOCAL_CONTAINER}"

--- a/jenkins/scripts/files/run_integration_tests.sh
+++ b/jenkins/scripts/files/run_integration_tests.sh
@@ -107,8 +107,6 @@ then
 
 elif [[ "${REPO_NAME}" == "project-infra" ]]
 then
-  export BAREMETAL_OPERATOR_LOCAL_IMAGE="https://github.com/metal3-io/baremetal-operator.git"
-  export CAPM3_LOCAL_IMAGE="https://github.com/metal3-io/cluster-api-provider-metal3.git"
   if [ "${CAPM3_VERSION}" == "v1alpha3" ]
   then
     export CAPM3_LOCAL_IMAGE_BRANCH="release-0.3"


### PR DESCRIPTION
This PR 
1. makes sure that when we fetch the container logs we also take the dead container logs since those can also give information about why a container might be failing. Currently we always have to login to the
CI vm to find out whats happening in-case an ironic container did not start properly.
2. Removes unnecessary image building for CAPM3 and BMO on a Project-infra integration test. 