### PR TITLE
Remove duplicating owners

### DIFF
--- a/jenkins/OWNERS
+++ b/jenkins/OWNERS
@@ -1,8 +1,0 @@
-# See the OWNERS docs at https://go.k8s.io/owners
-
-approvers:
- - maelk
- - fmuyassarov
- - kashifest
-
-reviewers:


### PR DESCRIPTION
Remove duplicating owners. Since @kashifest
@furkatgofurov7 and @maelk are now in the root
OWNERS, it is redundant to keep them in the sub
OWNERS too.