### PR TITLE
🌱 Add UPGRADE_TEST var export for e2e upgrade tests

### DIFF
--- a/jenkins/jobs/integration_tests.pipeline
+++ b/jenkins/jobs/integration_tests.pipeline
@@ -69,6 +69,8 @@ pipeline {
     NUM_NODES="${NUM_NODES}"
     TESTS_FOR="${TESTS_FOR}"
     SKIP_DELETION="${SKIP_DELETION}"
+    UPGRADE_TEST="${UPGRADE_TEST}"
+
   }
   stages {
     stage('SCM') {

--- a/jenkins/scripts/files/run_integration_tests.sh
+++ b/jenkins/scripts/files/run_integration_tests.sh
@@ -12,6 +12,7 @@ export CAPM3_VERSION
 export IMAGE_OS
 export DEFAULT_HOSTS_MEMORY
 export NUM_NODES
+export UPGRADE_TEST
 
 if [ "${REPO_NAME}" == "airship-dev-tools" ]
 then

--- a/jenkins/scripts/integration_test.sh
+++ b/jenkins/scripts/integration_test.sh
@@ -121,6 +121,7 @@ DISTRIBUTION="${DISTRIBUTION}"
 NUM_NODES="${NUM_NODES}"
 TESTS_FOR="${TESTS_FOR}"
 BARE_METAL_LAB="${BARE_METAL_LAB}"
+UPGRADE_TEST="${UPGRADE_TEST}"
 EOF
 
 # Only set these variables if they actually have values.


### PR DESCRIPTION
This PR exports UPGRADE_TEST that should be used in the CAPM3 e2e test to select the upgrade test