### PR TITLE
Fix capm3 cleaning issue

### DIFF
--- a/jenkins/scripts/files/run_clean.sh
+++ b/jenkins/scripts/files/run_clean.sh
@@ -4,6 +4,7 @@ set -eux
 
 REPO_NAME="${1:-metal3-dev-env}"
 IMAGE_OS="${2:-ubuntu}"
+TESTS_FOR="${3:-e2e_tests}"
 
 if [ "${IMAGE_OS}" == "ubuntu" ]; then
   export CONTAINER_RUNTIME="docker"
@@ -11,9 +12,9 @@ if [ "${IMAGE_OS}" == "ubuntu" ]; then
 else
   export EPHEMERAL_CLUSTER="minikube"
 fi
-
-if [ "${REPO_NAME}" == "metal3-dev-env" ]
-then
+if [[ ("${TESTS_FOR}" != "e2e_tests" && "${REPO_NAME}" == "metal3-dev-env") ||
+      ("${TESTS_FOR}" == "e2e_tests" && "${REPO_NAME}" == "cluster-api-provider-metal3") 
+  ]]; then
   pushd tested_repo
 else
   pushd metal3

--- a/jenkins/scripts/files/run_integration_tests.sh
+++ b/jenkins/scripts/files/run_integration_tests.sh
@@ -73,27 +73,21 @@ if [[ "${IMAGE_OS}" == "ubuntu" ]]; then
 else
   export EPHEMERAL_CLUSTER="minikube"
 fi
-if [[ "${TESTS_FOR}" != "e2e_tests" ]]; then
-# If we are testing metal3-dev-env, it will already be cloned to tested_repo
-  if [[ "${REPO_NAME}" == "metal3-dev-env" ]]
-  then
-    pushd tested_repo
-  else
-    git clone "${METAL3REPO}" metal3
-    pushd metal3
-    git checkout "${METAL3BRANCH}"
-  fi
+if [[ ("${TESTS_FOR}" != "e2e_tests" && "${REPO_NAME}" == "metal3-dev-env") ||
+      ("${TESTS_FOR}" == "e2e_tests" && "${REPO_NAME}" == "cluster-api-provider-metal3") 
+  ]]; then
+  # If we are testing ansible test from metal3-dev-env or e2e from capm3,
+  # it will already be cloned to tested_repo
+  pushd tested_repo
+elif [[ "${REPO_NAME}" == "cluster-api-provider-metal3" ]]; then
+  git clone "${CAPM3REPO}" metal3
+  pushd metal3
+  git checkout "${CAPM3BRANCH}"
 else
-  if [[ "${REPO_NAME}" == "cluster-api-provider-"* ]]
-  then
-    pushd tested_repo
-  else
-    git clone "${CAPM3REPO}" metal3
-    pushd metal3
-    git checkout "${CAPM3BRANCH}"
-  fi
+  git clone "${METAL3REPO}" metal3
+  pushd metal3
+  git checkout "${METAL3BRANCH}"
 fi
-
 
 if [[ ${BARE_METAL_LAB} == "true" ]]
 then

--- a/jenkins/scripts/integration_test_clean.sh
+++ b/jenkins/scripts/integration_test_clean.sh
@@ -60,4 +60,4 @@ ssh \
   -i "${METAL3_CI_USER_KEY}" \
   "${METAL3_CI_USER}"@"${TEST_EXECUTER_IP}" \
   PATH=/usr/local/bin:/usr/bin:/usr/local/sbin:/usr/sbin:/sbin:/bin \
-  /tmp/run_clean.sh "${REPO_NAME}" "${IMAGE_OS}"
+  /tmp/run_clean.sh "${REPO_NAME}" "${IMAGE_OS}" "${TESTS_FOR}"

--- a/jenkins/scripts/integration_test_env.sh
+++ b/jenkins/scripts/integration_test_env.sh
@@ -56,7 +56,7 @@ elif [ "${REPO_NAME}" == "ironic-ipa-downloader" ]
 then
   export IPA_DOWNLOADER_LOCAL_IMAGE="/home/${USER}/tested_repo"
 
-elif [[ "${REPO_NAME}" == "cluster-api-provider-"* ]]
+elif [[ "${REPO_NAME}" == "cluster-api-provider-metal3" ]]
 then
   export CAPM3REPO="${UPDATED_REPO}"
   export CAPM3BRANCH="${UPDATED_BRANCH}"


### PR DESCRIPTION
This PR fixes the issue : `/tmp/run_clean.sh: line 19: pushd: metal3: No such file or directory` when running e2e from capm3 repo