### PR TITLE
Increase feature tests timeout in CI

### DIFF
--- a/jenkins/jobs/integration_tests.pipeline
+++ b/jenkins/jobs/integration_tests.pipeline
@@ -7,7 +7,7 @@ def TIMEOUT = 5400
 
 if (env.TESTS_FOR) {
   if ( (env.TESTS_FOR).startsWith('feature_tests') ) {
-    TIMEOUT = 12600
+    TIMEOUT = 18000
   }
 }
 


### PR DESCRIPTION
When trying to add scale in and node reuse feature tests to feature test framework, [tests are timing out ](https://jenkins.nordix.org/job/airship_metal3io_metal3_dev_env_feature_tests_ubuntu/267/)due to the added features are time consuming(includes upgrading). For that reason, this PR increases time out for running feature tests in CI from 3.5h to 5h.  