### PR TITLE
Pin node image to be used in BML to CentOS8 Stream k8s v1.23.3

### DIFF
--- a/jenkins/scripts/files/run_integration_tests.sh
+++ b/jenkins/scripts/files/run_integration_tests.sh
@@ -101,6 +101,9 @@ then
   # https://wiki.nordix.org/pages/viewpage.action?spaceKey=CPI&title=Bare+Metal+Lab
   # In the bare metal lab, the external network has vlan id 3
   export EXTERNAL_VLAN_ID="3"
+  # Pin node image to be used in BML to CENTOS_8_NODE_IMAGE_K8S_v1.23.3.qcow2
+  export IMAGE_NAME="CENTOS_8_NODE_IMAGE_K8S_v1.23.3.qcow2"
+  export IMAGE_LOCATION="https://artifactory.nordix.org/artifactory/metal3/images/k8s_v1.23.3"
   make test
   exit 0
 fi


### PR DESCRIPTION
[BML tests](https://jenkins.nordix.org/view/Metal3%20Main/job/metal3_main_bml_integration_tests_centos/) in CI have been failing for some time and the tests we have done show that either introduction of CentOS9 stream: https://github.com/Nordix/metal3-dev-tools/commit/0d3e5cc313999e95e6a8e71842aafcd942ee0b48 or cloud-init changes: https://github.com/Nordix/metal3-dev-tools/commit/c5213dcd4582c6cb15d1873df70d8494a7a2c59f related to centos node image buildings, OR a combination of both, might have broken it. See the list of different tests run using different node images here: https://github.com/metal3-io/project-infra/pull/377#issuecomment-1128135511. For now, we can pin the node images used in BML to get the CI going.