### PR TITLE
Include ubuntu in status checks

### DIFF
--- a/jenkins/README.md
+++ b/jenkins/README.md
@@ -23,27 +23,22 @@ triggered on PR from metal3-dev-env, baremetal-operator, ironic-image, ip-addres
 and cluster-api-provider-metal3 repositories by commenting the commands below.
 The job result will be posted as a comment.
 
-* **/test-v1b1-integration** run integration tests for v1beta1 on Ubuntu
-* **/test-v1b1-centos-integration** run integration tests for v1beta1 on
-   CentOS
-* **/test-v1a5-integration** run integration tests for v1alpha5 on Ubuntu
-* **/test-v1a5-centos-integration** run integration tests for v1alpha5 on
-   CentOS
-* **/test-v1a4-integration** run integration tests for v1alpha4 on Ubuntu
-* **/test-v1a4-centos-integration** run integration tests for v1alpha4 on
-   CentOS
+* **/test-v1b1-ubuntu-integration** run integration tests for v1beta1 on Ubuntu
+* **/test-v1b1-centos-integration** run integration tests for v1beta1 on CentOS
+* **/test-v1a5-ubuntu-integration** run integration tests for v1alpha5 on Ubuntu
+* **/test-v1a5-centos-integration** run integration tests for v1alpha5 on CentOS
+* **/test-v1a4-ubuntu-integration** run integration tests for v1alpha4 on Ubuntu
+* **/test-v1a4-centos-integration** run integration tests for v1alpha4 on CentOS
 
 Usually, after the integration test part is completed, Jenkins executes another
 script to clean up the environment first and then deletes the VM. However, sometimes
 it may be desirable to keep the VM for debugging purposes. To avoid clean up
 and deletion operations, there are separate triggers phrases as below:
 
-* **/keep-test-v1b1-integration** run integration tests for v1beta1 on Ubuntu
-* **/keep-test-v1b1-centos-integration** run integration tests for v1beta1 on
-   CentOS
-* **/keep-test-v1a5-integration** run integration tests for v1alpha5 on Ubuntu
-* **/keep-test-v1a5-centos-integration** run integration tests for v1alpha5 on
-   CentOS
+* **/keep-test-v1b1-ubuntu-integration** run integration tests for v1beta1 on Ubuntu
+* **/keep-test-v1b1-centos-integration** run integration tests for v1beta1 on CentOS
+* **/keep-test-v1a5-ubuntu-integration** run integration tests for v1alpha5 on Ubuntu
+* **/keep-test-v1a5-centos-integration** run integration tests for v1alpha5 on CentOS
 
 Keep in mind that test VM created with these phrases will not be kept forever
 but deleted after 24 hours, to avoid garbage collection of VMs.

--- a/prow/config/config.yaml
+++ b/prow/config/config.yaml
@@ -88,50 +88,50 @@ branch-protection:
           branches:
             main:
               required_status_checks:
-                contexts: ["test-v1b1-centos-integration", "test-v1b1-integration"]
+                contexts: ["test-v1b1-centos-integration", "test-v1b1-ubuntu-integration"]
         cluster-api-provider-metal3:
           branches:
             main:
               required_status_checks:
-                contexts: ["test-v1b1-integration"]
+                contexts: ["test-v1b1-ubuntu-integration"]
             release-0.5:
               required_status_checks:
-                contexts: ["test-v1a5-integration"]
+                contexts: ["test-v1a5-ubuntu-integration"]
             release-0.4:
               required_status_checks:
-                contexts: ["test-v1a4-integration"]
+                contexts: ["test-v1a4-ubuntu-integration"]
         ironic-image:
           branches:
             main:
               required_status_checks:
-                contexts: ["test-v1b1-integration"]
+                contexts: ["test-v1b1-ubuntu-integration"]
         ironic-ipa-downloader:
           branches:
             main:
               required_status_checks:
-                contexts: ["test-v1b1-integration"]
+                contexts: ["test-v1b1-ubuntu-integration"]
         ip-address-manager:
           branches:
             main:
               required_status_checks:
-                contexts: ["test-v1b1-integration"]
+                contexts: ["test-v1b1-ubuntu-integration"]
             release-0.1:
               required_status_checks:
-                contexts: ["test-v1a5-integration"]
+                contexts: ["test-v1a5-ubuntu-integration"]
             release-0.0:
               required_status_checks:
-                contexts: ["test-v1a4-integration"]
+                contexts: ["test-v1a4-ubuntu-integration"]
         mariadb-image:
           required_status_checks:
-            contexts: ["test-v1b1-integration"]
+            contexts: ["test-v1b1-ubuntu-integration"]
         metal3-dev-env:
           branches:
             main:
               required_status_checks:
-                contexts: ["test-v1a5-centos-integration", "test-v1b1-integration"]
+                contexts: ["test-v1a5-centos-integration", "test-v1b1-ubuntu-integration"]
             master:
               required_status_checks:
-                contexts: ["test-v1a5-centos-integration", "test-v1b1-integration"]
+                contexts: ["test-v1a5-centos-integration", "test-v1b1-ubuntu-integration"]
 
 
 deck:


### PR DESCRIPTION
This makes the required status checks symmetrical, i.e. they always include
"ubuntu" or "centos" in the name instead of taking the absense of
"centos" as "ubuntu". Spelling out the OS makes it easier to understand
and enables parametrization in JJB.