### PR TITLE
exports IMAGE_LOCATION and IMAGE_NAME variables for airship-dev-tools integration test

### DIFF
--- a/jenkins/scripts/files/run_integration_tests.sh
+++ b/jenkins/scripts/files/run_integration_tests.sh
@@ -13,6 +13,12 @@ export IMAGE_OS
 export DEFAULT_HOSTS_MEMORY
 export NUM_NODES
 
+if [ "${REPO_NAME}" == "airship-dev-tools" ]
+then
+  export IMAGE_NAME
+  export IMAGE_LOCATION
+fi
+
 if [ "${CAPM3_VERSION}" == "v1alpha4" ]
 then
   export KUBERNETES_VERSION="v1.21.2"


### PR DESCRIPTION
IMAGE_LOCATION and IMAGE_NAME vars are needed to download temporary created image from artifactory for airship-dev-tools repo`s integration test