### PR TITLE
🌱 Move maelk to emeritus_approvers list

### DIFF
--- a/OWNERS
+++ b/OWNERS
@@ -2,7 +2,6 @@
 
 approvers:
  - russellb
- - maelk
  - fmuyassarov
  - kashifest
  - furkatgofurov7
@@ -10,3 +9,6 @@ approvers:
 reviewers:
  - macaptain
  - smoshiur1237
+
+emeritus_approvers:
+ - maelk


### PR DESCRIPTION
Maël's focus has shifted from this project to other tasks thus the
OWNERS list has to be modified accordingly.