### PR TITLE
Run BML test with updated code on metal3-dev-env.

### DIFF
--- a/jenkins/scripts/bare_metal_lab/deploy-lab.yaml
+++ b/jenkins/scripts/bare_metal_lab/deploy-lab.yaml
@@ -3,17 +3,16 @@
     bml_ilo_username: "{{ lookup('env', 'BML_ILO_USERNAME') }}"
     bml_ilo_password: "{{ lookup('env', 'BML_ILO_PASSWORD') }}"
     github_token: "{{ lookup('env', 'GITHUB_TOKEN') }}"
+    metal3_dev_env_repo: "{{ lookup('env', 'BML_METAL3_DEV_ENV_REPO') }}"
+    metal3_dev_env_branch: "{{ lookup('env', 'BML_METAL3_DEV_ENV_BRANCH') }}"
+    node_ips:
+      - "192.168.1.12"
+      - "192.168.1.15"
+    serial_log_location: "/tmp/BMLlog"
   environment:
     EPHEMERAL_CLUSTER: "minikube"
     EXTERNAL_VLAN_ID: 3
   tasks:
-    - name: set_fact
-      set_fact:
-        node_ips:
-          - "192.168.1.12"
-          - "192.168.1.15"
-        serial_log_location: "/tmp/BMLlog"
-
     - name: Check required env vars are set
       fail:
         msg: Ensure that BML_ILO_USERNAME, BML_ILO_PASSWORD and GITHUB_TOKEN environment variables are set
@@ -117,9 +116,9 @@
 
     - name: Clone the metal3-dev-env repo
       git:
-        repo: https://github.com/metal3-io/metal3-dev-env.git
+        repo: "{{ metal3_dev_env_repo }}"
         dest: "/home/{{ ansible_user_id }}/metal3-dev-env"
-        version: main
+        version: "{{ metal3_dev_env_branch }}"
       tags: git
 
     - name: Clean any existing setup

--- a/jenkins/scripts/bml_integration_test.sh
+++ b/jenkins/scripts/bml_integration_test.sh
@@ -1,6 +1,6 @@
 #! /usr/bin/env bash
 
-set -eu
+set -xeu
 
 # Description:
 #   Runs the integration tests for metal3-dev-env in the BML
@@ -24,6 +24,14 @@ REPO_NAME="${REPO_NAME:-metal3-dev-env}"
 REPO_BRANCH="${REPO_BRANCH:-main}"
 UPDATED_REPO="${UPDATED_REPO:-https://github.com/${REPO_ORG}/${REPO_NAME}.git}"
 UPDATED_BRANCH="${UPDATED_BRANCH:-main}"
+if [[ "${REPO_NAME}" == "metal3-dev-env" ]]; then
+  export BML_METAL3_DEV_ENV_REPO="${UPDATED_REPO}"
+  export BML_METAL3_DEV_ENV_BRANCH="${UPDATED_BRANCH}"
+else
+  export BML_METAL3_DEV_ENV_REPO="https://github.com/metal3-io/metal3-dev-env.git"
+  export BML_METAL3_DEV_ENV_BRANCH="main"
+fi
+
 CAPI_VERSION="${CAPI_VERSION:-v1beta1}"
 CAPM3_VERSION="${CAPM3_VERSION:-v1beta1}"
 NUM_NODES="${NUM_NODES:-2}"
@@ -77,6 +85,8 @@ ssh \
   -o SendEnv="BML_ILO_USERNAME" \
   -o SendEnv="BML_ILO_PASSWORD" \
   -o SendEnv="GITHUB_TOKEN" \
+  -o SendEnv="BML_METAL3_DEV_ENV_REPO" \
+  -o SendEnv="BML_METAL3_DEV_ENV_BRANCH" \
   ansible-playbook /tmp/bare_metal_lab/deploy-lab.yaml
 
 echo "Running the tests"


### PR DESCRIPTION
Currently, triggering the BML test on metal3-dev-env can only test the main branch of metal3-dev-env. This PR makes it test the patch in the PR where the test is triggered. 