### PR TITLE
Fix unbound variable use logic

### DIFF
--- a/jenkins/scripts/integration_test.sh
+++ b/jenkins/scripts/integration_test.sh
@@ -126,11 +126,13 @@ TESTS_FOR="${TESTS_FOR}"
 BARE_METAL_LAB="${BARE_METAL_LAB}"
 EOF
 
-if [[ -z "${CAPIRELEASE}" ]]
+# Only set these variables if they actually have values.
+# If the variable is unset or empty (""), do nothing.
+if [[ ! -z "${CAPIRELEASE:+x}" ]]
 then
   echo "CAPIRELEASE=${CAPIRELEASE}" | tee --append "${CI_DIR}/files/vars.sh"
 fi
-if [[ -z "${CAPM3RELEASE}" ]]
+if [[ ! -z "${CAPM3RELEASE:+x}" ]]
 then
   echo "CAPM3RELEASE=${CAPM3RELEASE}" | tee --append "${CI_DIR}/files/vars.sh"
 fi


### PR DESCRIPTION
I made a logic error in the last PR. It should be setting these variables only *if they have some value*. If they are unset or empty string we should ignore them to allow default values to be used.

/hold
Don't merge this until [this](https://gerrit.nordix.org/c/infra/cicd/+/12038) is in so we can properly test it.