### PR TITLE
Run all main builds on Fra1

### DIFF
--- a/jenkins/scripts/fetch_logs.sh
+++ b/jenkins/scripts/fetch_logs.sh
@@ -19,7 +19,7 @@ source "${CI_DIR}/utils.sh"
 
 TEST_EXECUTER_PORT_NAME="${TEST_EXECUTER_PORT_NAME:-${TEST_EXECUTER_VM_NAME}-int-port}"
 
-if [[ "${TESTS_FOR}" == "feature_tests"* ]]
+if [[ "${UPDATED_BRANCH}" =~ "^(main|master)$" ]]
 then
   OS_REGION_NAME="Fra1"
   OS_AUTH_URL="https://fra1.citycloud.com:5000"

--- a/jenkins/scripts/integration_clean.sh
+++ b/jenkins/scripts/integration_clean.sh
@@ -17,7 +17,7 @@ CI_DIR="$(dirname "$(readlink -f "${0}")")"
 # shellcheck disable=SC1090
 source "${CI_DIR}/utils.sh"
 
-if [[ "${TESTS_FOR}" == "feature_tests"* ]]
+if [[ "${UPDATED_BRANCH}" =~ "^(main|master)$" ]]
 then
   OS_REGION_NAME="Fra1"
   OS_AUTH_URL="https://fra1.citycloud.com:5000"

--- a/jenkins/scripts/integration_delete.sh
+++ b/jenkins/scripts/integration_delete.sh
@@ -19,7 +19,7 @@ source "${CI_DIR}/utils.sh"
 
 TEST_EXECUTER_PORT_NAME="${TEST_EXECUTER_PORT_NAME:-${TEST_EXECUTER_VM_NAME}-int-port}"
 
-if [[ "${TESTS_FOR}" == "feature_tests"* ]]
+if [[ "${UPDATED_BRANCH}" =~ "^(main|master)$" ]]
 then
   OS_REGION_NAME="Fra1"
   OS_AUTH_URL="https://fra1.citycloud.com:5000"

--- a/jenkins/scripts/integration_test.sh
+++ b/jenkins/scripts/integration_test.sh
@@ -60,7 +60,7 @@ VM_TIMELABEL="${VM_TIMELABEL:-$(date '+%Y%m%d%H%M%S')}"
 TEST_EXECUTER_VM_NAME="${TEST_EXECUTER_VM_NAME:-ci-test-vm-${VM_TIMELABEL}}"
 TEST_EXECUTER_PORT_NAME="${TEST_EXECUTER_PORT_NAME:-${TEST_EXECUTER_VM_NAME}-int-port}"
 
-if [[ "${TESTS_FOR}" == "feature_tests"* ]]
+if [[ "${UPDATED_BRANCH}" =~ "^(main|master)$" ]]
 then
   OS_REGION_NAME="Fra1"
   OS_AUTH_URL="https://fra1.citycloud.com:5000"

--- a/jenkins/scripts/integration_test_clean.sh
+++ b/jenkins/scripts/integration_test_clean.sh
@@ -22,7 +22,7 @@ source "${CI_DIR}/utils.sh"
 
 TEST_EXECUTER_PORT_NAME="${TEST_EXECUTER_PORT_NAME:-${TEST_EXECUTER_VM_NAME}-int-port}"
 
-if [[ "${TESTS_FOR}" == "feature_tests"* ]]
+if [[ "${UPDATED_BRANCH}" =~ "^(main|master)$" ]]
 then
   OS_REGION_NAME="Fra1"
   OS_AUTH_URL="https://fra1.citycloud.com:5000"


### PR DESCRIPTION
The Kna1 region isn't as stable as Fra1 and sometimes we see higher CPU steal. We saw improvements moving feature tests to Fra1 region, so let's try moving all builds of the main branch to Fra1 as well. Jobs which are triggered on PRs are still run on Kna1.