### PR TITLE
Move sushy-tools & vbmc to ironic-image repo

### DIFF
--- a/jenkins/scripts/files/run_integration_tests.sh
+++ b/jenkins/scripts/files/run_integration_tests.sh
@@ -53,9 +53,6 @@ if [ "${REPO_NAME}" == "metal3-dev-env" ]
 then
   export METAL3REPO="${UPDATED_REPO}"
   export METAL3BRANCH="${UPDATED_BRANCH}"
-  # Build/test the sushy-tools/vbmc images, since they are defined in this repo
-  export SUSHY_TOOLS_LOCAL_IMAGE="/home/${USER}/tested_repo/resources/sushy-tools"
-  export VBMC_LOCAL_IMAGE="/home/${USER}/tested_repo/resources/vbmc"
 
   # If the target repo and branch are the same as the source repo and branch
   # we're running a master test, that is not for a PR, so we build the image
@@ -89,6 +86,9 @@ then
 elif [ "${REPO_NAME}" == "ironic-image" ]
 then
   export IRONIC_LOCAL_IMAGE="/home/${USER}/tested_repo"
+  # Build/test the sushy-tools/vbmc images, since they are defined in this repo
+  export SUSHY_TOOLS_LOCAL_IMAGE="/home/${USER}/tested_repo/resources/sushy-tools"
+  export VBMC_LOCAL_IMAGE="/home/${USER}/tested_repo/resources/vbmc"
 
 elif [ "${REPO_NAME}" == "ironic-inspector-image" ]
 then


### PR DESCRIPTION
We are moving Metal3-dev-env and sushy-tools Dockerfiles to ironic-image repo. This is to update the vars of local image. 