### PR TITLE
Fix a bug with jsonpath during log fetching

### DIFF
--- a/jenkins/scripts/files/run_fetch_logs.sh
+++ b/jenkins/scripts/files/run_fetch_logs.sh
@@ -45,11 +45,10 @@ do
 done
 
 # Dump Prometheus data if Prometheus pod exists
-prometheus_pod=$(kubectl --kubeconfig=${kconfig} get pods --namespace monitoring -l "app=prometheus-server" -o jsonpath="{.items[0].metadata.name}")
+prometheus_pod=$(kubectl --kubeconfig=${kconfig} get pods -n monitoring -l "app=prometheus-server" -o=jsonpath="{.items[*]['metadata.name']}")
 if [ !-z "${prometheus_pod}" ]; then
   kubectl promdump meta -p $POD_NAME -n monitoring -c prometheus -d /prometheus
 fi
-
 }
 
 # Fetch k8s logs


### PR DESCRIPTION
We have been getting this issue but didn't notice it because the script
that runs it doesn't request to print out the commands.  I spotted this
issue in https://github.com/metal3-io/metal3-dev-env/pull/863, while adding `-x` flag to set. 

```
error executing jsonpath "{.items[0].metadata.name}": Error executing template: array index out of bounds: index 0, length 0. Printing more information for debugging the template:
	template was:
		{.items[0].metadata.name}
	object given to jsonpath engine was:
		map[string]interface {}{"apiVersion":"v1", "items":[]interface {}{}, "kind":"List", "metadata":map[string]interface {}{"resourceVersion":"", "selfLink":""}}
```
