### PR TITLE
Ensure logs are fetched from the correct region

### DIFF
--- a/jenkins/scripts/fetch_logs.sh
+++ b/jenkins/scripts/fetch_logs.sh
@@ -19,11 +19,14 @@ source "${CI_DIR}/utils.sh"
 
 TEST_EXECUTER_PORT_NAME="${TEST_EXECUTER_PORT_NAME:-${TEST_EXECUTER_VM_NAME}-int-port}"
 
-if [[ "${UPDATED_BRANCH}" =~ "^(main|master)$" ]]
+# Run feature tests and main and master integration tests in the Frankfurt region
+if [[ "${TESTS_FOR}" == "feature_tests"* ]] || \
+   [[ "${UPDATED_BRANCH}" == "main" ]] || [[ "${UPDATED_BRANCH}" == "master" ]]
 then
   OS_REGION_NAME="Fra1"
   OS_AUTH_URL="https://fra1.citycloud.com:5000"
 fi
+echo "Running in region: $OS_REGION_NAME"
 
 # Get the IP
 TEST_EXECUTER_IP="$(openstack port show -f json "${TEST_EXECUTER_PORT_NAME}" \


### PR DESCRIPTION
The fetch_logs.sh script was missed from #251, so the jobs are trying to fetch logs from the wrong region. This patch corrects that.