### PR TITLE
Rename airship to metal3 in repos and jjb

### DIFF
--- a/jenkins/README.md
+++ b/jenkins/README.md
@@ -2,8 +2,8 @@
 
 Integration tests are running in the [Nordix](https://www.nordix.org)
 infrastructure. Nordix provides a
-[Jenkins](https://jenkins.nordix.org/view/Airship/) instance and cloud resources
-on [CityCloud](https://www.citycloud.com/) for the Airship project. We use those
+[Jenkins](https://jenkins.nordix.org/view/Metal3/) instance and cloud resources
+on [CityCloud](https://www.citycloud.com/) for the Metal3 project. We use those
 resources to run integration tests for Metal3.
 
 ## Admins whitelist
@@ -50,7 +50,7 @@ but deleted after 24 hours, to avoid garbage collection of VMs.
 
 ## Cloud Resources cleanup
 
-There is a Jenkins [main job](https://jenkins.nordix.org/view/Airship/job/airship_master_integration_tests_cleanup/)
+There is a Jenkins [main job](https://jenkins.nordix.org/view/Metal3/job/metal3_master_integration_tests_cleanup/)
 that cleans up all the leftover VMs from
 [CityCloud](https://www.citycloud.com/) every 6 hours which has failed to be
 deleted at the end of v1alphaX integration test.
@@ -68,7 +68,7 @@ whitelist if trusted.
 Pods, CRDs logs are collected at the end of each Jenkins job run and
 archived so that they can be later used for debugging purposes. You can
 find the archived logs under the  "*Build artifacts*" section of the
-[job](https://jenkins.nordix.org/view/Airship/job/airship_metal3io_bmo_v1a4_integration_test_ubuntu/).
+[job](https://jenkins.nordix.org/view/Metal3/job/metal3_metal3io_bmo_v1a4_integration_test_ubuntu/).
 Please note that the logs will be removed 30 days after creation or after 100 subsequent job runs,
 whichever occurs first.
 
@@ -86,11 +86,11 @@ rather than writing/creating them directly in Jenkins UI. Your YAML formatted jo
 will create a Jenkins job, which in turn executes your specified jenkins pipeline.
 Check [Job definitions](https://docs.openstack.org/infra/jenkins-job-builder/definition.html) to
 familiarize yourself with the JJB syntax. Our job definitions are stored in [Nordix Gerrit](https://gerrit.nordix.org/admin/repos/infra/cicd)
-instance under `cicd/jjb/airship/` path. Please, note that [cicd](https://gerrit.nordix.org/admin/repos/infra/cicd)
+instance under `cicd/jjb/metal3/` path. Please, note that [cicd](https://gerrit.nordix.org/admin/repos/infra/cicd)
 gerrit repository includes job defitinions for other projects as well that share the same Jenkins environment.
 
-When you add/remove a new job definition in `cicd/jjb/airship/` path, you will be able to see that job
-added/removed in Jenkins UI under [airship window](https://jenkins.nordix.org/view/Airship/).
+When you add/remove a new job definition in `cicd/jjb/metal3/` path, you will be able to see that job
+added/removed in Jenkins UI under the [Metal3 view](https://jenkins.nordix.org/view/Metal3/).
 
 ![webhook](images/jenkins_ui.png)
 
@@ -154,10 +154,10 @@ the integration tests.
 every night which will include pre-executed script for installing metal3
 requirements. The base volume then will be cloned and attached to the VM which
 will be running integration tests. The volume building script for Ubuntu can be
-found [here](https://github.com/Nordix/airship-dev-tools/blob/master/ci/images/gen_metal3_ubuntu_volume.sh).
+found [here](https://github.com/Nordix/metal3-dev-tools/blob/master/ci/images/gen_metal3_ubuntu_volume.sh).
 * Pre-baked image is used to speed up the integrations tests which comes with
 pre-baked Kubernetes executables. The image building script for CentOS can be
-found [here](https://github.com/Nordix/airship-dev-tools/blob/master/ci/images/gen_metal3_centos_image.sh).
+found [here](https://github.com/Nordix/metal3-dev-tools/blob/master/ci/images/gen_metal3_centos_image.sh).
 
 ## Contact
 

--- a/jenkins/scripts/bare_metal_lab/README.md
+++ b/jenkins/scripts/bare_metal_lab/README.md
@@ -26,5 +26,5 @@ You can trigger builds to run in the bare metal lab by adding the following line
 
 **Note:** Concurrent builds are disabled for the BML, since they would run on the same host and interfere with each other.
 This means that if there is already one build job running in the BML, a new one will not start before the first has finished.
-Github won't show the usual *Details* link for this specific run but build status can be checked from the [Jenkins dashboard](https://jenkins.nordix.org/job/airship_metal3io_project_infra_bml_integration_tests_centos/) where the build will be scheduled and stay in pending at this time.
+Github won't show the usual *Details* link for this specific run but build status can be checked from the [Jenkins dashboard](https://jenkins.nordix.org/job/metal3_metal3io_project_infra_bml_integration_tests_centos/) where the build will be scheduled and stay in pending at this time.
 Once the build starts, the status will be updated with a link.

--- a/jenkins/scripts/bare_metal_lab/deploy-lab.yaml
+++ b/jenkins/scripts/bare_metal_lab/deploy-lab.yaml
@@ -57,7 +57,7 @@
       ansible.builtin.find:
         paths: /home/{{ ansible_user_id }}
         recurse: no
-        patterns: "logs-jenkins-airship*"
+        patterns: "logs-jenkins-*"
         file_type: any
       register: old_logs
       tags: cleanup

--- a/jenkins/scripts/files/run_integration_tests.sh
+++ b/jenkins/scripts/files/run_integration_tests.sh
@@ -14,7 +14,7 @@ export DEFAULT_HOSTS_MEMORY
 export NUM_NODES
 export UPGRADE_TEST
 
-if [ "${REPO_NAME}" == "airship-dev-tools" ]
+if [ "${REPO_NAME}" == "metal3-dev-tools" ]
 then
   export IMAGE_NAME
   export IMAGE_LOCATION


### PR DESCRIPTION
Where credentials, repo names and JJB paths are mentioned in
project-infra, where airship was referenced, metal3 is now used instead.

TODO before merging:
* Rename airship-dev-tools -> metal3-dev-tools
* Rename airship -> metal3 in JJB directory and job names
* Update Nordix Jenkins view to Metal3 (referencing metal3 jobs)

Remaining to fix:
* airshipci username in images
* Environment variables in scripts named AIRSHIP

@kashifest @furkatgofurov7 