### PR TITLE
Remove workaround for "no-space" issue

### DIFF
--- a/jenkins/scripts/integration_test.sh
+++ b/jenkins/scripts/integration_test.sh
@@ -108,39 +108,13 @@ then
   "$FLOATING_IP"
 fi
 
-for i in {1..6}; do
-  echo "Waiting for the host ${TEST_EXECUTER_VM_NAME} to come up"
-  # Wait for the host to come up
-  wait_for_ssh "${METAL3_CI_USER}" "${METAL3_CI_USER_KEY}" "${TEST_EXECUTER_IP}"
-  if vm_healthy "${METAL3_CI_USER}" "${METAL3_CI_USER_KEY}" "${TEST_EXECUTER_IP}"; then
-    break
-  else
-    if [ ${i} -eq 5 ]; then
-      echo "Server is still unhealthy after retry. Giving up."
-      exit 1
-    fi
-    echo "Trying to create server again. Retry ${i}/5"
-    echo "Deleting unhealthy server ${TEST_EXECUTER_VM_NAME}..."
-    openstack server delete "${TEST_EXECUTER_VM_NAME}"
-    echo "Server ${TEST_EXECUTER_VM_NAME} deleted."
-
-    # Create new executer vm
-    echo "Recreating server ${TEST_EXECUTER_VM_NAME}"
-    openstack server create -f json \
-      --image "${IMAGE_NAME}" \
-      --flavor "${TEST_EXECUTER_FLAVOR}" \
-      --port "${EXT_PORT_ID}" \
-      "${TEST_EXECUTER_VM_NAME}" | jq -r '.id'
-
-    if [[ "$OS_REGION_NAME" != "Kna1" ]]
-    then
-      # Attach floating IP
-      openstack server add floating ip \
-        "${TEST_EXECUTER_VM_NAME}" \
-        "$FLOATING_IP"
-    fi
-  fi
-done
+echo "Waiting for the host ${TEST_EXECUTER_VM_NAME} to come up"
+# Wait for the host to come up
+wait_for_ssh "${METAL3_CI_USER}" "${METAL3_CI_USER_KEY}" "${TEST_EXECUTER_IP}"
+if ! vm_healthy "${METAL3_CI_USER}" "${METAL3_CI_USER_KEY}" "${TEST_EXECUTER_IP}"; then
+  echo "Server is unhealthy. Giving up."
+  exit 1
+fi
 
 cat <<-EOF >> "${CI_DIR}/files/vars.sh"
 REPO_ORG="${REPO_ORG}"

--- a/jenkins/scripts/utils.sh
+++ b/jenkins/scripts/utils.sh
@@ -47,8 +47,7 @@ wait_for_ssh() {
 }
 
 # Description:
-# Check that the VM is in working condition, e.g. that the file-system is
-# resized properly.
+# Check that cloud-init completed successfully.
 #
 # Usage:
 #   vm_healthy <ssh_user> <ssh_key_path> <server>
@@ -58,28 +57,6 @@ vm_healthy() {
   USER="${1:?}"
   KEY="${2:?}"
   SERVER="${3:?}"
-
-  # CentOS has a cloud-init error all the time so we cannot rely on cloud-init
-  # to check if it is healthy or not.
-  # TODO: Fix cloud-init error on centos so we can remove this special check
-  if [ "${IMAGE_OS}" == "centos" ]; then
-    lsblk_out=$(ssh -o ConnectTimeout=2 -o StrictHostKeyChecking=no \
-      -o UserKnownHostsFile=/dev/null -i "${KEY}" \
-      "${USER}"@"${SERVER}" lsblk --json)
-    disk_data="$(echo "${lsblk_out}" | jq -r '.blockdevices[] | select(.name == "vda") | {disk_size: .size, part_size: .children[0].size}')"
-    disk_size="$(echo "${disk_data}" | jq -r '.disk_size')"
-    part_size="$(echo "${disk_data}" | jq -r '.part_size')"
-
-    if [ "${disk_size}" == "${part_size}" ]; then
-      echo "Filesystem was resized successfully!"
-      return 0
-    else
-      echo "Filesystem resizing failed!"
-      echo "Disk size: ${disk_size}"
-      echo "Partition size: ${part_size}"
-      return 1
-    fi
-  fi
 
   cloud_init_status=$(ssh -o ConnectTimeout=2 -o StrictHostKeyChecking=no \
     -o UserKnownHostsFile=/dev/null -i "${KEY}" \


### PR DESCRIPTION
The issue should now be fixed and we can rely on checking cloud-init status instead of comparing filesystem and disk sizes. The retry for server creation was also removed since we do not expect there to be issues that can be solved by recreating the server anymore.