### PR TITLE
🐛 Change status checks for master and release branches in CAPM3/IPAM

### DIFF
--- a/prow/config/config.yaml
+++ b/prow/config/config.yaml
@@ -85,10 +85,10 @@ branch-protection:
           branches:
             master:
               required_status_checks:
-                contexts: ["test-integration"]
+                contexts: ["test-v1a5-integration"]
             release-0.4:
               required_status_checks:
-                contexts: ["test-v1a4-integration"]
+                contexts: ["test-integration"]
         ironic-image:
           required_status_checks:
             contexts: ["test-integration"]
@@ -99,10 +99,10 @@ branch-protection:
           branches:
             master:
               required_status_checks:
-                contexts: ["test-integration"]
+                contexts: ["test-v1a5-integration"]
             release-0.0:
               required_status_checks:
-                contexts: ["test-v1a4-integration"]
+                contexts: ["test-integration"]
         metal3-dev-env:
           required_status_checks:
             contexts: ["test-centos-integration", "test-integration"]


### PR DESCRIPTION
Since we keep running only v1a4 changes for now, and current configurations in CAPM3/IPAM expects to run v1a5 jobs with different keywords, this needs an update. 

Related jjb patch: [9097](https://gerrit.nordix.org/c/infra/cicd/+/9097)