### PR TITLE
Change integration test status check

### DIFF
--- a/prow/config/config.yaml
+++ b/prow/config/config.yaml
@@ -85,10 +85,10 @@ branch-protection:
           branches:
             master:
               required_status_checks:
-                contexts: ["test-v1a5-integration"]
+                contexts: ["test-integration"]
             release-0.4:
               required_status_checks:
-                contexts: ["test-integration"]
+                contexts: ["test-v1a4-integration"]
         ironic-image:
           required_status_checks:
             contexts: ["test-integration"]
@@ -99,13 +99,13 @@ branch-protection:
           branches:
             master:
               required_status_checks:
-                contexts: ["test-v1a5-integration"]
+                contexts: ["test-integration"]
             release-0.0:
               required_status_checks:
-                contexts: ["test-integration"]
+                contexts: ["test-v1a4-integration"]
         metal3-dev-env:
           required_status_checks:
-            contexts: ["test-centos-integration", "test-integration"]
+            contexts: ["test-v1a4-centos-integration", "test-integration"]
 
 deck:
   spyglass:


### PR DESCRIPTION
This PR changes integration test status check
1. test-integration points to master
2. test-v1a4-integration points to release branches

for CAPM3 and IPAM