### PR TITLE
Avoid unnecessary CI jobs

### DIFF
--- a/prow/config/config.yaml
+++ b/prow/config/config.yaml
@@ -207,7 +207,7 @@ periodics:
 presubmits:
   metal3-io/baremetal-operator:
   - name: gofmt
-    always_run: true
+    run_if_changed: '\.go$'
     decorate: true
     spec:
       containers:
@@ -221,7 +221,7 @@ presubmits:
         image: docker.io/golang:1.16
         imagePullPolicy: Always
   - name: gosec
-    always_run: true
+    skip_if_only_changed: '(((^|/)OWNERS)|(\.md))$'
     decorate: true
     spec:
       containers:
@@ -235,7 +235,7 @@ presubmits:
         image: docker.io/securego/gosec:latest
         imagePullPolicy: Always
   - name: gomod
-    always_run: true
+    skip_if_only_changed: '(((^|/)OWNERS)|(\.md))$'
     decorate: true
     spec:
       containers:
@@ -249,8 +249,7 @@ presubmits:
         image: docker.io/golang:1.16
         imagePullPolicy: Always
   - name: markdownlint
-    always_run: false
-    run_if_changed: '\.(md)$'
+    run_if_changed: '\.md$'
     decorate: true
     spec:
       containers:
@@ -264,8 +263,7 @@ presubmits:
         image: docker.io/pipelinecomponents/markdownlint:latest
         imagePullPolicy: Always
   - name: shellcheck
-    always_run: false
-    run_if_changed: '(\.(sh)|^Makefile)$'
+    run_if_changed: '((\.sh)|^Makefile)$'
     decorate: true
     spec:
       containers:
@@ -279,7 +277,7 @@ presubmits:
         image: docker.io/koalaman/shellcheck-alpine:stable
         imagePullPolicy: Always
   - name: unit
-    always_run: true
+    skip_if_only_changed: '(((^|/)OWNERS)|(\.md))$'
     decorate: true
     spec:
       containers:
@@ -301,7 +299,7 @@ presubmits:
         image: docker.io/golang:1.16
         imagePullPolicy: Always
   - name: generate
-    always_run: true
+    skip_if_only_changed: '(((^|/)OWNERS)|(\.md))$'
     decorate: true
     spec:
       containers:
@@ -323,7 +321,7 @@ presubmits:
         image: docker.io/golang:1.16
         imagePullPolicy: Always
   - name: golint
-    always_run: true
+    run_if_changed: '\.go$'
     decorate: true
     spec:
       containers:
@@ -337,7 +335,7 @@ presubmits:
         image: quay.io/metal3-io/golint:latest
         imagePullPolicy: Always
   - name: manifestlint
-    always_run: true
+    skip_if_only_changed: '(((^|/)OWNERS)|(\.md))$'
     decorate: true
     spec:
       containers:
@@ -353,7 +351,7 @@ presubmits:
 
   metal3-io/cluster-api-provider-metal3:
   - name: gofmt
-    always_run: true
+    run_if_changed: '\.go$'
     decorate: true
     optional: true
     spec:
@@ -368,7 +366,7 @@ presubmits:
         image: quay.io/metal3-io/capm3-unit:main
         imagePullPolicy: Always
   - name: golint
-    always_run: true
+    run_if_changed: '\.go$'
     decorate: true
     optional: true
     spec:
@@ -383,7 +381,7 @@ presubmits:
         image: quay.io/metal3-io/capm3-unit:main
         imagePullPolicy: Always
   - name: govet
-    always_run: true
+    run_if_changed: '\.go$'
     decorate: true
     optional: true
     spec:
@@ -398,8 +396,7 @@ presubmits:
         image: quay.io/metal3-io/capm3-unit:main
         imagePullPolicy: Always
   - name: markdownlint
-    always_run: false
-    run_if_changed: '\.(md)$'
+    run_if_changed: '\.md$'
     decorate: true
     optional: true
     spec:
@@ -414,8 +411,7 @@ presubmits:
         image: docker.io/pipelinecomponents/markdownlint:latest
         imagePullPolicy: Always
   - name: shellcheck
-    always_run: false
-    run_if_changed: '(\.(sh)|^Makefile)$'
+    run_if_changed: '((\.sh)|^Makefile)$'
     decorate: true
     optional: true
     spec:
@@ -430,7 +426,7 @@ presubmits:
         image: docker.io/koalaman/shellcheck-alpine:stable
         imagePullPolicy: Always
   - name: generate
-    always_run: true
+    skip_if_only_changed: '(((^|/)OWNERS)|(\.md))$'
     decorate: true
     optional: true
     spec:
@@ -445,7 +441,7 @@ presubmits:
         image: quay.io/metal3-io/capm3-unit:main
         imagePullPolicy: Always
   - name: unit
-    always_run: true
+    skip_if_only_changed: '(((^|/)OWNERS)|(\.md))$'
     decorate: true
     optional: true
     spec:
@@ -460,7 +456,7 @@ presubmits:
         image: quay.io/metal3-io/capm3-unit:main
         imagePullPolicy: Always
   - name: manifestlint
-    always_run: true
+    skip_if_only_changed: '(((^|/)OWNERS)|(\.md))$'
     decorate: true
     optional: true
     spec:
@@ -477,8 +473,7 @@ presubmits:
 
   metal3-io/metal3-dev-env:
   - name: shellcheck
-    always_run: false
-    run_if_changed: '(\.(sh)|^Makefile)$'
+    run_if_changed: '((\.sh)|^Makefile)$'
     decorate: true
     optional: true
     spec:
@@ -493,8 +488,7 @@ presubmits:
         image: docker.io/koalaman/shellcheck-alpine:stable
         imagePullPolicy: Always
   - name: markdownlint
-    always_run: false
-    run_if_changed: '\.(md)$'
+    run_if_changed: '\.md$'
     decorate: true
     optional: true
     spec:
@@ -511,7 +505,7 @@ presubmits:
 
   metal3-io/project-infra:
   - name: check-prow-config
-    always_run: true
+    skip_if_only_changed: '(((^|/)OWNERS)|(\.md))$'
     decorate: true
     optional: true
     spec:
@@ -529,8 +523,7 @@ presubmits:
             memory: "500Mi"
   metal3-io/metal3-docs:
   - name: markdownlint
-    always_run: false
-    run_if_changed: '\.(md)$'
+    run_if_changed: '\.md$'
     decorate: true
     spec:
       containers:
@@ -546,7 +539,7 @@ presubmits:
 
   metal3-io/ip-address-manager:
   - name: gofmt
-    always_run: true
+    run_if_changed: '\.go$'
     decorate: true
     optional: true
     spec:
@@ -561,7 +554,7 @@ presubmits:
         image: docker.io/golang:1.16
         imagePullPolicy: Always
   - name: govet
-    always_run: true
+    run_if_changed: '\.go$'
     decorate: true
     optional: true
     spec:
@@ -576,8 +569,7 @@ presubmits:
         image: docker.io/golang:1.16
         imagePullPolicy: Always
   - name: markdownlint
-    always_run: false
-    run_if_changed: '\.(md)$'
+    run_if_changed: '\.md$'
     decorate: true
     optional: true
     spec:
@@ -592,8 +584,7 @@ presubmits:
         image: docker.io/pipelinecomponents/markdownlint:latest
         imagePullPolicy: Always
   - name: shellcheck
-    always_run: false
-    run_if_changed: '(\.(sh)|^Makefile)$'
+    run_if_changed: '((\.sh)|^Makefile)$'
     decorate: true
     optional: true
     spec:
@@ -608,7 +599,7 @@ presubmits:
         image: docker.io/koalaman/shellcheck-alpine:stable
         imagePullPolicy: Always
   - name: unit
-    always_run: true
+    skip_if_only_changed: '(((^|/)OWNERS)|(\.md))$'
     decorate: true
     optional: true
     spec:
@@ -623,7 +614,7 @@ presubmits:
         image: quay.io/metal3-io/capm3-unit:main
         imagePullPolicy: Always
   - name: generate
-    always_run: true
+    skip_if_only_changed: '(((^|/)OWNERS)|(\.md))$'
     decorate: true
     optional: true
     spec:
@@ -638,7 +629,7 @@ presubmits:
         image: quay.io/metal3-io/capm3-unit:main
         imagePullPolicy: Always
   - name: manifestlint
-    always_run: true
+    skip_if_only_changed: '(((^|/)OWNERS)|(\.md))$'
     decorate: true
     optional: true
     spec:
@@ -655,7 +646,7 @@ presubmits:
 
   metal3-io/hardware-classification-controller:
   - name: gofmt
-    always_run: true
+    run_if_changed: '\.go$'
     decorate: true
     spec:
       containers:
@@ -669,7 +660,7 @@ presubmits:
         image: docker.io/golang:1.16
         imagePullPolicy: Always
   - name: govet
-    always_run: true
+    run_if_changed: '\.go$'
     decorate: true
     spec:
       containers:
@@ -683,8 +674,7 @@ presubmits:
         image: docker.io/golang:1.16
         imagePullPolicy: Always
   - name: markdownlint
-    always_run: false
-    run_if_changed: '\.(md)$'
+    run_if_changed: '\.md$'
     decorate: true
     spec:
       containers:
@@ -698,8 +688,7 @@ presubmits:
         image: docker.io/pipelinecomponents/markdownlint:latest
         imagePullPolicy: Always
   - name: shellcheck
-    always_run: false
-    run_if_changed: '(\.(sh)|^Makefile)$'
+    run_if_changed: '((\.sh)|(^Makefile))$'
     decorate: true
     spec:
       containers:
@@ -713,7 +702,7 @@ presubmits:
         image: docker.io/koalaman/shellcheck-alpine:stable
         imagePullPolicy: Always
   - name: unit
-    always_run: true
+    skip_if_only_changed: '(((^|/)OWNERS)|(\.md))$'
     decorate: true
     spec:
       containers:
@@ -727,7 +716,7 @@ presubmits:
         image: quay.io/metal3-io/capm3-unit:main
         imagePullPolicy: Always
   - name: manifestlint
-    always_run: true
+    skip_if_only_changed: '(((^|/)OWNERS)|(\.md))$'
     decorate: true
     spec:
       containers:


### PR DESCRIPTION
Skip CI jobs that are not needed when only e.g. docs or OWNERS files are
modified in the PR.