### PR TITLE
Add export K8s  version for airship integration tests

### DIFF
--- a/jenkins/scripts/files/run_integration_tests.sh
+++ b/jenkins/scripts/files/run_integration_tests.sh
@@ -21,6 +21,7 @@ if [ "${REPO_NAME}" == "airship-dev-tools" ]
 then
   export IMAGE_NAME
   export IMAGE_LOCATION
+  export KUBERNETES_VERSION
 fi
 
 if [ "${CAPM3_VERSION}" == "v1alpha4" ]


### PR DESCRIPTION
add export KUBERNETES_VERSION for airship dev tools integration tests.
We need to export KUBERNETES_VERSION variable for airship integration tests. 