### PR TITLE
Add linter CI for YAML files

### DIFF
--- a/.github/workflows/yamllint.yaml
+++ b/.github/workflows/yamllint.yaml
@@ -1,0 +1,16 @@
+---
+name: yamllint
+on:
+  pull_request:
+    types: [opened, edited, synchronize, reopened]
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: yaml-lint
+        uses: ibiqlik/action-yamllint@v3
+        with:
+          config_file: .yamllint.yaml

--- a/.yamllint.yaml
+++ b/.yamllint.yaml
@@ -1,0 +1,10 @@
+yaml-files:
+  - '*.yaml'
+  - '*.yml'
+  - '.yamllint'
+
+rules:
+  trailing-spaces: enable
+  key-duplicates: enable
+  truthy:
+    allowed-values: ['true', 'false']

--- a/.yamllint.yaml
+++ b/.yamllint.yaml
@@ -7,4 +7,4 @@ rules:
   trailing-spaces: enable
   key-duplicates: enable
   truthy:
-    allowed-values: ['true', 'false']
+    allowed-values: ['true', 'false', 'yes', 'no', 'on']

--- a/jenkins/scripts/bare_metal_lab/deploy-lab.yaml
+++ b/jenkins/scripts/bare_metal_lab/deploy-lab.yaml
@@ -8,8 +8,8 @@
     EXTERNAL_VLAN_ID: 3
   tasks:
     - name: set_fact
-      set_fact: 
-        node_ips: 
+      set_fact:
+        node_ips:
           - "192.168.1.12"
           - "192.168.1.15"
         serial_log_location: "/tmp/BMLlog"
@@ -88,17 +88,17 @@
       tags: cleanup
 
     - name: Delete existing ssh connections to HPE CLI
-      shell: 
+      shell:
         cmd: |
-         killall ssh 
+         killall ssh
          exit 0
          EOT
 
-    - name: Start to capture log from virtual serial port 
-      shell: 
+    - name: Start to capture log from virtual serial port
+      shell:
         cmd: |
           mkdir -p "{{ serial_log_location }}"
-          nohup /bin/bash <<EOF 
+          nohup /bin/bash <<EOF
           ssh -o "KexAlgorithms diffie-hellman-group14-sha1" "{{ lookup('env', 'BML_ILO_USERNAME') }}"@{{ item }}  'vsp' > "{{ serial_log_location }}/{{ item }}.txt" &
           EOF
           exit 0


### PR DESCRIPTION
Currently we don't lint YAML files. As a result, sometimes we see
issues with some YAML code being merged and the issue is identified
later on. Example, trailing spaces which might breake the
configuration file of Prow.

This patch adds yamllinter based GitHub action so that we verify
correctness of YAML files on every pull request submission, before
landing on the main branch. As a start, trailing space, key-duplicate
and truthy rules are enabled, and the list can be extended based on
the need.
Fixes: https://github.com/metal3-io/project-infra/issues/322