### PR TITLE
Add .cluster-api config to fetch logs tarball

### DIFF
--- a/jenkins/scripts/files/run_fetch_logs.sh
+++ b/jenkins/scripts/files/run_fetch_logs.sh
@@ -61,6 +61,9 @@ mkdir -p "${LOGS_DIR}/qemu"
 sudo sh -c "cp -r /var/log/libvirt/qemu/* ${LOGS_DIR}/qemu/"
 sudo chown -R ${USER}:${USER} "${LOGS_DIR}/qemu"
 
+mkdir -p "${LOGS_DIR}/cluster-api-config"
+cp -r "/home/airshipci/.cluster-api/." "${LOGS_DIR}/cluster-api-config/"
+
 if [[ "${TESTS_FOR}" == "feature_tests_upgrade"* ]]
 then
   mkdir -p "${LOGS_DIR}/upgrade"


### PR DESCRIPTION
Configuration is written to ~/.cluster-api, edited and reapplied during the upgrade tests. It would be useful to examine the contents when debugging.