### PR TITLE
Pick a random floating IP for Frankfurt

### DIFF
--- a/jenkins/scripts/integration_test.sh
+++ b/jenkins/scripts/integration_test.sh
@@ -104,7 +104,9 @@ TEST_EXECUTER_IP="$(openstack port show -f json "${TEST_EXECUTER_PORT_NAME}" \
 if [[ "$OS_REGION_NAME" != "Kna1" ]]
 then 
   # Fetch Free floating IP 
-  FLOATING_IP="$(openstack floating ip list --status DOWN -c "Floating IP Address" -f value | head -1 )"
+  # TODO: To avoid jobs taking the same floating IP, instead jobs should create / delete / cleanup
+  # their own floating IPs.
+  FLOATING_IP="$(openstack floating ip list --status DOWN -c "Floating IP Address" -f value | shuf -n 1 )"
 
   if [[ -z "$FLOATING_IP" ]]
   then


### PR DESCRIPTION
If two jobs run at the same time, they will take the same IP address at the top of the floating IP list. By taking a random IP address, we reduce the chances of an IP address collision in CI.

Ideally, we create and destroy floating IPs as part of the job in order to avoid this race condition, but this requires a bit more work, I've added a TODO for this.