### PR TITLE
✨ Add transfer-issue plugin to Prow

### DIFF
--- a/prow/config/plugins.yaml
+++ b/prow/config/plugins.yaml
@@ -21,6 +21,7 @@ plugins:
     - retitle
     - shrug
     - size
+    - transfer-issue
     - trigger
     - verify-owners
     - wip

--- a/prow/manifests/starter.yaml
+++ b/prow/manifests/starter.yaml
@@ -27,6 +27,7 @@ data:
         - hold
         - label
         - lgtm
+        - transfer-issue
         - trigger
         - verify-owners
         - wip


### PR DESCRIPTION
Based on my investigation, we should be able to get the advantage of using `transfer-issue` plugin by just adding it to the list of plugins and metal3-io-bot should be able to interpret it as intended, unless I missed some configuration part.

**Workflow:**

![transfer-issue-workflow](https://user-images.githubusercontent.com/40443040/149936728-3f56f45a-fbd4-4b71-ac51-caa5eb3e172c.png)

Source: https://docs.google.com/document/d/1uqKI5QEAh2fnq7LRRz-2Mhf-jInIpuiAUnPow36jCVU/edit

**Usage within the same org commented on the issue:**

`/transfer <TARGET_REPO>` or `/transfer-issue <TARGET_REPO>`

i.e, transferring issue from cluster-api-provider-metal3 repo to ip-address-manager repo should be done using:
`/transfer ip-address-manager`

Fixes: #234 




 