### PR TITLE
Add verbosity to bm lab integration test

### DIFF
--- a/jenkins/scripts/bml_integration_test.sh
+++ b/jenkins/scripts/bml_integration_test.sh
@@ -87,7 +87,7 @@ ssh \
   -o SendEnv="GITHUB_TOKEN" \
   -o SendEnv="BML_METAL3_DEV_ENV_REPO" \
   -o SendEnv="BML_METAL3_DEV_ENV_BRANCH" \
-  ansible-playbook /tmp/bare_metal_lab/deploy-lab.yaml
+  ANSIBLE_FORCE_COLOR=true ansible-playbook -v /tmp/bare_metal_lab/deploy-lab.yaml
 
 echo "Running the tests"
 # Execute remote script


### PR DESCRIPTION
There was no verbosity at the beginning of the BM deployment. This will help us to debug the test.