### PR TITLE
🐛 Fix master cleanup job

### DIFF
--- a/jenkins/jobs/integration_tests_clean.pipeline
+++ b/jenkins/jobs/integration_tests_clean.pipeline
@@ -27,6 +27,7 @@ pipeline {
     OS_TENANT_NAME="Default Project 37137"
     OS_AUTH_VERSION=3
     OS_IDENTITY_API_VERSION=3
+    TESTS_FOR="${TESTS_FOR}"
   }
   stages {
     stage('SCM') {


### PR DESCRIPTION
[Master cleanup job](https://jenkins.nordix.org/view/Airship/job/airship_master_integration_tests_cleanup/) is failing after #236. CI logs:

```
Resetting working tree
 > git reset --hard # timeout=10
 > git clean -fdx # timeout=10
+ ./jenkins/scripts/integration_clean.sh
./jenkins/scripts/integration_clean.sh: line 22: TESTS_FOR: unbound variable
```

This should fix it by passing `TESTS_FOR` env to the integration_tests_clean.pipeline 