### PR TITLE
✨ Add required test triggering contexts for v1a4 and v1a5

### DIFF
--- a/prow/config/config.yaml
+++ b/prow/config/config.yaml
@@ -86,9 +86,9 @@ branch-protection:
             master:
               required_status_checks:
                 contexts: ["test-integration"]
-            release-0.3:
+            release-0.4:
               required_status_checks:
-                contexts: ["test-v1a3-integration"]
+                contexts: ["test-v1a4-integration"]
         ironic-image:
           required_status_checks:
             contexts: ["test-integration"]
@@ -96,8 +96,13 @@ branch-protection:
           required_status_checks:
             contexts: ["test-integration"]
         ip-address-manager:
-          required_status_checks:
-            contexts: ["test-integration"]
+          branches:
+            master:
+              required_status_checks:
+                contexts: ["test-integration"]
+            release-0.0:
+              required_status_checks:
+                contexts: ["test-v1a4-integration"]
         metal3-dev-env:
           required_status_checks:
             contexts: ["test-centos-integration", "test-integration"]


### PR DESCRIPTION
Related JJB jobs in gerrit:
Removing v1a3 jobs: [9034](https://gerrit.nordix.org/c/infra/cicd/+/9034)
Adding v1a5 jobs: [9024](https://gerrit.nordix.org/c/infra/cicd/+/9024)

