### PR TITLE
Remove duplication in external plugins

### DIFF
--- a/prow/config/plugins.yaml
+++ b/prow/config/plugins.yaml
@@ -54,16 +54,6 @@ external_plugins:
     # is in use, these two tokens are only needed if the PR or its mergeability changed.
     - issue_comment
 
-external_plugins:
-  metal3-io:
-  - name: needs-rebase
-    # No endpoint specified implies "http://{{name}}".
-    events:
-    - pull_request
-    # Dispatching issue_comment events to the needs-rebase plugin is optional. If enabled, this may cost up to two token per comment on a PR. If `ghproxy`
-    # is in use, these two tokens are only needed if the PR or its mergeability changed.
-    - issue_comment
-
 config_updater:
   maps:
     # Update the config configmap whenever config.yaml changes


### PR DESCRIPTION
We have duplicated [lines of code](https://github.com/metal3-io/project-infra/blob/master/prow/config/plugins.yaml#L47-L65) for enabling external plugin needs-rebase. This patch removes the duplication for that.