### PR TITLE
Remove master reference in BML pipeline and comments

### DIFF
--- a/jenkins/README.md
+++ b/jenkins/README.md
@@ -42,7 +42,7 @@ jobs on its own.
 
 ## Cloud Resources cleanup
 
-There is a Jenkins [master job](https://jenkins.nordix.org/view/Airship/job/airship_master_integration_tests_cleanup/)
+There is a Jenkins [main job](https://jenkins.nordix.org/view/Airship/job/airship_master_integration_tests_cleanup/)
 that cleans up all the leftover VMs from
 [CityCloud](https://www.citycloud.com/) every 6 hours which has failed to be
 deleted at the end of v1alphaX integration test.

--- a/jenkins/scripts/bare_metal_lab/deploy-lab.yaml
+++ b/jenkins/scripts/bare_metal_lab/deploy-lab.yaml
@@ -109,7 +109,7 @@
         chdir: "/home/{{ ansible_user_id }}/metal3-dev-env/"
       environment:
         NUM_NODES: 0
-        NUM_OF_MASTER_REPLICAS: 0
+        NUM_OF_CONTROLPLANE_REPLICAS: 0
         NUM_OF_WORKER_REPLICAS: 0
 
       # Allowing UDP forwarding allows minikube to use ipmitool (port 623) as

--- a/jenkins/scripts/files/run_integration_tests.sh
+++ b/jenkins/scripts/files/run_integration_tests.sh
@@ -70,7 +70,7 @@ then
   export METAL3BRANCH="${UPDATED_BRANCH}"
 
   # If the target repo and branch are the same as the source repo and branch
-  # we're running a master test, that is not for a PR, so we build the image
+  # we're running a main test, that is not for a PR, so we build the image
   # for CAPM3 to verify the process (not BMO due to the build time for BMO image)
 
   if [[ "${UPDATED_BRANCH}" == "${REPO_BRANCH}" ]] && [[ "${UPDATED_REPO}" == *"${REPO_ORG}/${REPO_NAME}"* ]]; then

--- a/jenkins/scripts/integration_clean.sh
+++ b/jenkins/scripts/integration_clean.sh
@@ -3,7 +3,7 @@
 set -eu
 
 # Description:
-# Runs in master integration cleanup job defined in jjb. 
+# Runs in main integration cleanup job defined in jjb. 
 # Consumed by integration_tests_clean.pipeline and cleans any leftover executer vm
 # and port once every day.
 #   Requires:

--- a/jenkins/scripts/integration_delete.sh
+++ b/jenkins/scripts/integration_delete.sh
@@ -3,7 +3,7 @@
 set -eu
 
 # Description:
-# Runs in every single master job and in jobs triggered within the PR in metal3 repos. 
+# Runs in every single main job and in jobs triggered within the PR in metal3 repos. 
 # Consumed by integration_tests.pipeline and cleans the executer vm/volume and port after
 # integration tests.
 #   Requires:

--- a/jenkins/scripts/integration_test_clean.sh
+++ b/jenkins/scripts/integration_test_clean.sh
@@ -3,7 +3,7 @@
 set -eu
 
 # Description:
-# Runs in every single master job and in jobs triggered within the PR in metal3 repos. 
+# Runs in every single main job and in jobs triggered within the PR in metal3 repos. 
 # Consumed by integration_tests.pipeline and cleans the integration test results by
 # running 'make clean' target (check run_clean.sh script) eventually.
 #   Requires:


### PR DESCRIPTION
This PR removes master references. It doesn't cover all the cases. Followup PRs would be needed to remove all the references once other repos in metal3 also introduce the same.