### PR TITLE
Create/delete floating IP in Fra1

### DIFF
--- a/jenkins/scripts/integration_delete.sh
+++ b/jenkins/scripts/integration_delete.sh
@@ -3,7 +3,7 @@
 set -eu
 
 # Description:
-# Runs in every single main job and in jobs triggered within the PR in metal3 repos. 
+# Runs in every single main job and in jobs triggered within the PR in metal3 repos.
 # Consumed by integration_tests.pipeline and cleans the executer vm/volume and port after
 # integration tests.
 #   Requires:
@@ -18,6 +18,7 @@ CI_DIR="$(dirname "$(readlink -f "${0}")")"
 source "${CI_DIR}/utils.sh"
 
 TEST_EXECUTER_PORT_NAME="${TEST_EXECUTER_PORT_NAME:-${TEST_EXECUTER_VM_NAME}-int-port}"
+TEST_EXECUTER_FIP_TAG="${TEST_EXECUTER_FIP_TAG:-${TEST_EXECUTER_VM_NAME}-floating-ip}"
 
 # Run feature tests, e2e tests, main, master and release* tests in the Frankfurt region
 if [[ "${TESTS_FOR}" == "feature_tests"* ]] || [[ "${TESTS_FOR}" == "e2e_tests"* ]] || \
@@ -27,6 +28,17 @@ then
   OS_AUTH_URL="https://fra1.citycloud.com:5000"
 fi
 echo "Running in region: $OS_REGION_NAME"
+
+if [[ "$OS_REGION_NAME" != "Kna1" ]]
+then
+  # Find executer floating ip
+  TEST_EXECUTER_FIP_ID="$(openstack floating ip list --tags "${TEST_EXECUTER_FIP_TAG}" -f value -c ID)"
+
+  # Delete executer floating ip
+  echo "Deleting executer floating IP ${TEST_EXECUTER_FIP_ID}."
+  echo "${TEST_EXECUTER_FIP_ID}" | xargs openstack floating ip delete
+  echo "Executer floating IP ${TEST_EXECUTER_FIP_ID} is deleted."
+fi
 
 # Delete executer vm
 echo "Deleting executer VM ${TEST_EXECUTER_VM_NAME}."

--- a/jenkins/scripts/integration_test.sh
+++ b/jenkins/scripts/integration_test.sh
@@ -44,6 +44,7 @@ DEFAULT_HOSTS_MEMORY="${DEFAULT_HOSTS_MEMORY:-4096}"
 VM_TIMELABEL="${VM_TIMELABEL:-$(date '+%Y%m%d%H%M%S')}"
 TEST_EXECUTER_VM_NAME="${TEST_EXECUTER_VM_NAME:-ci-test-vm-${VM_TIMELABEL}}"
 TEST_EXECUTER_PORT_NAME="${TEST_EXECUTER_PORT_NAME:-${TEST_EXECUTER_VM_NAME}-int-port}"
+TEST_EXECUTER_FIP_TAG="${TEST_EXECUTER_FIP_TAG:-${TEST_EXECUTER_VM_NAME}-floating-ip}"
 
 # Run feature tests, e2e tests, main, master and release* tests in the Frankfurt region
 if [[ "${TESTS_FOR}" == "feature_tests"* ]] || [[ "${TESTS_FOR}" == "e2e_tests"* ]] || \
@@ -88,10 +89,10 @@ TEST_EXECUTER_IP="$(openstack port show -f json "${TEST_EXECUTER_PORT_NAME}" \
 
 if [[ "$OS_REGION_NAME" != "Kna1" ]]
 then
-  # Fetch Free floating IP
-  # TODO: To avoid jobs taking the same floating IP, instead jobs should create / delete / cleanup
-  # their own floating IPs.
-  FLOATING_IP="$(openstack floating ip list --status DOWN -c "Floating IP Address" -f value | shuf -n 1 )"
+  # Create floating IP
+  FLOATING_IP="$(openstack floating ip create -f value -c name \
+    --tag "${TEST_EXECUTER_FIP_TAG}" \
+    "${CI_FLOATING_IP_NET}")"
 
   if [[ -z "$FLOATING_IP" ]]
   then

--- a/jenkins/scripts/utils.sh
+++ b/jenkins/scripts/utils.sh
@@ -5,6 +5,7 @@
 
 CI_EXT_NET="airship-ci-ext-net"
 CI_EXT_SUBNET_CIDR="10.100.10.0/24"
+CI_FLOATING_IP_NET="ext-net"
 CI_METAL3_IMAGE="airship-ci-ubuntu-metal3-img"
 CI_METAL3_CENTOS_IMAGE="airship-ci-centos-metal3-img"
 
@@ -56,7 +57,7 @@ create_test_executer_volume() {
 
   BASE_VOLUME_NAME_ID="${1:?}"
   TEST_EXECUTER_VM_NAME="${2:?}"
-    
+
   openstack volume create \
     --source "${BASE_VOLUME_NAME_ID}" \
     "${TEST_EXECUTER_VM_NAME}"


### PR DESCRIPTION
This is to avoid collisions when multiple jobs would happen to select
the same IP. If each job creates its own IP we get no collisions.