### PR TITLE
Handle e2e tests in integration test scripts

### DIFF
--- a/jenkins/scripts/files/run_integration_tests.sh
+++ b/jenkins/scripts/files/run_integration_tests.sh
@@ -140,6 +140,11 @@ then
 elif [[ "${TESTS_FOR}" == "feature_tests" || "${TESTS_FOR}" == "feature_tests_centos" ]]
 then
   make feature_tests
+elif [[ "${TESTS_FOR}" == "e2e_tests" ]]
+then
+  pushd "${CAPM3PATH}"
+  make test-e2e
+  popd
 else
   make
   make test

--- a/jenkins/scripts/integration_test.sh
+++ b/jenkins/scripts/integration_test.sh
@@ -49,7 +49,7 @@ VM_TIMELABEL="${VM_TIMELABEL:-$(date '+%Y%m%d%H%M%S')}"
 TEST_EXECUTER_VM_NAME="${TEST_EXECUTER_VM_NAME:-ci-test-vm-${VM_TIMELABEL}}"
 TEST_EXECUTER_PORT_NAME="${TEST_EXECUTER_PORT_NAME:-${TEST_EXECUTER_VM_NAME}-int-port}"
 
-if [[ "${TESTS_FOR}" == "feature_tests"* ]]
+if [[ "${TESTS_FOR}" == "feature_tests"* || ${"TEST_FOR"} == "e2e_tests"* ]]
 then
   if [ "${DISTRIBUTION}" == "ubuntu" ]
   then


### PR DESCRIPTION
Run the CAPM3 e2e tests on Jenkins.

Relies on [CAPM3#229](https://github.com/metal3-io/cluster-api-provider-metal3/pull/229)