### PR TITLE
Add labels.yaml to config_updater

### DIFF
--- a/prow/config/plugins.yaml
+++ b/prow/config/plugins.yaml
@@ -77,3 +77,6 @@ config_updater:
     # Update the plugins configmap whenever plugins.yaml changes
     prow/config/plugins.yaml:
       name: plugins
+    # Update the label-config configmap whenever labels.yaml changes
+    prow/config/labels.yaml:
+      name: label-config


### PR DESCRIPTION
This ensures that whenever a patch that modifies labels.yaml gets
merged, label-config live configMap gets updated by config updater.