### PR TITLE
Fix fetching e2e logs

### DIFF
--- a/jenkins/scripts/files/run_fetch_logs.sh
+++ b/jenkins/scripts/files/run_fetch_logs.sh
@@ -22,7 +22,13 @@ cp -r /tmp/manifests/* "${LOGS_DIR}/manifests"
 
 if [[ "${TESTS_FOR}" == "e2e_tests"* ]]; then
   mkdir -p "${LOGS_DIR}/e2e_artifacts"
-  cp -r /home/metal3ci/tested_repo/_artifacts/. "${LOGS_DIR}/e2e_artifacts"
+    # only if we triggered the e2e from the capm3 repo it will be cloned under tested_repo
+    # else it is under metal3
+    if [[ -d "/home/metal3ci/tested_repo/_artifacts" ]]; then
+      cp -r /home/metal3ci/tested_repo/_artifacts/ "${LOGS_DIR}/e2e_artifacts"
+    else
+      cp -r /home/metal3ci/metal3/_artifacts/ "${LOGS_DIR}/e2e_artifacts"
+    fi
 fi
 
 function fetch_k8s_logs() {

--- a/jenkins/scripts/files/run_integration_tests.sh
+++ b/jenkins/scripts/files/run_integration_tests.sh
@@ -66,7 +66,7 @@ fi
 cd "/home/${USER}"
 
 
-if [ "${IMAGE_OS}" == "ubuntu" ]; then
+if [[ "${IMAGE_OS}" == "ubuntu" ]]; then
   #Must match with run_fetch_logs.sh
   export CONTAINER_RUNTIME="docker"
   export EPHEMERAL_CLUSTER="kind"
@@ -75,7 +75,7 @@ else
 fi
 if [[ "${TESTS_FOR}" != "e2e_tests" ]]; then
 # If we are testing metal3-dev-env, it will already be cloned to tested_repo
-  if [ "${REPO_NAME}" == "metal3-dev-env" ]
+  if [[ "${REPO_NAME}" == "metal3-dev-env" ]]
   then
     pushd tested_repo
   else
@@ -84,7 +84,7 @@ if [[ "${TESTS_FOR}" != "e2e_tests" ]]; then
     git checkout "${METAL3BRANCH}"
   fi
 else
-  if [ "${REPO_NAME}" == "cluster-api-provider-"* ]
+  if [[ "${REPO_NAME}" == "cluster-api-provider-"* ]]
   then
     pushd tested_repo
   else


### PR DESCRIPTION
The condition `'[' cluster-api-provider-metal3 == 'cluster-api-provider-*' ']'`  [here](https://github.com/metal3-io/project-infra/blob/5ae9c8bcaccfb092350301c35dd7f446478c96de/jenkins/scripts/files/run_integration_tests.sh#L87)  was resulting in `false` while it should be `true`  and this because the pattern matching works only with double brackets so we need to use double `[[` instead of` [ `

Also this PR add the correct path to fetch logs when the e2e triggered from other repos