### PR TITLE
✨ Define CONTAINER_REGISTRY variable for new Nordix Harbor registry

### DIFF
--- a/jenkins/scripts/files/run_integration_tests.sh
+++ b/jenkins/scripts/files/run_integration_tests.sh
@@ -13,6 +13,9 @@ export IMAGE_OS
 export DEFAULT_HOSTS_MEMORY
 export NUM_NODES
 
+# Container image registry value to override the default value in m3-dev-env
+export CONTAINER_REGISTRY=${CONTAINER_REGISTRY:-"registry.nordix.org/quay-io-proxy"}
+
 if [ "${REPO_NAME}" == "airship-dev-tools" ]
 then
   export IMAGE_NAME


### PR DESCRIPTION
Introduces new var `CONTAINER_REGISTRY` defaulting to Nordix Harbor registry and expected to override the same value in metal3-dev-env which defaults to quay.io in case it is not overwritten. This is a part of a patch series where we trying to achieve pulling container images from Nordix Harbor Proxy Cache instead of quay.io in case of inaccessibility of the latter registry.

Related to [m3-dev-env#835](https://github.com/metal3-io/metal3-dev-env/pull/835)