### PR TITLE
Update DockerHub registry path

### DIFF
--- a/prow/config/config.yaml
+++ b/prow/config/config.yaml
@@ -207,7 +207,7 @@ presubmits:
         env:
         - name: IS_CONTAINER
           value: "TRUE"
-        image: registry.hub.docker.com/library/golang:1.16
+        image: docker.io/golang:1.16
         imagePullPolicy: Always
   - name: gosec
     always_run: true
@@ -221,7 +221,7 @@ presubmits:
         env:
         - name: IS_CONTAINER
           value: "TRUE"
-        image: registry.hub.docker.com/securego/gosec:latest
+        image: docker.io/securego/gosec:latest
         imagePullPolicy: Always
   - name: gomod
     always_run: true
@@ -235,7 +235,7 @@ presubmits:
         env:
         - name: IS_CONTAINER
           value: "TRUE"
-        image: registry.hub.docker.com/library/golang:1.16
+        image: docker.io/golang:1.16
         imagePullPolicy: Always
   - name: markdownlint
     always_run: true
@@ -249,7 +249,7 @@ presubmits:
         env:
         - name: IS_CONTAINER
           value: "TRUE"
-        image: registry.hub.docker.com/pipelinecomponents/markdownlint:latest
+        image: docker.io/pipelinecomponents/markdownlint:latest
         imagePullPolicy: Always
   - name: shellcheck
     always_run: true
@@ -263,7 +263,7 @@ presubmits:
         env:
         - name: IS_CONTAINER
           value: "TRUE"
-        image: koalaman/shellcheck-alpine:stable
+        image: docker.io/koalaman/shellcheck-alpine:stable
         imagePullPolicy: Always
   - name: unit
     always_run: true
@@ -285,7 +285,7 @@ presubmits:
           value: "http://localhost:6385/v1/"
         - name: IRONIC_INSPECTOR_ENDPOINT
           value: "http://localhost:5050/v1/"
-        image: registry.hub.docker.com/library/golang:1.16
+        image: docker.io/golang:1.16
         imagePullPolicy: Always
   - name: generate
     always_run: true
@@ -307,7 +307,7 @@ presubmits:
           value: "http://localhost:6385/v1/"
         - name: IRONIC_INSPECTOR_ENDPOINT
           value: "http://localhost:5050/v1/"
-        image: registry.hub.docker.com/library/golang:1.16
+        image: docker.io/golang:1.16
         imagePullPolicy: Always
   - name: golint
     always_run: true
@@ -335,7 +335,7 @@ presubmits:
         env:
         - name: IS_CONTAINER
           value: "TRUE"
-        image: garethr/kubeval:latest
+        image: docker.io/garethr/kubeval:latest
         imagePullPolicy: Always
 
   metal3-io/cluster-api-provider-metal3:
@@ -397,7 +397,7 @@ presubmits:
         env:
         - name: IS_CONTAINER
           value: "TRUE"
-        image: registry.hub.docker.com/pipelinecomponents/markdownlint:latest
+        image: docker.io/pipelinecomponents/markdownlint:latest
         imagePullPolicy: Always
   - name: shellcheck
     always_run: true
@@ -412,7 +412,7 @@ presubmits:
         env:
         - name: IS_CONTAINER
           value: "TRUE"
-        image: koalaman/shellcheck-alpine:stable
+        image: docker.io/koalaman/shellcheck-alpine:stable
         imagePullPolicy: Always
   - name: generate
     always_run: true
@@ -457,7 +457,7 @@ presubmits:
         env:
         - name: IS_CONTAINER
           value: "TRUE"
-        image: garethr/kubeval:latest
+        image: docker.io/garethr/kubeval:latest
         imagePullPolicy: Always
 
   metal3-io/metal3-dev-env:
@@ -474,7 +474,7 @@ presubmits:
         env:
         - name: IS_CONTAINER
           value: "TRUE"
-        image: koalaman/shellcheck-alpine:stable
+        image: docker.io/koalaman/shellcheck-alpine:stable
         imagePullPolicy: Always
   - name: markdownlint
     always_run: true
@@ -489,7 +489,7 @@ presubmits:
         env:
         - name: IS_CONTAINER
           value: "TRUE"
-        image: registry.hub.docker.com/pipelinecomponents/markdownlint:latest
+        image: docker.io/pipelinecomponents/markdownlint:latest
         imagePullPolicy: Always
 
   metal3-io/project-infra:
@@ -523,7 +523,7 @@ presubmits:
         env:
         - name: IS_CONTAINER
           value: "TRUE"
-        image: registry.hub.docker.com/pipelinecomponents/markdownlint:latest
+        image: docker.io/pipelinecomponents/markdownlint:latest
         imagePullPolicy: Always
 
   metal3-io/ip-address-manager:
@@ -540,7 +540,7 @@ presubmits:
         env:
         - name: IS_CONTAINER
           value: "TRUE"
-        image: registry.hub.docker.com/library/golang:1.16
+        image: docker.io/golang:1.16
         imagePullPolicy: Always
   - name: govet
     always_run: true
@@ -555,7 +555,7 @@ presubmits:
         env:
         - name: IS_CONTAINER
           value: "TRUE"
-        image: registry.hub.docker.com/library/golang:1.16
+        image: docker.io/golang:1.16
         imagePullPolicy: Always
   - name: markdownlint
     always_run: true
@@ -570,7 +570,7 @@ presubmits:
         env:
         - name: IS_CONTAINER
           value: "TRUE"
-        image: registry.hub.docker.com/pipelinecomponents/markdownlint:latest
+        image: docker.io/pipelinecomponents/markdownlint:latest
         imagePullPolicy: Always
   - name: shellcheck
     always_run: true
@@ -585,7 +585,7 @@ presubmits:
         env:
         - name: IS_CONTAINER
           value: "TRUE"
-        image: koalaman/shellcheck-alpine:stable
+        image: docker.io/koalaman/shellcheck-alpine:stable
         imagePullPolicy: Always
   - name: unit
     always_run: true
@@ -630,7 +630,7 @@ presubmits:
         env:
         - name: IS_CONTAINER
           value: "TRUE"
-        image: garethr/kubeval:latest
+        image: docker.io/garethr/kubeval:latest
         imagePullPolicy: Always
 
   metal3-io/hardware-classification-controller:
@@ -646,7 +646,7 @@ presubmits:
         env:
         - name: IS_CONTAINER
           value: "TRUE"
-        image: registry.hub.docker.com/library/golang:1.16
+        image: docker.io/golang:1.16
         imagePullPolicy: Always
   - name: govet
     always_run: true
@@ -660,7 +660,7 @@ presubmits:
         env:
         - name: IS_CONTAINER
           value: "TRUE"
-        image: registry.hub.docker.com/library/golang:1.16
+        image: docker.io/golang:1.16
         imagePullPolicy: Always
   - name: markdownlint
     always_run: true
@@ -674,7 +674,7 @@ presubmits:
         env:
         - name: IS_CONTAINER
           value: "TRUE"
-        image: registry.hub.docker.com/pipelinecomponents/markdownlint:latest
+        image: docker.io/pipelinecomponents/markdownlint:latest
         imagePullPolicy: Always
   - name: shellcheck
     always_run: true
@@ -688,7 +688,7 @@ presubmits:
         env:
         - name: IS_CONTAINER
           value: "TRUE"
-        image: koalaman/shellcheck-alpine:stable
+        image: docker.io/koalaman/shellcheck-alpine:stable
         imagePullPolicy: Always
   - name: unit
     always_run: true
@@ -716,5 +716,5 @@ presubmits:
         env:
         - name: IS_CONTAINER
           value: "TRUE"
-        image: garethr/kubeval:latest
+        image: docker.io/garethr/kubeval:latest
         imagePullPolicy: Always


### PR DESCRIPTION
The registry path for DockerHub https://registry.hub.docker.com/v2/ returns a 404. Docker/Podman make a GET request to this path before pulling the image, and they're failing at this step. Whether DockerHub have deprecated or changed the behaviour of their registry is unclear.

Updating the paths to docker.io resolves this issue and allows Docker image pulling once more. This should fix the Prow jobs that are failing markdownlint.

Additionally, images which were being pulled from DockerHub have now been explicitly marked as being pulled from docker.io.