### PR TITLE
🐛 Prow: Remove additional blank space from prow config file

### DIFF
--- a/prow/config/config.yaml
+++ b/prow/config/config.yaml
@@ -100,7 +100,7 @@ branch-protection:
             release-0.4:
               required_status_checks:
                 contexts: ["test-v1a4-integration"]
-        ironic-image: 
+        ironic-image:
           branches:
             main:
               required_status_checks:


### PR DESCRIPTION
Whenever there is a change in files (`config.yaml, labels.yaml or plugins.yaml`) under `prow/config` folder, configmap will be updated in the prow cluster. Current configmap for config.yaml looks like as below:
```
`ubuntu@prow-metal3:~/project-infra/prow$ kubectl get cm config -n prow -oyaml
apiVersion: v1
data:
  config.yaml: "prowjob_namespace: prow\npod_namespace: test-pods\nlog_level: debug\n\n#
    Sinker configurations (for cleanup)\nsinker:\n  resync_period: 1m\n  max_prowjob_age:
    4h\n  max_pod_age: 30m\n  terminated_pod_ttl: 2h\n\nplank:\n  job_url_prefix_config:\n
    \   \"*\": https://prow.apps.test.metal3.io/view/\n  report_templates:\n    '*':
    >-\n        [Full PR test history](https://prow.apps.test.metal3.io/pr-history?org={{.Spec.Refs.Org}}&repo={{.Spec.Refs.Repo}}&pr={{with
    index .Spec.Refs.Pulls 0}}{{.Number}}{{end}}).\n        [Your PR dashboard](https://prow.apps.test.metal3.io/pr?query=is:pr+state:open+author:{{with\n
    \       index .Spec.Refs.Pulls 0}}{{.Author}}{{end}}).\n  default_decoration_configs:\n
    \   \"*\":\n      gcs_configuration:\n        bucket: s3://prow-logs\n        path_strategy:
    explicit\n      s3_credentials_secret: s3-credentials\n      utility_images:\n
    \       clonerefs: gcr.io/k8s-prow/clonerefs:v20210916-3c87dfedd5\n        entrypoint:
    gcr.io/k8s-prow/entrypoint:v20210916-3c87dfedd5\n        initupload: gcr.io/k8s-prow/initupload:v20210916-3c87dfedd5\n
    \       sidecar: gcr.io/k8s-prow/sidecar:v20210916-3c87dfedd5\n\ntide:\n  merge_method:\n
    \   metal3-io/project-config: merge\n  queries:\n  - repos:\n    - metal3-io/baremetal-operator\n
    \   - metal3-io/base-image\n    - metal3-io/cluster-api-provider-metal3\n    -
    metal3-io/ironic-client\n    - metal3-io/ironic-hardware-inventory-recorder-image\n
    \   - metal3-io/ironic-image\n    - metal3-io/ironic-agent-image\n    - metal3-io/ironic-ipa-downloader\n
    \   - metal3-io/ironic-prometheus-exporter\n    - metal3-io/mariadb-image\n    -
    metal3-io/metal3-dev-env\n    - metal3-io/metal3-docs\n    - metal3-io/metal3-helm-chart\n
    \   - metal3-io/metal3-io.github.io\n    - metal3-io/metal3-smart-exporter\n    -
    metal3-io/project-infra\n    - metal3-io/static-ip-manager-image\n    - metal3-io/ip-address-manager\n
    \   - metal3-io/hardware-classification-controller\n    labels:\n    - lgtm\n
    \   - approved\n    missingLabels:\n    - needs-rebase\n    - do-not-merge\n    -
    do-not-merge/hold\n    - do-not-merge/invalid-owners-file\n    - do-not-merge/work-in-progress\n
    \ context_options:\n    # Use branch protection options to define required and
    optional contexts\n    from-branch-protection: true\n
    \n#\n# Use prow to manage
    
    ........................................................text has been truncated .................................................................................
`
```
that is because of the blank space added in the `config.yaml` in previous patches. This was found during debugging another issue in the prow and might result in confusing to interpret the text for prow components and malfunctioning in the future if left unfixed. 