### PR TITLE
Prow: add cherrypicker external plugin

### DIFF
--- a/prow/config/external-plugins/cherrypicker_deployment.yaml
+++ b/prow/config/external-plugins/cherrypicker_deployment.yaml
@@ -1,0 +1,69 @@
+# Copyright 2021 The Kubernetes Authors All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  namespace: prow
+  name: cherrypicker
+  labels:
+    app: cherrypicker
+spec:
+  replicas: 1
+  strategy:
+    type: RollingUpdate
+    rollingUpdate:
+      maxSurge: 1
+      maxUnavailable: 1
+  selector:
+    matchLabels:
+      app: cherrypicker
+  template:
+    metadata:
+      labels:
+        app: cherrypicker
+    spec:
+      serviceAccountName: ""
+      serviceAccount: ""
+      terminationGracePeriodSeconds: 180
+      containers:
+      - name: cherrypicker
+        image: gcr.io/k8s-prow/cherrypicker:v20211111-bce61c7c4a
+        imagePullPolicy: Always
+        args:
+        - --github-token-path=/etc/github/token
+        - --github-endpoint=http://ghproxy
+        - --github-endpoint=https://api.github.com
+        - --dry-run=false
+        ports:
+          - name: http
+            containerPort: 8888
+        volumeMounts:
+        - name: hmac
+          mountPath: /etc/webhook
+          readOnly: true
+        - name: github-token
+          mountPath: /etc/github
+          readOnly: true
+        - name: tmp
+          mountPath: /tmp
+      volumes:
+      - name: tmp
+        emptyDir: {}
+      - name: hmac
+        secret:
+          secretName: hmac-token
+      - name: github-token
+        secret:
+          secretName: cherrypick-bot-github-token

--- a/prow/config/external-plugins/cherrypicker_service.yaml
+++ b/prow/config/external-plugins/cherrypicker_service.yaml
@@ -1,0 +1,26 @@
+# Copyright 2021 The Kubernetes Authors All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: v1
+kind: Service
+metadata:
+  name: cherrypicker
+  namespace: prow
+spec:
+  selector:
+    app: cherrypicker
+  ports:
+  - port: 80
+    targetPort: 8888
+  type: ClusterIP

--- a/prow/config/plugins.yaml
+++ b/prow/config/plugins.yaml
@@ -64,7 +64,11 @@ external_plugins:
     # Dispatching issue_comment events to the needs-rebase plugin is optional. If enabled, this may cost up to two token per comment on a PR. If `ghproxy`
     # is in use, these two tokens are only needed if the PR or its mergeability changed.
     - issue_comment
-
+  - name: cherrypicker
+    events:
+    - issue_comment
+    - pull_request
+    endpoint: http://cherrypicker
 config_updater:
   maps:
     # Update the config configmap whenever config.yaml changes


### PR DESCRIPTION
This adds cherry-pick external plugin.
Short description from https://prow.k8s.io/plugins

_"The cherrypick plugin is used for cherrypicking
PRs across branches. For every successful
cherrypick invocation a new PR is opened
against the target branch and assigned to
the requestor. If the parent PR contains
a release note, it is copied to the cherrypick
PR."_