### PR TITLE
Handle floating ip deletion error

### DIFF
--- a/jenkins/scripts/integration_delete.sh
+++ b/jenkins/scripts/integration_delete.sh
@@ -40,7 +40,7 @@ then
   echo "Executer floating IP ${TEST_EXECUTER_FIP_ID} is deleted."
 
   # Check and delete orphaned floating IPs
-  openstack floating ip list --status "DOWN" --column "ID" -f json | jq --raw-output '.[]."ID"' | xargs -0 openstack floating ip delete
+  openstack floating ip list --status "DOWN" --column "ID" -f json | jq --raw-output '.[]."ID"' | xargs -0 openstack floating ip delete || true
 fi
 
 # Delete executer vm


### PR DESCRIPTION
This commit makes the Fra1 floating IP deletion command a non
blocking action. This change was needed because there could be
provider side issues that might block deltion or there could be no
IP to delete and that would also cause an error response that would
break the VM deletion workflow.