### PR TITLE
Fetch Ironic container logs before pivoting

### DIFF
--- a/jenkins/scripts/files/run_fetch_logs.sh
+++ b/jenkins/scripts/files/run_fetch_logs.sh
@@ -48,13 +48,21 @@ done
 # Fetch k8s logs
 fetch_k8s_logs "management_cluster" "/home/airshipci/.kube/config"
 
-mkdir -p "${LOGS_DIR}/${CONTAINER_RUNTIME}"
+
+# Fetch Ironic containers logs before pivoting to the target cluster
+CONTAINER_LOGS_DIR="${LOGS_DIR}/${CONTAINER_RUNTIME}/before_pivoting"
+mkdir -p "${CONTAINER_LOGS_DIR}"
+cp -r /tmp/"${CONTAINER_RUNTIME}"/* "${CONTAINER_LOGS_DIR}"
+
+# Fetch Ironic containers logs after pivoting back to the source cluster
+CONTAINER_LOGS_DIR="${LOGS_DIR}/${CONTAINER_RUNTIME}/after_pivoting"
+mkdir -p "${CONTAINER_LOGS_DIR}"
 LOCAL_CONTAINERS="$(sudo "${CONTAINER_RUNTIME}" ps -a --format "{{.Names}}")"
 for LOCAL_CONTAINER in $LOCAL_CONTAINERS
 do
-  mkdir -p "${LOGS_DIR}/${CONTAINER_RUNTIME}/${LOCAL_CONTAINER}"
-  sudo "${CONTAINER_RUNTIME}" logs "$LOCAL_CONTAINER" > "${LOGS_DIR}/${CONTAINER_RUNTIME}/${LOCAL_CONTAINER}/stdout.log" \
-  2> "${LOGS_DIR}/${CONTAINER_RUNTIME}/${LOCAL_CONTAINER}/stderr.log"
+  mkdir -p "${CONTAINER_LOGS_DIR}/${LOCAL_CONTAINER}"
+  sudo "${CONTAINER_RUNTIME}" logs "$LOCAL_CONTAINER" > "${CONTAINER_LOGS_DIR}/${LOCAL_CONTAINER}/stdout.log" \
+  2> "${CONTAINER_LOGS_DIR}/${LOCAL_CONTAINER}/stderr.log"
 done
 
 mkdir -p "${LOGS_DIR}/qemu"


### PR DESCRIPTION
When Ironic is running outside of the cluster, i.e., as docker containers, initial logs of the containers get lost after pivoting to the target cluster. Currently we are fetching Ironic container logs at the end of the CI run, when we are pivoted back to the source cluster and when Ironic containers are recreated. Since Ironic is re-created, we are losing initial logs of Ironic containers, for example when Ironic nodes go from registering to ready state, which happens only on the source cluster. Losing those logs will only make it confusing for someone debugging the Ironic.
This patch copies those fetched logs from `/tmp` to the CI output. See the related slack discussion [here](https://kubernetes.slack.com/archives/CHD49TLE7/p1627462885343400).
Related PR in dev-env: https://github.com/metal3-io/metal3-dev-env/pull/748