### PR TITLE
Make Ansible colors in Jenkins readable

### DIFF
--- a/jenkins/scripts/files/run_integration_tests.sh
+++ b/jenkins/scripts/files/run_integration_tests.sh
@@ -115,8 +115,9 @@ fi
 export GITHUB_TOKEN="${GITHUB_TOKEN}"
 
 # Ansible colors
-ANSIBLE_FORCE_COLOR=true
-ANSIBLE_COLOR_CHANGED="dark gray"
+export ANSIBLE_FORCE_COLOR=true
+# Make 'changed' tasks the same color as 'succeeded' tasks in Jenkins output
+export ANSIBLE_COLOR_CHANGED="green"
 
 # Make the ipa-downloader pull the ironic-python-agent from Artifactory to
 # reduce dependency on upstream services and improve build times


### PR DESCRIPTION
Change the 'yellow' color used in Ansible changed tasks to something more readable.