### PR TITLE
Don't use prow image autobump

### DIFF
--- a/prow/config/config.yaml
+++ b/prow/config/config.yaml
@@ -191,57 +191,6 @@ periodics:
      - name: token
        secret:
          secretName: github-token
-#  - name: ci-prow-autobump
-#    # https://github.com/kubernetes/test-infra/tree/master/prow/cmd/autobump#prow-autobump
-#    # https://github.com/kubernetes/test-infra/blob/master/prow/cmd/autobump/example-periodic.yaml
-#    cron: "05 15-23 * * 1-5"  # Run at 7:05-15:05 PST (15:05 UTC) Mon-Fri
-#    decorate: true
-#    extra_refs:
-#    # Check out the repo containing the config and deployment files for your Prow instance.
-#    - org: metal3-io
-#      repo: project-infra
-#      base_ref: master
-#    spec:
-#      containers:
-#      - image: gcr.io/k8s-prow/autobump # TODO: add a tag once we've push this the first time.
-#        command:
-#        - /autobump.sh
-#        args:
-#        - /etc/github-token/token
-#        # Make the bot name and email match the user data of the provided token's user.
-#        - "metal3-io-bot"
-#        - metal3.io.bot@gmail.com
-#        volumeMounts:
-#        - name: github
-#          mountPath: /etc/github-token
-#          readOnly: true
-#        env:
-#      # autobump.sh args
-#        # GitHub org containing the repo where the Prow config and component files live.
-#        - name: GH_ORG
-#          value: metal3-io
-#        # GitHub repo where the Prow config and component deployment files live.
-#        - name: GH_REPO
-#          value: project-infra
-#        # Repo relative path of the `plank` component k8s deployment file.
-#        - name: PLANK_DEPLOYMENT_FILE
-#          value: prow/manifests/plank-deployment.yaml
-#      # bump.sh args
-#        # Directory (or comma-delimited list of directories) containing k8s deployment YAMLs for Prow components.
-#        - name: COMPONENT_FILE_DIR
-#          value: prow/manifests
-#        # Repo relative path of the core Prow config file (config.yaml).
-#        - name: CONFIG_PATH
-#          value: prow/config/config.yaml
-#        # Repo relative path of the ProwJob config file or directory.
-#        # Omit this if ProwJobs are only defined in config.yaml (or are not configured at all).
-#        #- name: JOB_CONFIG_PATH
-#        #  value: config/jobs
-#      volumes:
-#      - name: github
-#        secret:
-#          # Secret containing a GitHub user access token with `repo` scope for creating PRs.
-#          secretName: github-token
 
 presubmits:
   metal3-io/baremetal-operator:


### PR DESCRIPTION
I think even in the previous prow setup we weren't using autobump, and by looking at [past PRs](https://github.com/metal3-io/project-infra/pulls?q=is%3Apr+author%3Ametal3-io-bot+is%3Aclosed), it seems automatic image updates didn't go well. I've also looked at other repos like KubeVirt, Jetstack, Falco and it seems they are also doing image updates manually.
I can take care of updating those images from time to time. The good thing from doing updates manually is sometimes we might need to make some configuration changes in our manifests/config/plugins files before taking the latest images.