### PR TITLE
Shrink syslog file size in BML 

### DIFF
--- a/jenkins/scripts/bare_metal_lab/deploy-lab.yaml
+++ b/jenkins/scripts/bare_metal_lab/deploy-lab.yaml
@@ -41,6 +41,14 @@
       become: true
       when: sshd_config.changed
 
+    - name: Shrink size of syslog
+      become: true
+      become_user: root
+      shell:
+        cmd: truncate --size 10737418240 /var/log/syslog && truncate --size 10737418240 /var/log/syslog.1   2>/dev/null
+      ignore_errors: true
+      tags: cleanup
+
     - name: Clone the metal3-dev-env repo
       git:
         repo: https://github.com/metal3-io/metal3-dev-env.git


### PR DESCRIPTION
This PR adds ansible task which shrinks size of syslog before starting the test in BML .

In Bare metal lab syslog file size sometimes increases up to 20-30 Gb per day. Before running tests on BML we should shrink the size of syslog file in order to avoid failure due to shortage of space