### PR TITLE
disable automatic self-approval and ensure 2 lgtm does not approve

### DIFF
--- a/prow/config/plugins.yaml
+++ b/prow/config/plugins.yaml
@@ -44,6 +44,17 @@ plugins:
     plugins:
     - config-updater
 
+approve:
+  - repos:
+    - metal3-io
+
+    # RequireSelfApproval requires PR authors to explicitly approve their PRs.
+    # Otherwise the plugin assumes the author of the PR approves the changes in the PR.
+    require_self_approval: true
+
+    # A /lgtm from a single approver should not allow a PR to merge.
+    lgtm_acts_as_approve: false
+
 external_plugins:
   metal3-io:
   - name: needs-rebase


### PR DESCRIPTION
As a community-driven open source project, we want all PR authors to
be subject to the same review requirements. That includes requiring
folks who have approval rights to have 2 reviews, including a review
from another approver. To achieve this, enable the `approve` plugin
setting `require_self_approval` to require explicit approval of PRs.

At the same time, ensure that all PRs are examined by someone with
approval permission by explicitly disabling `lgtm_acts_as_approve`.

Discussion on the mailing list: https://groups.google.com/g/metal3-dev/c/H9rR-mjgJ5s