### PR TITLE
Remove IPAM master branch from prow config

### DIFF
--- a/prow/config/config.yaml
+++ b/prow/config/config.yaml
@@ -104,9 +104,6 @@ branch-protection:
             main:
               required_status_checks:
                 contexts: ["test-integration"]
-            master:
-              required_status_checks:
-                contexts: ["test-integration"]
             release-0.0:
               required_status_checks:
                 contexts: ["test-v1a4-integration"]


### PR DESCRIPTION
Now that main is the default branch, prow should not be tracking master branch anymore.