### PR TITLE
Prow: Add missing require-matching-label plugin to plugins list

### DIFF
--- a/prow/config/plugins.yaml
+++ b/prow/config/plugins.yaml
@@ -26,6 +26,7 @@ plugins:
     - verify-owners
     - wip
     - yuks
+    - require-matching-label
   metal3-io/baremetal-operator:
   metal3-io/base-image:
   metal3-io/cluster-api-provider-baremetal:

--- a/prow/manifests/starter.yaml
+++ b/prow/manifests/starter.yaml
@@ -32,6 +32,7 @@ data:
         - verify-owners
         - wip
         - yuks
+        - require-matching-label
 ---
 apiVersion: v1
 kind: Secret


### PR DESCRIPTION
We have enabled needs/triage label earlier in https://github.com/metal3-io/project-infra/pull/307 but that commit misses adding `require-matching-label` plugin to the list of plugins used across Metal3.io repos. This adds that plugin to the list.