### PR TITLE
Switch to docker.io/golang:1.16 image in capm3 tests

### DIFF
--- a/prow/config/config.yaml
+++ b/prow/config/config.yaml
@@ -628,6 +628,8 @@ presubmits:
 
   metal3-io/ip-address-manager:
   - name: gofmt
+    branches:
+    - main
     run_if_changed: '\.go$'
     decorate: true
     spec:
@@ -641,7 +643,26 @@ presubmits:
           value: "TRUE"
         image: docker.io/golang:1.17
         imagePullPolicy: Always
+  - name: gofmt
+    branches:
+    - release-0.0
+    - release-0.1
+    run_if_changed: '\.go$'
+    decorate: true
+    spec:
+      containers:
+      - args:
+        - ./hack/gofmt.sh
+        command:
+        - sh
+        env:
+        - name: IS_CONTAINER
+          value: "TRUE"
+        image: docker.io/golang:1.16
+        imagePullPolicy: Always
   - name: govet
+    branches:
+    - main
     run_if_changed: '\.go$'
     decorate: true
     spec:
@@ -654,6 +675,23 @@ presubmits:
         - name: IS_CONTAINER
           value: "TRUE"
         image: docker.io/golang:1.17
+        imagePullPolicy: Always
+  - name: govet
+    branches:
+    - release-0.0
+    - release-0.1
+    run_if_changed: '\.go$'
+    decorate: true
+    spec:
+      containers:
+      - args:
+        - ./hack/govet.sh
+        command:
+        - sh
+        env:
+        - name: IS_CONTAINER
+          value: "TRUE"
+        image: docker.io/golang:1.16
         imagePullPolicy: Always
   - name: markdownlint
     run_if_changed: '\.md$'
@@ -684,7 +722,26 @@ presubmits:
         image: docker.io/koalaman/shellcheck-alpine:stable
         imagePullPolicy: Always
   - name: unit
+    branches:
+    - main
     skip_if_only_changed: '(((^|/)OWNERS)|(\.md))$'
+    decorate: true
+    spec:
+      containers:
+      - args:
+        - ./hack/unit.sh
+        command:
+        - sh
+        env:
+        - name: IS_CONTAINER
+          value: "TRUE"
+        image: docker.io/golang:1.17
+        imagePullPolicy: Always
+  - name: unit
+    branches:
+    - release-0.0
+    - release-0.1
+    run_if_changed: '\.go$'
     decorate: true
     spec:
       containers:
@@ -698,7 +755,26 @@ presubmits:
         image: docker.io/golang:1.16
         imagePullPolicy: Always
   - name: generate
+    branches:
+    - main
     skip_if_only_changed: '(((^|/)OWNERS)|(\.md))$'
+    decorate: true
+    spec:
+      containers:
+      - args:
+        - ./hack/codegen.sh
+        command:
+        - sh
+        env:
+        - name: IS_CONTAINER
+          value: "TRUE"
+        image: docker.io/golang:1.17
+        imagePullPolicy: Always
+  - name: generate
+    branches:
+    - release-0.0
+    - release-0.1
+    run_if_changed: '\.go$'
     decorate: true
     spec:
       containers:

--- a/prow/config/config.yaml
+++ b/prow/config/config.yaml
@@ -370,27 +370,11 @@ presubmits:
         env:
         - name: IS_CONTAINER
           value: "TRUE"
-        image: quay.io/metal3-io/capm3-unit:main
+        image: docker.io/golang:1.17
         imagePullPolicy: Always
-  - name: gofmt-release-0.5
+  - name: gofmt
     branches:
     - release-0.5
-    run_if_changed: '\.go$'
-    decorate: true
-    optional: true
-    spec:
-      containers:
-      - args:
-        - ./hack/gofmt.sh
-        command:
-        - sh
-        env:
-        - name: IS_CONTAINER
-          value: "TRUE"
-        image: quay.io/metal3-io/capm3-unit:release-0.5
-        imagePullPolicy: Always
-  - name: gofmt-release-0.4
-    branches:
     - release-0.4
     run_if_changed: '\.go$'
     decorate: true
@@ -404,7 +388,7 @@ presubmits:
         env:
         - name: IS_CONTAINER
           value: "TRUE"
-        image: quay.io/metal3-io/capm3-unit:release-0.4
+        image: docker.io/golang:1.16
         imagePullPolicy: Always
   - name: golint
     branches:
@@ -421,27 +405,11 @@ presubmits:
         env:
         - name: IS_CONTAINER
           value: "TRUE"
-        image: quay.io/metal3-io/capm3-unit:main
+        image: docker.io/golang:1.17
         imagePullPolicy: Always
-  - name: golint-release-0.5
+  - name: golint
     branches:
     - release-0.5
-    run_if_changed: '\.go$'
-    decorate: true
-    optional: true
-    spec:
-      containers:
-      - args:
-        - ./hack/golint.sh
-        command:
-        - sh
-        env:
-        - name: IS_CONTAINER
-          value: "TRUE"
-        image: quay.io/metal3-io/capm3-unit:release-0.5
-        imagePullPolicy: Always
-  - name: golint-release-0.4
-    branches:
     - release-0.4
     run_if_changed: '\.go$'
     decorate: true
@@ -455,7 +423,7 @@ presubmits:
         env:
         - name: IS_CONTAINER
           value: "TRUE"
-        image: quay.io/metal3-io/capm3-unit:release-0.4
+        image: docker.io/golang:1.16
         imagePullPolicy: Always
   - name: govet
     branches:
@@ -472,27 +440,11 @@ presubmits:
         env:
         - name: IS_CONTAINER
           value: "TRUE"
-        image: quay.io/metal3-io/capm3-unit:main
+        image: docker.io/golang:1.17
         imagePullPolicy: Always
-  - name: govet-release-0.5
+  - name: govet
     branches:
     - release-0.5
-    run_if_changed: '\.go$'
-    decorate: true
-    optional: true
-    spec:
-      containers:
-      - args:
-        - ./hack/govet.sh
-        command:
-        - sh
-        env:
-        - name: IS_CONTAINER
-          value: "TRUE"
-        image: quay.io/metal3-io/capm3-unit:release-0.5
-        imagePullPolicy: Always
-  - name: govet-release-0.4
-    branches:
     - release-0.4
     run_if_changed: '\.go$'
     decorate: true
@@ -506,7 +458,7 @@ presubmits:
         env:
         - name: IS_CONTAINER
           value: "TRUE"
-        image: quay.io/metal3-io/capm3-unit:release-0.4
+        image: docker.io/golang:1.16
         imagePullPolicy: Always
   - name: markdownlint
     run_if_changed: '\.md$'
@@ -553,27 +505,11 @@ presubmits:
         env:
         - name: IS_CONTAINER
           value: "TRUE"
-        image: quay.io/metal3-io/capm3-unit:main
+        image: docker.io/golang:1.17
         imagePullPolicy: Always
   - name: generate-release-0.5
     branches:
     - release-0.5
-    skip_if_only_changed: '(((^|/)OWNERS)|(\.md))$'
-    decorate: true
-    optional: true
-    spec:
-      containers:
-      - args:
-        - ./hack/codegen.sh
-        command:
-        - sh
-        env:
-        - name: IS_CONTAINER
-          value: "TRUE"
-        image: quay.io/metal3-io/capm3-unit:release-0.5
-        imagePullPolicy: Always
-  - name: generate-release-0.4
-    branches:
     - release-0.4
     skip_if_only_changed: '(((^|/)OWNERS)|(\.md))$'
     decorate: true
@@ -587,7 +523,7 @@ presubmits:
         env:
         - name: IS_CONTAINER
           value: "TRUE"
-        image: quay.io/metal3-io/capm3-unit:release-0.4
+        image: docker.io/golang:1.16
         imagePullPolicy: Always
   - name: unit
     branches:
@@ -604,27 +540,11 @@ presubmits:
         env:
         - name: IS_CONTAINER
           value: "TRUE"
-        image: quay.io/metal3-io/capm3-unit:main
+        image: docker.io/golang:1.17
         imagePullPolicy: Always
-  - name: unit-release-0.5
+  - name: unit
     branches:
     - release-0.5
-    skip_if_only_changed: '(((^|/)OWNERS)|(\.md))$'
-    decorate: true
-    optional: true
-    spec:
-      containers:
-      - args:
-        - ./hack/unit.sh
-        command:
-        - sh
-        env:
-        - name: IS_CONTAINER
-          value: "TRUE"
-        image: quay.io/metal3-io/capm3-unit:release-0.5
-        imagePullPolicy: Always
-  - name: unit-release-0.4
-    branches:
     - release-0.4
     skip_if_only_changed: '(((^|/)OWNERS)|(\.md))$'
     decorate: true
@@ -638,7 +558,7 @@ presubmits:
         env:
         - name: IS_CONTAINER
           value: "TRUE"
-        image: quay.io/metal3-io/capm3-unit:release-0.4
+        image: docker.io/golang:1.16
         imagePullPolicy: Always
   - name: manifestlint
     skip_if_only_changed: '(((^|/)OWNERS)|(\.md))$'
@@ -796,7 +716,7 @@ presubmits:
         env:
         - name: IS_CONTAINER
           value: "TRUE"
-        image: quay.io/metal3-io/capm3-unit:main
+        image: docker.io/golang:1.16
         imagePullPolicy: Always
   - name: generate
     skip_if_only_changed: '(((^|/)OWNERS)|(\.md))$'
@@ -811,7 +731,7 @@ presubmits:
         env:
         - name: IS_CONTAINER
           value: "TRUE"
-        image: quay.io/metal3-io/capm3-unit:main
+        image: docker.io/golang:1.16
         imagePullPolicy: Always
   - name: manifestlint
     skip_if_only_changed: '(((^|/)OWNERS)|(\.md))$'
@@ -898,7 +818,7 @@ presubmits:
         env:
         - name: IS_CONTAINER
           value: "TRUE"
-        image: quay.io/metal3-io/capm3-unit:main
+        image: docker.io/golang:1.16
         imagePullPolicy: Always
   - name: manifestlint
     skip_if_only_changed: '(((^|/)OWNERS)|(\.md))$'

--- a/prow/config/config.yaml
+++ b/prow/config/config.yaml
@@ -360,7 +360,6 @@ presubmits:
     - main
     run_if_changed: '\.go$'
     decorate: true
-    optional: true
     spec:
       containers:
       - args:
@@ -378,7 +377,6 @@ presubmits:
     - release-0.4
     run_if_changed: '\.go$'
     decorate: true
-    optional: true
     spec:
       containers:
       - args:
@@ -395,7 +393,6 @@ presubmits:
     - main
     run_if_changed: '\.go$'
     decorate: true
-    optional: true
     spec:
       containers:
       - args:
@@ -413,7 +410,6 @@ presubmits:
     - release-0.4
     run_if_changed: '\.go$'
     decorate: true
-    optional: true
     spec:
       containers:
       - args:
@@ -430,7 +426,6 @@ presubmits:
     - main
     run_if_changed: '\.go$'
     decorate: true
-    optional: true
     spec:
       containers:
       - args:
@@ -448,7 +443,6 @@ presubmits:
     - release-0.4
     run_if_changed: '\.go$'
     decorate: true
-    optional: true
     spec:
       containers:
       - args:
@@ -463,7 +457,6 @@ presubmits:
   - name: markdownlint
     run_if_changed: '\.md$'
     decorate: true
-    optional: true
     spec:
       containers:
       - args:
@@ -478,7 +471,6 @@ presubmits:
   - name: shellcheck
     run_if_changed: '((\.sh)|^Makefile)$'
     decorate: true
-    optional: true
     spec:
       containers:
       - args:
@@ -495,7 +487,6 @@ presubmits:
     - main
     skip_if_only_changed: '(((^|/)OWNERS)|(\.md))$'
     decorate: true
-    optional: true
     spec:
       containers:
       - args:
@@ -513,7 +504,6 @@ presubmits:
     - release-0.4
     skip_if_only_changed: '(((^|/)OWNERS)|(\.md))$'
     decorate: true
-    optional: true
     spec:
       containers:
       - args:
@@ -530,7 +520,6 @@ presubmits:
     - main
     skip_if_only_changed: '(((^|/)OWNERS)|(\.md))$'
     decorate: true
-    optional: true
     spec:
       containers:
       - args:
@@ -548,7 +537,6 @@ presubmits:
     - release-0.4
     skip_if_only_changed: '(((^|/)OWNERS)|(\.md))$'
     decorate: true
-    optional: true
     spec:
       containers:
       - args:
@@ -563,7 +551,6 @@ presubmits:
   - name: manifestlint
     skip_if_only_changed: '(((^|/)OWNERS)|(\.md))$'
     decorate: true
-    optional: true
     spec:
       containers:
       - args:
@@ -580,7 +567,6 @@ presubmits:
   - name: shellcheck
     run_if_changed: '((\.sh)|^Makefile)$'
     decorate: true
-    optional: true
     spec:
       containers:
       - args:
@@ -595,7 +581,6 @@ presubmits:
   - name: markdownlint
     run_if_changed: '\.md$'
     decorate: true
-    optional: true
     spec:
       containers:
       - args:
@@ -612,7 +597,6 @@ presubmits:
   - name: check-prow-config
     skip_if_only_changed: '(((^|/)OWNERS)|(\.md))$'
     decorate: true
-    optional: true
     spec:
       containers:
       - image: gcr.io/k8s-prow/checkconfig:v20210916-7657ce97bf
@@ -646,7 +630,6 @@ presubmits:
   - name: gofmt
     run_if_changed: '\.go$'
     decorate: true
-    optional: true
     spec:
       containers:
       - args:
@@ -661,7 +644,6 @@ presubmits:
   - name: govet
     run_if_changed: '\.go$'
     decorate: true
-    optional: true
     spec:
       containers:
       - args:
@@ -676,7 +658,6 @@ presubmits:
   - name: markdownlint
     run_if_changed: '\.md$'
     decorate: true
-    optional: true
     spec:
       containers:
       - args:
@@ -691,7 +672,6 @@ presubmits:
   - name: shellcheck
     run_if_changed: '((\.sh)|^Makefile)$'
     decorate: true
-    optional: true
     spec:
       containers:
       - args:
@@ -706,7 +686,6 @@ presubmits:
   - name: unit
     skip_if_only_changed: '(((^|/)OWNERS)|(\.md))$'
     decorate: true
-    optional: true
     spec:
       containers:
       - args:
@@ -721,7 +700,6 @@ presubmits:
   - name: generate
     skip_if_only_changed: '(((^|/)OWNERS)|(\.md))$'
     decorate: true
-    optional: true
     spec:
       containers:
       - args:
@@ -736,7 +714,6 @@ presubmits:
   - name: manifestlint
     skip_if_only_changed: '(((^|/)OWNERS)|(\.md))$'
     decorate: true
-    optional: true
     spec:
       containers:
       - args:


### PR DESCRIPTION
1. Switch to `docker.io/golang` image in CAPM3 and IPAM from `capm3:unit` image.
2. Remove optional flag from Prow jobs, since they have to run on every PR and it
was temporarily added while Prow was down.
3. Add `gofmt`, `unit`,  `govet`, `generate` jobs to IPAM release-0.0 & release-0.1
branches.