### PR TITLE
Increase frequency of running go based CI jobs 

### DIFF
--- a/prow/config/config.yaml
+++ b/prow/config/config.yaml
@@ -358,7 +358,7 @@ presubmits:
   - name: gofmt
     branches:
     - main
-    run_if_changed: '\.go$'
+    skip_if_only_changed: '(((^|/)OWNERS)|(\.md))$'
     decorate: true
     spec:
       containers:
@@ -375,7 +375,7 @@ presubmits:
     branches:
     - release-0.5
     - release-0.4
-    run_if_changed: '\.go$'
+    skip_if_only_changed: '(((^|/)OWNERS)|(\.md))$'
     decorate: true
     spec:
       containers:
@@ -391,7 +391,7 @@ presubmits:
   - name: golint
     branches:
     - main
-    run_if_changed: '\.go$'
+    skip_if_only_changed: '(((^|/)OWNERS)|(\.md))$'
     decorate: true
     spec:
       containers:
@@ -408,7 +408,7 @@ presubmits:
     branches:
     - release-0.5
     - release-0.4
-    run_if_changed: '\.go$'
+    skip_if_only_changed: '(((^|/)OWNERS)|(\.md))$'
     decorate: true
     spec:
       containers:
@@ -424,7 +424,7 @@ presubmits:
   - name: govet
     branches:
     - main
-    run_if_changed: '\.go$'
+    skip_if_only_changed: '(((^|/)OWNERS)|(\.md))$'
     decorate: true
     spec:
       containers:
@@ -441,7 +441,7 @@ presubmits:
     branches:
     - release-0.5
     - release-0.4
-    run_if_changed: '\.go$'
+    skip_if_only_changed: '(((^|/)OWNERS)|(\.md))$'
     decorate: true
     spec:
       containers:
@@ -630,7 +630,7 @@ presubmits:
   - name: gofmt
     branches:
     - main
-    run_if_changed: '\.go$'
+    skip_if_only_changed: '(((^|/)OWNERS)|(\.md))$'
     decorate: true
     spec:
       containers:
@@ -647,7 +647,7 @@ presubmits:
     branches:
     - release-0.0
     - release-0.1
-    run_if_changed: '\.go$'
+    skip_if_only_changed: '(((^|/)OWNERS)|(\.md))$'
     decorate: true
     spec:
       containers:
@@ -663,7 +663,7 @@ presubmits:
   - name: govet
     branches:
     - main
-    run_if_changed: '\.go$'
+    skip_if_only_changed: '(((^|/)OWNERS)|(\.md))$'
     decorate: true
     spec:
       containers:
@@ -680,7 +680,7 @@ presubmits:
     branches:
     - release-0.0
     - release-0.1
-    run_if_changed: '\.go$'
+    skip_if_only_changed: '(((^|/)OWNERS)|(\.md))$'
     decorate: true
     spec:
       containers:
@@ -741,7 +741,7 @@ presubmits:
     branches:
     - release-0.0
     - release-0.1
-    run_if_changed: '\.go$'
+    skip_if_only_changed: '(((^|/)OWNERS)|(\.md))$'
     decorate: true
     spec:
       containers:
@@ -774,7 +774,7 @@ presubmits:
     branches:
     - release-0.0
     - release-0.1
-    run_if_changed: '\.go$'
+    skip_if_only_changed: '(((^|/)OWNERS)|(\.md))$'
     decorate: true
     spec:
       containers:


### PR DESCRIPTION
Increase frequency of running go based CI jobs.
We should be more careful to when not to run go based
prow jobs. We recently faced a PR which didn't touch
`.go `file, so gofmt test didn't run but that change made
existing `.go` files to fail passing go fmt. As such, make it
more strict when the jobs should not run. 