### PR TITLE
Fix MinIO image to RELEASE.2022-04-29T01-27-09Z

### DIFF
--- a/prow/manifests/starter.yaml
+++ b/prow/manifests/starter.yaml
@@ -1367,7 +1367,7 @@ spec:
     spec:
       containers:
       - name: minio
-        image: minio/minio:latest
+        image: minio/minio:RELEASE.2022-04-29T01-27-09Z
         args:
         - gateway
         - azure
@@ -1381,6 +1381,7 @@ spec:
           value: minio
         ports:
         - containerPort: 9000
+        imagePullPolicy: IfNotPresent
         readinessProbe:
           httpGet:
             path: /minio/health/ready


### PR DESCRIPTION
Recent releases starting from docker `RELEASE.2022-04-30T22-23-53Z` have dropped the support for the Azure gateway mode. And for those who are interested in continuing the usage of Azure gateway mode using releases prior to `RELEASE.2022-04-30T22-23-53Z` is suggested in https://github.com/minio/minio/issues/14331#issuecomment-1058639010. As such, we are rolling back the image version from being latest to the `RELEASE.2022-04-29T01-27-09Z`, which is the latest&last release before the drop of the Azure gateway mode support. 

Also changed the image pull policy to be the `IfNotPresent` so that deployment doesn't try to pull the image from the internet and instead uses that one available locally, which is good enough for our case.