### PR TITLE
Avoid running Prow jobs unnecessarily (part2)

### DIFF
--- a/prow/config/config.yaml
+++ b/prow/config/config.yaml
@@ -242,7 +242,8 @@ presubmits:
         image: docker.io/golang:1.16
         imagePullPolicy: Always
   - name: markdownlint
-    always_run: true
+    always_run: false
+    run_if_changed: '\.(md)$'
     decorate: true
     spec:
       containers:
@@ -256,7 +257,8 @@ presubmits:
         image: docker.io/pipelinecomponents/markdownlint:latest
         imagePullPolicy: Always
   - name: shellcheck
-    always_run: true
+    always_run: false
+    run_if_changed: '(\.(sh)|^Makefile)$'
     decorate: true
     spec:
       containers:
@@ -389,7 +391,8 @@ presubmits:
         image: quay.io/metal3-io/capm3-unit:master
         imagePullPolicy: Always
   - name: markdownlint
-    always_run: true
+    always_run: false
+    run_if_changed: '\.(md)$'
     decorate: true
     optional: true
     spec:
@@ -404,7 +407,8 @@ presubmits:
         image: docker.io/pipelinecomponents/markdownlint:latest
         imagePullPolicy: Always
   - name: shellcheck
-    always_run: true
+    always_run: false
+    run_if_changed: '(\.(sh)|^Makefile)$'
     decorate: true
     optional: true
     spec:
@@ -518,7 +522,8 @@ presubmits:
             memory: "500Mi"
   metal3-io/metal3-docs:
   - name: markdownlint
-    always_run: true
+    always_run: false
+    run_if_changed: '\.(md)$'
     decorate: true
     spec:
       containers:
@@ -564,7 +569,8 @@ presubmits:
         image: docker.io/golang:1.16
         imagePullPolicy: Always
   - name: markdownlint
-    always_run: true
+    always_run: false
+    run_if_changed: '\.(md)$'
     decorate: true
     optional: true
     spec:
@@ -579,7 +585,8 @@ presubmits:
         image: docker.io/pipelinecomponents/markdownlint:latest
         imagePullPolicy: Always
   - name: shellcheck
-    always_run: true
+    always_run: false
+    run_if_changed: '(\.(sh)|^Makefile)$'
     decorate: true
     optional: true
     spec:
@@ -669,7 +676,8 @@ presubmits:
         image: docker.io/golang:1.16
         imagePullPolicy: Always
   - name: markdownlint
-    always_run: true
+    always_run: false
+    run_if_changed: '\.(md)$'
     decorate: true
     spec:
       containers:
@@ -683,7 +691,8 @@ presubmits:
         image: docker.io/pipelinecomponents/markdownlint:latest
         imagePullPolicy: Always
   - name: shellcheck
-    always_run: true
+    always_run: false
+    run_if_changed: '(\.(sh)|^Makefile)$'
     decorate: true
     spec:
       containers:


### PR DESCRIPTION
Run markdownlint only if a patch actually touches markdown files
or run shellcheck tests only when .sh files are modified to avoid
running tests unnecessarily even though they consume less
resources.

This is 2nd part of https://github.com/metal3-io/project-infra/pull/237 for this improvement. I would like to test
it in metal3-dev-env before adding run_if_changed to other repos.

Ref: https://github.com/kubernetes/test-infra/blob/master/prow/jobs.md