### PR TITLE
Fix the log so the `manifests` dir is no longer empty

### DIFF
--- a/jenkins/scripts/files/fetch_manifests.sh
+++ b/jenkins/scripts/files/fetch_manifests.sh
@@ -1,0 +1,34 @@
+#!/bin/bash
+
+mkdir -p /tmp/manifests
+
+manifests=(
+  bmh
+  cluster
+  deployment
+  machine
+  machinedeployment
+  machinehealthchecks
+  machinesets
+  machinepools
+  m3cluster
+  m3machine
+  metal3machinetemplate
+  kcp
+  kubeadmconfig
+  kubeadmconfigtemplates
+  kubeadmcontrolplane
+  replicaset
+)
+
+if [[ "${CAPM3_VERSION}" == "v1alpha4" ]]; then
+   manifests+=("ippool" "ipclaim" "ipaddress" "m3data" "m3dataclaim" "m3datatemplate")
+fi
+
+for kind in "${manifests[@]}"; do
+  mkdir -p /tmp/manifests/"$kind"
+  for name in $(kubectl get -n metal3 -o name "$kind" || true)
+  do
+    kubectl get -n metal3 -o yaml "$name" > /tmp/manifests/"$kind"/"$(basename "$name")".yaml || true
+  done
+done

--- a/jenkins/scripts/files/run_fetch_logs.sh
+++ b/jenkins/scripts/files/run_fetch_logs.sh
@@ -18,6 +18,7 @@ mkdir -p ${LOGS_DIR}
 
 # Fetch cluster manifests
 mkdir -p "${LOGS_DIR}/manifests"
+. ./fetch_manifests.sh
 cp -r /tmp/manifests/* "${LOGS_DIR}/manifests"
 
 function fetch_k8s_logs() {


### PR DESCRIPTION
Currently, in the integration test, the directory `manifests` in the log is empty. Examples can be found here: 
- https://jenkins.nordix.org/job/airship_metal3io_ironic_image_v1a4_integration_test_centos/54/artifact/logs-jenkins-airship_metal3io_ironic_image_v1a4_integration_test_centos-54.tgz 
- https://jenkins.nordix.org/view/Metal3/job/airship_master_v1a4_integration_test_ubuntu/574/artifact/logs-jenkins-airship_master_v1a4_integration_test_ubuntu-574.tgz

This PR aims to fix it. 