### PR TITLE
Use metal3ci user for CI runs

### DIFF
--- a/jenkins/jobs/integration_tests.pipeline
+++ b/jenkins/jobs/integration_tests.pipeline
@@ -41,13 +41,13 @@ script {
 pipeline {
   agent { label 'airship-static-workers' }
   environment {
-    AIRSHIP_CI_USER="airshipci"
+    AIRSHIP_CI_USER="metal3ci"
     REPO_ORG = "${PROJECT_REPO_ORG}"
     REPO_NAME = "${PROJECT_REPO_NAME}"
     UPDATED_REPO = "${ghprbAuthorRepoGitUrl}"
     REPO_BRANCH = "${ghprbTargetBranch}"
     UPDATED_BRANCH = "${ghprbActualCommit}"
-    OS_USERNAME="airshipci"
+    OS_USERNAME="metal3ci"
     OS_AUTH_URL="https://kna1.citycloud.com:5000"
     OS_USER_DOMAIN_NAME="CCP_Domain_37137"
     OS_PROJECT_DOMAIN_NAME="CCP_Domain_37137"

--- a/jenkins/jobs/integration_tests_clean.pipeline
+++ b/jenkins/jobs/integration_tests_clean.pipeline
@@ -18,7 +18,7 @@ script {
 pipeline {
   agent { label 'airship-static-workers' }
   environment {
-    OS_USERNAME="airshipci"
+    OS_USERNAME="metal3ci"
     OS_AUTH_URL="https://kna1.citycloud.com:5000"
     OS_USER_DOMAIN_NAME="CCP_Domain_37137"
     OS_PROJECT_DOMAIN_NAME="CCP_Domain_37137"

--- a/jenkins/scripts/files/run_fetch_logs.sh
+++ b/jenkins/scripts/files/run_fetch_logs.sh
@@ -51,7 +51,7 @@ done
 }
 
 # Fetch k8s logs
-fetch_k8s_logs "management_cluster" "/home/airshipci/.kube/config"
+fetch_k8s_logs "management_cluster" "/home/metal3ci/.kube/config"
 
 # Fetch Ironic containers logs before pivoting to the target cluster
 CONTAINER_LOGS_DIR="${LOGS_DIR}/${CONTAINER_RUNTIME}/before_pivoting"
@@ -82,7 +82,7 @@ sudo sh -c "cp -r /var/log/sysstat/* ${LOGS_DIR}/metrics/sysstat/"
 sudo chown -R "${USER}:${USER}" "${LOGS_DIR}/metrics"
 
 mkdir -p "${LOGS_DIR}/cluster-api-config"
-cp -r "/home/airshipci/.cluster-api/." "${LOGS_DIR}/cluster-api-config/"
+cp -r "/home/metal3ci/.cluster-api/." "${LOGS_DIR}/cluster-api-config/"
 
 if [[ "${TESTS_FOR}" == "feature_tests_upgrade"* ]]
 then


### PR DESCRIPTION
This will swap to use the metal3ci user in the image instead of the airshipci user. After this, other pipelines will be updated and then the old airshipci user can be removed from use.