### PR TITLE
Bug: fix incorrect namespace in the prow configMap

### DIFF
--- a/prow/config/config.yaml
+++ b/prow/config/config.yaml
@@ -1,4 +1,4 @@
-prowjob_namespace: default
+prowjob_namespace: prow
 pod_namespace: test-pods
 log_level: debug
 
@@ -10,20 +10,24 @@ sinker:
   terminated_pod_ttl: 2h
 
 plank:
-  job_url_template: 'https://prow.apps.test.metal3.io/view/gs/metal3-prow/{{if eq .Spec.Type "presubmit"}}pr-logs/pull{{else if eq .Spec.Type "batch"}}pr-logs/pull{{else}}logs{{end}}{{if .Spec.Refs}}{{if ne .Spec.Refs.Org ""}}/{{.Spec.Refs.Org}}_{{.Spec.Refs.Repo}}{{end}}{{end}}{{if eq .Spec.Type "presubmit"}}/{{with index .Spec.Refs.Pulls 0}}{{.Number}}{{end}}{{else if eq .Spec.Type "batch"}}/batch{{end}}/{{.Spec.Job}}/{{.Status.BuildID}}/'
   job_url_prefix_config:
-    '*': https://prow.apps.test.metal3.io/view
+    "*": https://prow.apps.test.metal3.io/view/
+  report_templates:
+    '*': >-
+        [Full PR test history](https://prow.apps.test.metal3.io/pr-history?org={{.Spec.Refs.Org}}&repo={{.Spec.Refs.Repo}}&pr={{with index .Spec.Refs.Pulls 0}}{{.Number}}{{end}}).
+        [Your PR dashboard](https://prow.apps.test.metal3.io/pr?query=is:pr+state:open+author:{{with
+        index .Spec.Refs.Pulls 0}}{{.Author}}{{end}}).
   default_decoration_configs:
-    '*':
-      utility_images:
-        clonerefs: "gcr.io/k8s-prow/clonerefs:v20210916-3c87dfedd5"
-        initupload: "gcr.io/k8s-prow/initupload:v20210916-3c87dfedd5"
-        entrypoint: "gcr.io/k8s-prow/entrypoint:v20210916-3c87dfedd5"
-        sidecar: "gcr.io/k8s-prow/sidecar:v20210916-3c87dfedd5"
-      gcs_configuration:  # configuration for uploading job results to GCS
-        bucket: metal3-prow # the bucket holding the artifacts & logs
+    "*":
+      gcs_configuration:
+        bucket: s3://prow-logs
         path_strategy: explicit
-      gcs_credentials_secret: gcs-credentials # the name of the secret that stores cloud provider credentials
+      s3_credentials_secret: s3-credentials
+      utility_images:
+        clonerefs: gcr.io/k8s-prow/clonerefs:v20210916-3c87dfedd5
+        entrypoint: gcr.io/k8s-prow/entrypoint:v20210916-3c87dfedd5
+        initupload: gcr.io/k8s-prow/initupload:v20210916-3c87dfedd5
+        sidecar: gcr.io/k8s-prow/sidecar:v20210916-3c87dfedd5
 
 tide:
   merge_method:


### PR DESCRIPTION
1. Replace `gcs_configuration` with s3 bucket
2. Fix `prowjob_namespace`  to be `prow` instead of `default`