### PR TITLE
Don't download IPA in integration tests

### DIFF
--- a/jenkins/scripts/files/run_integration_tests.sh
+++ b/jenkins/scripts/files/run_integration_tests.sh
@@ -119,9 +119,9 @@ export ANSIBLE_FORCE_COLOR=true
 # Make 'changed' tasks the same color as 'succeeded' tasks in Jenkins output
 export ANSIBLE_COLOR_CHANGED="green"
 
-# Make the ipa-downloader pull the ironic-python-agent from Artifactory to
-# reduce dependency on upstream services and improve build times
-export IPA_BASEURI="https://artifactory.nordix.org/artifactory/airship/ironic-python-agent"
+# Use the IPA which is already downloaded in the image, instead of downloading
+# from upstream.
+export IPA_DOWNLOAD_ENABLED="false"
 
 METAL3REPO="${METAL3REPO:-https://github.com/metal3-io/metal3-dev-env.git}"
 METAL3BRANCH="${METAL3BRANCH:-master}"


### PR DESCRIPTION
Instead, IPA is bundled with the image. We don't need to run the ipa-downloader again, so set the IPA_DOWNLOAD_ENABLED environment variable to "false" to skip the download.

TODO: Run integration tests after https://github.com/metal3-io/baremetal-operator/pull/957 is merged, and check that ipa-downloader isn't run in the build output.