### PR TITLE
Re-configure label synchronization CronJob

### DIFF
--- a/prow/Makefile
+++ b/prow/Makefile
@@ -9,7 +9,7 @@ update-plugins:
 	kubectl create configmap plugins -n prow --from-file=plugins.yaml=config/plugins.yaml --dry-run=client -o yaml | kubectl replace configmap -n prow plugins -f -
 
 update-labels:
-	kubectl create configmap label-config -n prow --from-file=labels.yaml=labels.yaml --dry-run=client -o yaml | kubectl replace configmap -n prow label-config -f -
+	kubectl create configmap label-config --from-file=labels.yaml=config/labels.yaml --dry-run=client -o yaml | kubectl replace configmap label-config -f -
 
 validate:
 	$(CONTAINER_RUNTIME) run --rm \

--- a/prow/manifests/labels_cronjob.yaml
+++ b/prow/manifests/labels_cronjob.yaml
@@ -16,9 +16,8 @@ apiVersion: batch/v1beta1
 kind: CronJob
 metadata:
   name: label-sync
-  namespace: prow
 spec:
-  schedule: "17 * * * *"  # Every hour at 17 minutes past the hour
+  schedule: "0 0 * * *"  # Run once a day
   concurrencyPolicy: Forbid
   jobTemplate:
     metadata:
@@ -29,14 +28,14 @@ spec:
         spec:
           containers:
             - name: label-sync
-              image: gcr.io/k8s-prow/label_sync:v20210916-7657ce97bf
+              image: gcr.io/k8s-prow/label_sync:v20211111-bce61c7c4a
               args:
               - --config=/etc/config/labels.yaml
               - --confirm=true
               - --orgs=metal3-io
-              - --token=/etc/github/oauth
+              - --token=/etc/github/token
               volumeMounts:
-              - name: oauth
+              - name: github-token
                 mountPath: /etc/github
                 readOnly: true
               - name: config
@@ -44,9 +43,9 @@ spec:
                 readOnly: true
           restartPolicy: Never
           volumes:
-          - name: oauth
+          - name: github-token
             secret:
-              secretName: oauth-token
+              secretName: github-token
           - name: config
             configMap:
               name: label-config


### PR DESCRIPTION
This patch moves label synchronization CronJob to default
namespace, thus updates the Makefile entry related to it.
Also, it makes it to reuse the existing github-token Secret,
and bumps the label synchronization image to
[v20211111-bce61c7c4a]( gcr.io/k8s-prow/label_sync:v20211111-bce61c7c4a).