### PR TITLE
Set Kubernetes Version to v1.21.2 for v1a4 jobs

### DIFF
--- a/jenkins/scripts/files/run_integration_tests.sh
+++ b/jenkins/scripts/files/run_integration_tests.sh
@@ -64,6 +64,7 @@ then
     if [ "${CAPM3_VERSION}" == "v1alpha4" ]
     then
       export CAPM3_LOCAL_IMAGE_BRANCH="release-0.4"
+      export KUBERNETES_VERSION="v1.21.2"
     else
       export CAPM3_LOCAL_IMAGE_BRANCH="master"
     fi


### PR DESCRIPTION
This will help to run v1a4 with k8s version 1.21.2 and v1a5 with k8s version>= 1.22 