### PR TITLE
Update the name of BMHs in CRs

### DIFF
--- a/jenkins/scripts/bare_metal_lab/templates/bmhosts_crs.yaml.j2
+++ b/jenkins/scripts/bare_metal_lab/templates/bmhosts_crs.yaml.j2
@@ -20,7 +20,7 @@ data:
 apiVersion: metal3.io/v1alpha1
 kind: BareMetalHost
 metadata:
-  name: eselda13u31s03.est.lan
+  name: eselda13u31s03
 spec:
   online: true
   bootMACAddress: b4:b5:2f:6d:89:d8
@@ -33,7 +33,7 @@ spec:
 apiVersion: metal3.io/v1alpha1
 kind: BareMetalHost
 metadata:
-  name: eselda13u31s06.est.lan
+  name: eselda13u31s06
 spec:
   online: true
   bootMACAddress: B4:B5:2F:6D:68:10


### PR DESCRIPTION
changing eselda13u31s03.est.lan to eselda13u31s03. Recently BML main jobs are failing due to regex complaining about the provider ID format which containe BMH name. This PR attempts to simplify BMH name to avoid having special characters like `.` in the name. '