### PR TITLE
Add Michael as reviewer

### DIFF
--- a/OWNERS
+++ b/OWNERS
@@ -6,3 +6,6 @@ approvers:
  - fmuyassarov
  - kashifest
  - furkatgofurov7
+
+reviewers:
+ - macaptain


### PR DESCRIPTION
Following community principle of adding reviewers, this PR adds Michael Captain (@macaptain) as a reviewer since he has 10 commits in this repository.

List of the commits: https://github.com/metal3-io/project-infra/commits?author=macaptain