### PR TITLE
Allow adding triage labels on issues across Metal3.io

### DIFF
--- a/prow/config/labels.yaml
+++ b/prow/config/labels.yaml
@@ -303,3 +303,35 @@ default:
       prowPlugin: needs-rebase
       isExternalPlugin: true
       addedBy: prow
+    - color: ff00ff
+      description: Indicates an issue lacks a `triage/foo` label and requires one.
+      name: needs-triage
+      target: issues
+      prowPlugin: require-matching-label
+      addedBy: prow
+    - color: 8fc951
+      description: Indicates an issue is ready to be actively worked on.
+      name: triage/accepted
+      target: issues
+      prowPlugin: label
+      addedBy: org members
+    - color: d455d0
+      description: Indicates an issue is a duplicate of other open issue.
+      name: triage/duplicate
+      target: issues
+      addedBy: anyone
+    - color: d455d0
+      description: Indicates an issue needs more information in order to work on it.
+      name: triage/needs-information
+      target: issues
+      addedBy: anyone
+    - color: d455d0
+      description: Indicates an issue can not be reproduced as described.
+      name: triage/not-reproducible
+      target: issues
+      addedBy: anyone
+    - color: d455d0
+      description: Indicates an issue that can not or will not be resolved.
+      name: triage/unresolved
+      target: issues
+      addedBy: anyone

--- a/prow/config/plugins.yaml
+++ b/prow/config/plugins.yaml
@@ -81,3 +81,15 @@ config_updater:
     # Update the label-config configmap whenever labels.yaml changes
     prow/config/labels.yaml:
       name: label-config
+
+require_matching_label:
+# triage configuration
+- missing_label: needs-triage
+  org: metal3-io
+  issues: true
+  prs: false
+  regexp: ^triage/accepted$
+  missing_comment: |
+    This issue is currently awaiting triage.
+    If Metal3.io contributors determine this is a relevant issue, they will accept it by applying the `triage/accepted` label and provide further guidance.
+    The `triage/accepted` label can be added by org members by writing `/triage accepted` in a comment.


### PR DESCRIPTION
Allow setting needs-triage label on GitHub issues. This will tag
issues so that community is aware and takes some actions on them
during next triage meeting. Once action is taken, triage/foo should
be set indicating the triage status of the issue. Possible options

triage/unresolved, triage/not-reproducible, triage/duplicate,
triage/needs-information, triage/accepted.