### PR TITLE
Change git diff logic in custom skip integration script

### DIFF
--- a/jenkins/scripts/skip_integration_test.sh
+++ b/jenkins/scripts/skip_integration_test.sh
@@ -40,8 +40,11 @@ exclude_markdown_and_owners_files() {
 # otherwise check the updated branch to decide on whether skipping or running 
 # the integration tests.
 if [[ "${UPDATED_BRANCH}" == "${REPO_BRANCH}" ]] && [[ "${UPDATED_REPO}" == *"${REPO_ORG}/${REPO_NAME}"* ]]; then
+  echo "Main job is runnning, not skipping integration tests"
   return 1
 else
+  echo "Clone updated repo"
   gclonecd $UPDATED_REPO
+  echo "Run skipping the integration test custom script to find out git diff"
   exclude_markdown_and_owners_files
 fi

--- a/jenkins/scripts/skip_integration_test.sh
+++ b/jenkins/scripts/skip_integration_test.sh
@@ -18,7 +18,7 @@ gclonecd () {
 # OWNERS file, return exit code (rc): 0 to skip integration tests, otherwise 
 # return 1 to run integration tests
 exclude_markdown_and_owners_files() {
-  for file in $(git diff "${UPDATED_BRANCH}" origin/"${REPO_BRANCH}" --name-only)
+  for file in $(git diff origin/"${REPO_BRANCH}"..."${UPDATED_BRANCH}" --name-only)
   do
     filename=$(basename -- "$file")
     extension="${filename##*.}"


### PR DESCRIPTION
This PR changes the way how we find out the changes made in the PR when custom skipping integration tests are used. The problem with the current implementation is, it does not consider the case, where for example the PR branch opened some time ago falls behind the origin branch it checked out (the branch is ahead of its checked out branch X commits and behind it, Y commits), then, git diff outputs all the changes that went in with Y commits since we are doing comparison from current branch against origin/{default_branch}. 
Now, this is done in a way that we look for all changes on the current branch since the branch start point as [here](https://stackoverflow.com/questions/29810331/is-there-a-quick-way-to-git-diff-from-the-point-or-branch-origin). 
