### PR TITLE
Prepare for BMO main branch switch

### DIFF
--- a/jenkins/scripts/bare_metal_lab/files/config.sh
+++ b/jenkins/scripts/bare_metal_lab/files/config.sh
@@ -46,7 +46,7 @@
 #
 # Set the Baremetal Operator branch to checkout
 #
-#export BMOBRANCH="${BMOBRANCH:-master}"
+#export BMOBRANCH="${BMOBRANCH:-main}"
 
 #
 # Set the Cluster Api Metal3 provider repository to clone

--- a/prow/config/config.yaml
+++ b/prow/config/config.yaml
@@ -84,8 +84,13 @@ branch-protection:
           # Use this to specify that a status coming from outside of prow is
           # required.  We use this to require functional jobs running in
           # jenkins are required, for example.
-          required_status_checks:
-            contexts: ["test-v1b1-integration"]
+          branches:
+            main:
+              required_status_checks:
+                contexts: ["test-v1b1-centos-integration", "test-v1b1-integration"]
+            master:
+              required_status_checks:
+                contexts: ["test-v1b1-centos-integration", "test-v1b1-integration"]
         cluster-api-provider-metal3:
           branches:
             main:


### PR DESCRIPTION
This PR prepares the prow config for BMO main branch switch. Mainly this PR adds the branch monitoring for BMO in prow config. Currently it monitors two branches main and master. Once main is the default branch, master would be removed.