### PR TITLE
Retry openstack server creation if unhealthy

### DIFF
--- a/jenkins/scripts/utils.sh
+++ b/jenkins/scripts/utils.sh
@@ -45,3 +45,51 @@ wait_for_ssh() {
 
   echo "SSH connection to host[${SERVER}] is up."
 }
+
+# Description:
+# Check that the VM is in working condition, e.g. that the file-system is
+# resized properly.
+#
+# Usage:
+#   vm_healthy <ssh_user> <ssh_key_path> <server>
+vm_healthy() {
+  local USER KEY SERVER
+
+  USER="${1:?}"
+  KEY="${2:?}"
+  SERVER="${3:?}"
+
+  # CentOS has a cloud-init error all the time so we cannot rely on cloud-init
+  # to check if it is healthy or not.
+  # TODO: Fix cloud-init error on centos so we can remove this special check
+  if [ "${IMAGE_OS}" == "centos" ]; then
+    lsblk_out=$(ssh -o ConnectTimeout=2 -o StrictHostKeyChecking=no \
+      -o UserKnownHostsFile=/dev/null -i "${KEY}" \
+      "${USER}"@"${SERVER}" lsblk --json)
+    disk_data="$(echo "${lsblk_out}" | jq -r '.blockdevices[] | select(.name == "vda") | {disk_size: .size, part_size: .children[0].size}')"
+    disk_size="$(echo "${disk_data}" | jq -r '.disk_size')"
+    part_size="$(echo "${disk_data}" | jq -r '.part_size')"
+
+    if [ "${disk_size}" == "${part_size}" ]; then
+      echo "Filesystem was resized successfully!"
+      return 0
+    else
+      echo "Filesystem resizing failed!"
+      echo "Disk size: ${disk_size}"
+      echo "Partition size: ${part_size}"
+      return 1
+    fi
+  fi
+
+  cloud_init_status=$(ssh -o ConnectTimeout=2 -o StrictHostKeyChecking=no \
+    -o UserKnownHostsFile=/dev/null -i "${KEY}" \
+    "${USER}"@"${SERVER}" cloud-init status --long --wait)
+  if echo "${cloud_init_status}" | grep "error"; then
+    echo "There was a cloud-init error:"
+    echo "${cloud_init_status}"
+    return 1
+  else
+    echo "Cloud-init completed sucessfully!"
+    return 0
+  fi
+}


### PR DESCRIPTION
This is an attempt to work around the "no space" issue that is caused by a failed filesystem resize.

You can see the retry working in this run: https://jenkins.nordix.org/job/metal3_project_infra_v1a5_integration_test_centos/38/console
Unfortunately it failed later while deprovisioning, but everything else worked. It is quite hard to reproduce the issue so I have not tried to get another successful run with the retry.
I used a temporary commit for running in Fra1 to reproduce it more easily. This is now removed.
