### PR TITLE
Increase e2e-tests timeout

### DIFF
--- a/jenkins/jobs/integration_tests.pipeline
+++ b/jenkins/jobs/integration_tests.pipeline
@@ -8,7 +8,7 @@ def CLEAN_TIMEOUT = 600
 def TIMEOUT = 5400
 
 if (env.TESTS_FOR) {
-  if ( (env.TESTS_FOR).startsWith('feature_tests') ) {
+  if ( (env.TESTS_FOR).startsWith('feature_tests') || (env.TESTS_FOR).startsWith('e2e_tests') ) {
     // 6 hours
     TIMEOUT = 21600
   }


### PR DESCRIPTION
The `e2e-tests` are equivalent to the feature-tests then once we have all `e2e-tests` in place they will need almost the same duration as feature-tests (more than 4h). 
Currently the `e2e-tests` timeout is the default 1 hour and 30 minutes, for this reason this PR increases the e2e-test timeout to 6 hours.  