### PR TITLE
Prow: add lifecycle/frozen label

### DIFF
--- a/prow/config/labels.yaml
+++ b/prow/config/labels.yaml
@@ -296,6 +296,12 @@ default:
       target: both
       prowPlugin: lifecycle
       addedBy: anyone
+    - color: d3e2f0
+      description: Indicates that an issue or PR should not be auto-closed due to staleness.
+      name: lifecycle/frozen
+      target: both
+      prowPlugin: lifecycle
+      addedBy: anyone
     - color: e11d21
       description: Indicates that a PR cannot be merged because it has merge conflicts with HEAD.
       name: needs-rebase


### PR DESCRIPTION
Add lifecycle/frozen lable to indicate that an issue or PR should not be auto-closed due to staleness.
/cc @Rozzii 