### PR TITLE
🐛 Prow: Add missing branch name configuration for mariadb-image repo

### DIFF
--- a/prow/config/config.yaml
+++ b/prow/config/config.yaml
@@ -116,8 +116,10 @@ branch-protection:
               required_status_checks:
                 contexts: ["test-ubuntu-integration-release-0-5"]
         mariadb-image:
-          required_status_checks:
-            contexts: ["test-ubuntu-integration-main"]
+          branches:
+            main:
+              required_status_checks:
+                contexts: ["test-ubuntu-integration-main"]
         metal3-dev-env:
           branches:
             main:


### PR DESCRIPTION
Configuration for enabling integration tests in the mariadb-image repo landed a long time ago, but it was missing to configure branch name for the repo, and this should fix it.  

See: https://github.com/metal3-io/mariadb-image/pull/2