### PR TITLE
Add main branch references for CAPM3

### DIFF
--- a/jenkins/scripts/bare_metal_lab/files/config.sh
+++ b/jenkins/scripts/bare_metal_lab/files/config.sh
@@ -56,7 +56,7 @@
 #
 # Set the Cluster Api Metal3 provider branch to checkout
 #
-#export CAPM3BRANCH="${CAPM3BRANCH:-master}"
+#export CAPM3BRANCH="${CAPM3BRANCH:-main}"
 
 #
 # Force deletion of the BMO and CAPM3 repositories before cloning them again

--- a/jenkins/scripts/files/run_integration_tests.sh
+++ b/jenkins/scripts/files/run_integration_tests.sh
@@ -76,7 +76,7 @@ then
     then
       export CAPM3_LOCAL_IMAGE_BRANCH="release-0.4"
     else
-      export CAPM3_LOCAL_IMAGE_BRANCH="master"
+      export CAPM3_LOCAL_IMAGE_BRANCH="main"
     fi
   fi
 
@@ -119,7 +119,7 @@ then
   then
     export CAPM3_LOCAL_IMAGE_BRANCH="release-0.4"
   else
-    export CAPM3_LOCAL_IMAGE_BRANCH="master"
+    export CAPM3_LOCAL_IMAGE_BRANCH="main"
   fi
 fi
 

--- a/jenkins/scripts/integration_test.sh
+++ b/jenkins/scripts/integration_test.sh
@@ -39,9 +39,12 @@ TESTS_FOR="${TESTS_FOR:-integration_test}"
 BARE_METAL_LAB=false
 
 # To Do: Remove the following lines once we change to main branch for all the repos
-if [[ "${PROJECT_REPO_ORG}" == "metal3-io" && "${PROJECT_REPO_NAME}" == "ip-adress-manager" ]]
+if [[ "${PROJECT_REPO_ORG}" == "metal3-io" ]]
 then
-  REPO_BRANCH="main"
+ if [[ "${PROJECT_REPO_NAME}" == "ip-adress-manager" || "${PROJECT_REPO_NAME}" == "cluster-api-provider-metal3" ]]
+  then
+    REPO_BRANCH="main"
+  fi
 fi
 
 

--- a/prow/config/config.yaml
+++ b/prow/config/config.yaml
@@ -87,6 +87,9 @@ branch-protection:
             contexts: ["test-integration"]
         cluster-api-provider-metal3:
           branches:
+            main:
+              required_status_checks:
+                contexts: ["test-integration"]
             master:
               required_status_checks:
                 contexts: ["test-integration"]
@@ -358,7 +361,7 @@ presubmits:
         env:
         - name: IS_CONTAINER
           value: "TRUE"
-        image: quay.io/metal3-io/capm3-unit:master
+        image: quay.io/metal3-io/capm3-unit:main
         imagePullPolicy: Always
   - name: golint
     always_run: true
@@ -373,7 +376,7 @@ presubmits:
         env:
         - name: IS_CONTAINER
           value: "TRUE"
-        image: quay.io/metal3-io/capm3-unit:master
+        image: quay.io/metal3-io/capm3-unit:main
         imagePullPolicy: Always
   - name: govet
     always_run: true
@@ -388,7 +391,7 @@ presubmits:
         env:
         - name: IS_CONTAINER
           value: "TRUE"
-        image: quay.io/metal3-io/capm3-unit:master
+        image: quay.io/metal3-io/capm3-unit:main
         imagePullPolicy: Always
   - name: markdownlint
     always_run: false
@@ -435,7 +438,7 @@ presubmits:
         env:
         - name: IS_CONTAINER
           value: "TRUE"
-        image: quay.io/metal3-io/capm3-unit:master
+        image: quay.io/metal3-io/capm3-unit:main
         imagePullPolicy: Always
   - name: unit
     always_run: true
@@ -450,7 +453,7 @@ presubmits:
         env:
         - name: IS_CONTAINER
           value: "TRUE"
-        image: quay.io/metal3-io/capm3-unit:master
+        image: quay.io/metal3-io/capm3-unit:main
         imagePullPolicy: Always
   - name: manifestlint
     always_run: true
@@ -613,7 +616,7 @@ presubmits:
         env:
         - name: IS_CONTAINER
           value: "TRUE"
-        image: quay.io/metal3-io/capm3-unit:master
+        image: quay.io/metal3-io/capm3-unit:main
         imagePullPolicy: Always
   - name: generate
     always_run: true
@@ -628,7 +631,7 @@ presubmits:
         env:
         - name: IS_CONTAINER
           value: "TRUE"
-        image: quay.io/metal3-io/capm3-unit:master
+        image: quay.io/metal3-io/capm3-unit:main
         imagePullPolicy: Always
   - name: manifestlint
     always_run: true
@@ -717,7 +720,7 @@ presubmits:
         env:
         - name: IS_CONTAINER
           value: "TRUE"
-        image: quay.io/metal3-io/capm3-unit:master
+        image: quay.io/metal3-io/capm3-unit:main
         imagePullPolicy: Always
   - name: manifestlint
     always_run: true


### PR DESCRIPTION
This PR adds main branch references for CAPM3 since we are renaming the default branch main.