### PR TITLE
Add e2e tested_repo _artifacts dir to logs tarball

### DIFF
--- a/jenkins/scripts/files/run_fetch_logs.sh
+++ b/jenkins/scripts/files/run_fetch_logs.sh
@@ -20,6 +20,11 @@ mkdir -p "${LOGS_DIR}"
 mkdir -p "${LOGS_DIR}/manifests"
 cp -r /tmp/manifests/* "${LOGS_DIR}/manifests"
 
+if [[ "${TESTS_FOR}" == "e2e_tests"* ]]; then
+  mkdir -p "${LOGS_DIR}/e2e_artifacts"
+  cp -r /home/airshipci/tested_repo/_artifacts/. "${LOGS_DIR}/e2e_artifacts"
+fi
+
 function fetch_k8s_logs() {
 dir_name="k8s_${1}"
 kconfig="$2"


### PR DESCRIPTION
When e2e tests are run, the resources in the cluster are dumped to the tested_repo/_artifacts directory. These artifacts will now be included in the Jenkins artifact logs tarball so that resources in e2e jobs can be inspected after the job has ended.