### PR TITLE
Don't enable push-gateway in ghProxy

### DIFF
--- a/prow/manifests/starter.yaml
+++ b/prow/manifests/starter.yaml
@@ -1022,8 +1022,6 @@ spec:
         args:
         - --cache-dir=/cache
         - --cache-sizeGB=99
-        - --push-gateway=pushgateway
-        - --serve-metrics=true
         ports:
         - containerPort: 8888
         volumeMounts:


### PR DESCRIPTION
We don't setup prometheus, so there is no benefit of passing these
flags to enable metrics collection.