### PR TITLE
Avoid running Prow jobs unnecessarily

### DIFF
--- a/prow/config/config.yaml
+++ b/prow/config/config.yaml
@@ -466,7 +466,8 @@ presubmits:
 
   metal3-io/metal3-dev-env:
   - name: shellcheck
-    always_run: true
+    always_run: false
+    run_if_changed: '(\.(sh)|^Makefile)$'
     decorate: true
     optional: true
     spec:
@@ -481,7 +482,8 @@ presubmits:
         image: docker.io/koalaman/shellcheck-alpine:stable
         imagePullPolicy: Always
   - name: markdownlint
-    always_run: true
+    always_run: false
+    run_if_changed: '\.(md)$'
     decorate: true
     optional: true
     spec:


### PR DESCRIPTION
Run markdownlint only if a patch actually touches markdown files
or run shellcheck tests only when .sh files are modified to avoid
running tests unnecessarily even though they consume less
resources.

This is 1st part of changes for this improvement. I would like to test
it in metal3-dev-env before adding `run_if_changed` to other repos.

Ref: https://github.com/kubernetes/test-infra/blob/master/prow/jobs.md