### PR TITLE
Add main branch centos test as required for metal3-dev-env

### DIFF
--- a/prow/config/config.yaml
+++ b/prow/config/config.yaml
@@ -124,7 +124,7 @@ branch-protection:
           branches:
             main:
               required_status_checks:
-                contexts: ["test-centos-integration-release-0-5", "test-ubuntu-integration-main"]
+                contexts: ["test-centos-integration-main", "test-ubuntu-integration-main"]
 
 
 deck:


### PR DESCRIPTION
Since CAPI has stopped supporting CAPI v1a4 which is equivalent to CAPM3
v1a5, it doesnt make any sense to keep testing v1a5/release-0.5 branch
as a required test. We are not dropping support yet but perhaps it
should not run as a required test on dev-env PRs.