### PR TITLE
🐛 Fix TESTS_FOR value check for ubuntu feature tests

### DIFF
--- a/jenkins/scripts/files/run_integration_tests.sh
+++ b/jenkins/scripts/files/run_integration_tests.sh
@@ -91,7 +91,7 @@ if [[ "${TESTS_FOR}" == "feature_tests_upgrade"* ]]
 then
   export NODE_DRAIN_TIMEOUT="300s"
   make "${TESTS_FOR}"
-elif [[ "${TESTS_FOR}" == "feature_tests" || "${TESTS_FOR}" == "feature_tests_centos" ]]
+elif [[ "${TESTS_FOR}" == "feature_tests_ubuntu" || "${TESTS_FOR}" == "feature_tests_centos" ]]
 then
   make feature_tests
 elif [[ "${TESTS_FOR}" == "e2e_tests" ]]


### PR DESCRIPTION
It used to check for feature_tests or feature_tests_centos, but now it
is in fact feature_tests_ubuntu or feature_tests_centos.

This change in the value was caused by https://gerrit.nordix.org/c/infra/cicd/+/12409 and I didn't realize it.