### PR TITLE
Fix ginkgo_focus null string value

### DIFF
--- a/jenkins/scripts/files/run_integration_tests.sh
+++ b/jenkins/scripts/files/run_integration_tests.sh
@@ -32,6 +32,11 @@ then
   unset NUM_NODES
 fi
 
+if [ "${GINKGO_FOCUS}" == "null" ]
+then
+  unset GINKGO_FOCUS
+fi
+
 if [ "${EPHEMERAL_TEST}" == "null" ]
 then
   unset EPHEMERAL_TEST


### PR DESCRIPTION
the script writes `'null'` in the vars file when ginkgo_focus is undefined 