### PR TITLE
Rename prefix of OpenStack networks from airship to metal3

### DIFF
--- a/jenkins/scripts/utils.sh
+++ b/jenkins/scripts/utils.sh
@@ -3,7 +3,7 @@
 # Global defines for Airship CI infrastructure
 # ============================================
 
-CI_EXT_NET="airship-ci-ext-net"
+CI_EXT_NET="metal3-ci-ext-net"
 CI_EXT_SUBNET_CIDR="10.100.10.0/24"
 CI_FLOATING_IP_NET="ext-net"
 CI_METAL3_IMAGE="airship-ci-ubuntu-metal3-img"


### PR DESCRIPTION
Network names was renamed in the CityCloud infra, where the Jenkins tests run.
Renaming it here too.
