### PR TITLE
Increase feature test timeout to 6 hours

### DIFF
--- a/jenkins/jobs/integration_tests.pipeline
+++ b/jenkins/jobs/integration_tests.pipeline
@@ -2,12 +2,15 @@ import java.text.SimpleDateFormat
 
 ci_git_credential_id = "metal3-jenkins-github-token"
 
+// 10 minutes
 def CLEAN_TIMEOUT = 600
+// 1 hour 30 minutes
 def TIMEOUT = 5400
 
 if (env.TESTS_FOR) {
   if ( (env.TESTS_FOR).startsWith('feature_tests') ) {
-    TIMEOUT = 18000
+    // 6 hours
+    TIMEOUT = 21600
   }
 }
 


### PR DESCRIPTION
Test time has increased since fixing the bug where an even number of replicas were created. Additionally, minikube may take some time to start in the retry loop.