### PR TITLE
Fix k8s version to 1.23.x for v1alpha5

### DIFF
--- a/jenkins/scripts/files/run_integration_tests.sh
+++ b/jenkins/scripts/files/run_integration_tests.sh
@@ -27,6 +27,11 @@ then
   export KUBERNETES_VERSION="v1.21.2"
 fi
 
+if [ "${CAPM3_VERSION}" == "v1alpha5" ]
+then
+  export KUBERNETES_VERSION="v1.23.5"
+fi
+
 if [ "${NUM_NODES}" == "null" ]
 then
   unset NUM_NODES

--- a/prow/config/config.yaml
+++ b/prow/config/config.yaml
@@ -129,9 +129,6 @@ branch-protection:
             main:
               required_status_checks:
                 contexts: ["test-v1a5-centos-integration", "test-v1b1-ubuntu-integration"]
-            master:
-              required_status_checks:
-                contexts: ["test-v1a5-centos-integration", "test-v1b1-ubuntu-integration"]
 
 
 deck:


### PR DESCRIPTION
- Currently CAPI clusterctl for v1alpha4 doesnt support 1.24.x due to the removal of the master taint. Until that is fixed upstream we need to run v1a5 with 1.23.x only.
- Remove master reference for m3-dev-env. Master branch for this repo has been removed. 