### PR TITLE
Enable tide (merge automation) on ironic-agent-image

### DIFF
--- a/prow/config/config.yaml
+++ b/prow/config/config.yaml
@@ -40,6 +40,7 @@ tide:
     - metal3-io/ironic-client
     - metal3-io/ironic-hardware-inventory-recorder-image
     - metal3-io/ironic-image
+    - metal3-io/ironic-agent-image
     - metal3-io/ironic-ipa-downloader
     - metal3-io/ironic-prometheus-exporter
     - metal3-io/metal3-dev-env

--- a/prow/config/plugins.yaml
+++ b/prow/config/plugins.yaml
@@ -32,6 +32,7 @@ plugins:
   metal3-io/ironic-client:
   metal3-io/ironic-hardware-inventory-recorder-image:
   metal3-io/ironic-image:
+  metal3-io/ironic-agent-image:
   metal3-io/ironic-ipa-downloader:
   metal3-io/ironic-prometheus-exporter:
   metal3-io/metal3-dev-env:


### PR DESCRIPTION
Currently this won't be tested via integration tests, but docs updates
are in progress to enable dev-testing with this image, and it would
be beneficial to adopt the normal merge process.