### PR TITLE
✨ Skip running integration tests on markdown and OWNERS files in PRs

### DIFF
--- a/jenkins/jobs/integration_tests.pipeline
+++ b/jenkins/jobs/integration_tests.pipeline
@@ -101,7 +101,20 @@ pipeline {
           withCredentials([sshUserPrivateKey(credentialsId: 'metal3ci_city_cloud_ssh_keypair', keyFileVariable: 'METAL3_CI_USER_KEY')]) {
             withCredentials([string(credentialsId: 'metal3-clusterctl-github-token', variable: 'GITHUB_TOKEN')]) {
               ansiColor('xterm') {
-                sh "./jenkins/scripts/integration_test.sh"
+                script {
+                  // script path
+                  SCRIPT_PATH = "./jenkins/scripts/skip_integration_test.sh"
+                  // invoke script, and save exit code in "rc"
+                  echo 'Running the skip integration test script...'
+                  rc = sh(script: "${SCRIPT_PATH}", returnStatus: true)
+                  // check exit code
+                  sh "echo \"exit code is : ${rc}\""
+                  if (rc != 0)  {
+                    sh "./jenkins/scripts/integration_test.sh"
+                  } else {
+                    echo "Skip running integration tests, only markdown or OWNERS file has been changed on a PR"
+                  }
+                }
               }
             }
           }
@@ -118,10 +131,40 @@ pipeline {
           }
           withCredentials([usernamePassword(credentialsId: 'metal3ci_city_cloud_openstack_credentials', usernameVariable: 'OS_USERNAME', passwordVariable: 'OS_PASSWORD')]) {
             withCredentials([sshUserPrivateKey(credentialsId: 'metal3ci_city_cloud_ssh_keypair', keyFileVariable: 'METAL3_CI_USER_KEY')]){
-              sh "./jenkins/scripts/fetch_logs.sh"
+              script {
+                // script path
+                SCRIPT_PATH = "./jenkins/scripts/skip_integration_test.sh"
+                // invoke script, and save exit code in "rc"
+                echo 'Running the skip integration test script...'
+                rc = sh(script: "${SCRIPT_PATH}", returnStatus: true)
+                // check exit code
+                sh "echo \"exit code is : ${rc}\""
+                if (rc != 0)  {
+                  sh "./jenkins/scripts/fetch_logs.sh"
+                } else {
+                  echo "Skip fetching logs, no integration test has been run, since only markdown or OWNERS file has been changed on a PR"
+                }
+              }
             }
           }
-          archiveArtifacts "logs-${env.BUILD_TAG}.tgz"
+          withCredentials([usernamePassword(credentialsId: 'metal3ci_city_cloud_openstack_credentials', usernameVariable: 'OS_USERNAME', passwordVariable: 'OS_PASSWORD')]) {
+            withCredentials([sshUserPrivateKey(credentialsId: 'metal3ci_city_cloud_ssh_keypair', keyFileVariable: 'METAL3_CI_USER_KEY')]){
+              script {
+                // script path
+                SCRIPT_PATH = "./jenkins/scripts/skip_integration_test.sh"
+                // invoke script, and save exit code in "rc"
+                echo 'Running the skip integration test script...'
+                rc = sh(script: "${SCRIPT_PATH}", returnStatus: true)
+                // check exit code
+                sh "echo \"exit code is : ${rc}\""
+                if (rc != 0)  {
+                  archiveArtifacts "logs-${env.BUILD_TAG}.tgz"
+                } else {
+                  echo "Skip archiving artifacts, no integration test has been run, only markdown or OWNERS file has been changed on a PR"
+                }
+              }
+            }
+          }
         }
       }
     }
@@ -134,7 +177,18 @@ pipeline {
             if ("${SKIP_DELETION}" == "true") {
               echo "Skipping environment clean up"
             } else {
-              sh "./jenkins/scripts/integration_test_clean.sh"
+              // script path
+              SCRIPT_PATH = "./jenkins/scripts/skip_integration_test.sh"
+              // invoke script, and save exit code in "rc"
+              echo 'Running the skip integration test script...'
+              rc = sh(script: "${SCRIPT_PATH}", returnStatus: true)
+              // check exit code
+              sh "echo \"exit code is : ${rc}\""
+              if (rc != 0) {
+                sh "./jenkins/scripts/integration_test_clean.sh"
+              } else {
+                echo "Skip cleaning up an environment, no integration test has been run, only markdown or OWNERS file has been changed on a PR"
+              }
             }
           }
         }
@@ -147,7 +201,18 @@ pipeline {
             if ("${SKIP_DELETION}" == "true") {
               echo "Skipping VM deletion"
             } else {
-              sh "./jenkins/scripts/integration_delete.sh"
+              // script path
+              SCRIPT_PATH = "./jenkins/scripts/skip_integration_test.sh"
+              // invoke script, and save exit code in "rc"
+              echo 'Running the skip integration test script...'
+              rc = sh(script: "${SCRIPT_PATH}", returnStatus: true)
+              // check exit code
+              sh "echo \"exit code is : ${rc}\""
+              if (rc != 0) {
+                sh "./jenkins/scripts/integration_delete.sh"
+              } else {
+                echo "Skip deleting VM, no integration test has been run, only markdown or OWNERS file has been changed on a PR"
+              }
             }
           }
         }

--- a/jenkins/scripts/skip_integration_test.sh
+++ b/jenkins/scripts/skip_integration_test.sh
@@ -1,0 +1,47 @@
+#! /usr/bin/env bash
+
+set -eu
+
+# Clone the target repo and change the directory to cloned repo name
+gclonecd () {
+    url=$1;
+    reponame=$(echo $url | awk -F/ '{print $NF}' | sed -e 's/.git$//');
+    if [ -d "$reponame" ]; then
+      echo "Target repo folder already exists"
+    else 
+      git clone $url $reponame;
+      cd $reponame;
+    fi
+}
+
+# If git diff on the target branch against source repo outputs ONLY markdown or
+# OWNERS file, return exit code (rc): 0 to skip integration tests, otherwise 
+# return 1 to run integration tests
+exclude_markdown_and_owners_files() {
+  for file in $(git diff "${UPDATED_BRANCH}" origin/"${REPO_BRANCH}" --name-only)
+  do
+    filename=$(basename -- "$file")
+    extension="${filename##*.}"
+    filename="${filename%.*}"
+    if [[ $extension != "md" ]]
+    then
+      if [[ $filename != "OWNERS" ]]
+      then
+        echo "The file(s) changed contains other extensions and files than markdown or OWNERS file"
+        return 1
+      fi
+    fi
+  done
+  return 0
+}
+
+# If the target repo and branch are the same as the source repo and branch
+# we're running a main test, return exit code (rc): 1 to run integration tests,
+# otherwise check the updated branch to decide on whether skipping or running 
+# the integration tests.
+if [[ "${UPDATED_BRANCH}" == "${REPO_BRANCH}" ]] && [[ "${UPDATED_REPO}" == *"${REPO_ORG}/${REPO_NAME}"* ]]; then
+  return 1
+else
+  gclonecd $UPDATED_REPO
+  exclude_markdown_and_owners_files
+fi


### PR DESCRIPTION
This PR introduces a possibility to skip running integration tests on PRs opened in Metal3 repositories, where the patch contains **ONLY** `.md` file extension or `OWNERS` file type changes. 
To clarify, all PR's in repositories still would require (if configured so) to trigger required/desired integration test triggers, since that is mandated not only in the Jenkins configuration file in this repo but also on all Metal3 Repos' GitHub settings, where certain integration test is marked as 'required'. However, time + resources can be saved, as we skip:

- creating a VM to run integration tests
- fetching logs and archiving them
- cleaning up the environment (make clean)
- deleting used resources (VM, port)

Main jobs using the same pipeline should also keep working as is after these changes, but that has not been tested though since there is no way of testing that case really.