### PR TITLE
Temporary fix while Nordix registry is down

### DIFF
--- a/jenkins/scripts/integration_test_env.sh
+++ b/jenkins/scripts/integration_test_env.sh
@@ -90,5 +90,6 @@ METAL3REPO="${METAL3REPO:-https://github.com/metal3-io/metal3-dev-env.git}"
 METAL3BRANCH="${METAL3BRANCH:-main}"
 
 # Container image registry value to override the default value in m3-dev-env
-export CONTAINER_REGISTRY=${CONTAINER_REGISTRY:-"registry.nordix.org/quay-io-proxy"}
-export DOCKER_HUB_PROXY=${DOCKER_HUB_PROXY:-"registry.nordix.org/docker-hub-proxy"}
+# TEMP: Commented out while waiting for nordics registry to come back up.
+# export CONTAINER_REGISTRY=${CONTAINER_REGISTRY:-"registry.nordix.org/quay-io-proxy"}
+# export DOCKER_HUB_PROXY=${DOCKER_HUB_PROXY:-"registry.nordix.org/docker-hub-proxy"}


### PR DESCRIPTION
Use upstream quay and docker hub while we wait for Nordix registry to be back up again.