### PR TITLE
Disable concurrent builds in BML

### DIFF
--- a/jenkins/jobs/bml_integration_tests.pipeline
+++ b/jenkins/jobs/bml_integration_tests.pipeline
@@ -21,6 +21,10 @@ script {
 }
 
 pipeline {
+  /* In the BML we always run on the same machine so concurrency must be disabled */
+  options {
+    disableConcurrentBuilds()
+  }
   agent { label 'airship-static-workers' }
   environment {
     AIRSHIP_CI_USER="airshipci"

--- a/jenkins/scripts/bare_metal_lab/README.md
+++ b/jenkins/scripts/bare_metal_lab/README.md
@@ -15,3 +15,16 @@ This repo is created to setup the baremetal lab for metal3.
 Then:
 
 `ansible-playbook ./deploy-lab.yaml -i ./hosts -u <user> --ask-become-pass`
+
+## Running tests for pull requests on Github
+
+You can trigger builds to run in the bare metal lab by adding the following line as a comment on the PR:
+
+```
+/test-integration-bml-centos
+```
+
+**Note:** Concurrent builds are disabled for the BML, since they would run on the same host and interfere with each other.
+This means that if there is already one build job running in the BML, a new one will not start before the first has finished.
+Github won't show the usual *Details* link for this specific run but build status can be checked from the [Jenkins dashboard](https://jenkins.nordix.org/job/airship_metal3io_project_infra_bml_integration_tests_centos/) where the build will be scheduled and stay in pending at this time.
+Once the build starts, the status will be updated with a link.


### PR DESCRIPTION
The builds in BML always use the same machine so we cannot allow multiple builds to run at the same time.