### PR TITLE
Start instances from images not volumes

### DIFF
--- a/jenkins/scripts/integration_delete.sh
+++ b/jenkins/scripts/integration_delete.sh
@@ -30,27 +30,6 @@ echo "Deleting executer VM ${TEST_EXECUTER_VM_NAME}."
 openstack server delete "${TEST_EXECUTER_VM_NAME}"
 echo "Executer VM ${TEST_EXECUTER_VM_NAME} is deleted."
 
-DISTRIBUTION="${DISTRIBUTION:-ubuntu}"
-if [ "${DISTRIBUTION}" == "ubuntu" ]
-then
-    echo "Waiting until volume status is available, to proceed with proper volume deletion."
-    until openstack volume show "${TEST_EXECUTER_VM_NAME}" -f json \
-        | jq .status | grep "available"
-    do
-        sleep 10
-        if [[ "$(openstack volume show "${TEST_EXECUTER_VM_NAME}" -f json \
-            | jq .status)" == *"error"* ]];
-        then
-            exit 1
-        fi
-    done
-
-    # Delete executer volume
-    echo "Deleting executer volume ${TEST_EXECUTER_VM_NAME}."
-    openstack volume delete "${TEST_EXECUTER_VM_NAME}"
-    echo "Executer volume ${TEST_EXECUTER_VM_NAME} is deleted."
-fi
-
 # Delete executer VM port
 echo "Deleting executer VM port ${TEST_EXECUTER_PORT_NAME}."
 openstack port delete "${TEST_EXECUTER_PORT_NAME}"


### PR DESCRIPTION
Both ephemeral / local storage (used when an OpenStack VM is started from an image) and volumes come from Ceph in CityCloud. Furthermore, the images are backed from Ceph, and raw images start instantly. So there should be no reason to complicate the build / image process by using volumes. (I also expect it may be cheaper, since we request less storage overall.)