### PR TITLE
🐛 Properly delete all orphaned floating IPs from Fra1 region

### DIFF
--- a/jenkins/scripts/integration_delete.sh
+++ b/jenkins/scripts/integration_delete.sh
@@ -40,7 +40,14 @@ then
   echo "Executer floating IP ${TEST_EXECUTER_FIP_ID} is deleted."
 
   # Check and delete orphaned floating IPs
-  openstack floating ip list --status "DOWN" --column "ID" -f json | jq --raw-output '.[]."ID"' | xargs -0 openstack floating ip delete || true
+  echo "Checking if there are any existing orphaned floating IPs"
+  ORPHANED_FLOATING_IP_LIST="$(openstack floating ip list --status "DOWN" --column "ID" -f json | jq --raw-output '.[]."ID"')"
+  if [ -z "$ORPHANED_FLOATING_IP_LIST" ]; then
+    echo "Orphaned floating IPs are not found."
+  else
+    echo "Deleting all orphaned floating IP addresses."
+    for floating_ip in $ORPHANED_FLOATING_IP_LIST; do openstack floating ip delete $floating_ip; done
+  fi
 fi
 
 # Delete executer vm


### PR DESCRIPTION
When running tests (e2e) in Fra1 region, orphaned floating IP deletion succeeds only to delete a single floating IP and leaves out other IPs if there are bunch of them. We have seen these when we exhausted floating IPs in jobs: https://jenkins.nordix.org/job/metal3_keep_capm3_main_e2e_test_centos/13/console

Log from CI when floating IP deletion happens:

```
Running in region: Fra1
The option [tenant_id] has been deprecated. Please avoid using it.
Deleting executer floating IP da6e3ada-5ea9-4b58-b707-9f34d983c5aa.
The option [tenant_id] has been deprecated. Please avoid using it.
Executer floating IP da6e3ada-5ea9-4b58-b707-9f34d983c5aa is deleted.
The option [tenant_id] has been deprecated. Please avoid using it.
The option [tenant_id] has been deprecated. Please avoid using it.
Failed to delete floating_ip with name or ID '09c69e8d-13ae-465d-8022-4ca2fc836535
110ce372-8dda-4481-b0de-70d679251c63
3c13f9ec-a935-4dc2-954a-82047e1a667a
3cd888fb-4e07-45a0-974f-e88e15867f14
4260ba7c-a429-43b1-81cf-447f5ccff3a4
42d46c31-9622-4c38-ad80-e046e2a3a2d0
49c14b89-b9dd-4d69-8f3b-919cbc9fafeb
49f013a0-e87c-4ae8-b702-9879c7c8a9b4
50b54daa-61a2-4611-89e3-13e6d8cef832
55ac36e6-ac18-47d5-878c-26e76dec35c5
578f7530-7566-4265-aa9d-6f142c0ecf9f
6230557f-4c15-46a9-a96e-67b8a2476003
62788957-7acf-481a-8cb9-428cfd7ecd89
70353206-aec1-4223-b48f-13b8aec01106
7f81881e-c9a0-4152-b2d9-67aa32f9285b
8247d1cd-2743-4fdc-ab6e-81a353e7ddfd
a1bb7512-3701-49ad-8862-f48d4a6ea379
a57c0b80-8a8a-4350-9413-9182a0132b13
ae8b5d10-514b-46c5-8420-eaa54d726f75
b16920c7-2b17-46ac-a08e-f9066a7a4999
c3e8f9ff-81a7-4630-8efe-24d38499771d
d924d254-62e2-4b58-ba4c-71994d3080d1
de26bcbd-b8a1-46a3-b202-9adc7c11e418
e1063090-f4f1-40db-a4e6-5a2c1396a858
e1800f66-ffbc-45aa-a3f7-2edd1b5ad74e
e41a140b-392d-4712-9b07-40b310b8dc7b
ede26932-6aa4-45fe-ad22-86385315aaaf
': No FloatingIP found for 09c69e8d-13ae-465d-8022-4ca2fc836535
110ce372-8dda-4481-b0de-70d679251c63
3c13f9ec-a935-4dc2-954a-82047e1a667a
3cd888fb-4e07-45a0-974f-e88e15867f14
4260ba7c-a429-43b1-81cf-447f5ccff3a4
42d46c31-9622-4c38-ad80-e046e2a3a2d0
49c14b89-b9dd-4d69-8f3b-919cbc9fafeb
49f013a0-e87c-4ae8-b702-9879c7c8a9b4
50b54daa-61a2-4611-89e3-13e6d8cef832
55ac36e6-ac18-47d5-878c-26e76dec35c5
578f7530-7566-4265-aa9d-6f142c0ecf9f
6230557f-4c15-46a9-a96e-67b8a2476003
62788957-7acf-481a-8cb9-428cfd7ecd89
70353206-aec1-4223-b48f-13b8aec01106
7f81881e-c9a0-4152-b2d9-67aa32f9285b
8247d1cd-2743-4fdc-ab6e-81a353e7ddfd
a1bb7512-3701-49ad-8862-f48d4a6ea379
a57c0b80-8a8a-4350-9413-9182a0132b13
ae8b5d10-514b-46c5-8420-eaa54d726f75
b16920c7-2b17-46ac-a08e-f9066a7a4999
c3e8f9ff-81a7-4630-8efe-24d38499771d
d924d254-62e2-4b58-ba4c-71994d3080d1
de26bcbd-b8a1-46a3-b202-9adc7c11e418
e1063090-f4f1-40db-a4e6-5a2c1396a858
e1800f66-ffbc-45aa-a3f7-2edd1b5ad74e
e41a140b-392d-4712-9b07-40b310b8dc7b
ede26932-6aa4-45fe-ad22-86385315aaaf

1 of 1 floating_ips failed to delete.
```

This patch should solve it by collecting all IPs to the list and delete them one by one while iterating over them.  