### PR TITLE
Make v1a5 centos job required in m3-dev-env repo

### DIFF
--- a/prow/config/config.yaml
+++ b/prow/config/config.yaml
@@ -116,7 +116,7 @@ branch-protection:
                 contexts: ["test-v1a4-integration"]
         metal3-dev-env:
           required_status_checks:
-            contexts: ["test-v1a4-centos-integration", "test-v1b1-integration"]
+            contexts: ["test-v1a5-centos-integration", "test-v1b1-integration"]
 
 deck:
   spyglass:


### PR DESCRIPTION
Since we migrated to v1b1 now, we should make v1a5 tests as required in m3-dev-env repo replacing v1a4, where latter can be triggered case by case scenarios and we keep only master jobs to watch it. 