### PR TITLE
Remove capm3 master branch reference

### DIFF
--- a/prow/config/config.yaml
+++ b/prow/config/config.yaml
@@ -90,9 +90,6 @@ branch-protection:
             main:
               required_status_checks:
                 contexts: ["test-integration"]
-            master:
-              required_status_checks:
-                contexts: ["test-integration"]
             release-0.4:
               required_status_checks:
                 contexts: ["test-v1a4-integration"]


### PR DESCRIPTION
Since default branch of capm3 is now main, we dont need to track master branch in prow config. 