### PR TITLE
Fix receiving variables from dev tools integration tests pipeline

### DIFF
--- a/jenkins/scripts/integration_test.sh
+++ b/jenkins/scripts/integration_test.sh
@@ -148,6 +148,11 @@ IRONIC_LOCAL_IMAGE="${IRONIC_LOCAL_IMAGE}"
 GINKGO_FOCUS="${GINKGO_FOCUS}"
 EOF
 
+# Write variables from pipeline for metal3 dev tools integration tests
+if [[  -f "${CI_DIR}/files/devtoolsvars.sh" ]] && [[ "${REPO_NAME}" == "metal3-dev-tools" ]];then
+  cat "${CI_DIR}/files/devtoolsvars.sh" >> "${CI_DIR}/files/${TEMP_FILE_NAME}"
+fi
+
 # Only set these variables if they actually have values.
 # If the variable is unset or empty (""), do nothing.
 if [[ ! -z "${CAPIRELEASE:+x}" ]]


### PR DESCRIPTION
Fix for pipeline part is [here](https://github.com/Nordix/metal3-dev-tools/pull/580)

This PR fixes receiving IMAGE_NAME and  IMAGE LOCATION variables from pipeline for metal3 dev tools integration tests. Metal3 dev tools integration tests are not using temporarily built node image, but  default node image. Cause of the problem is IMAGE_NAME and iMAGE_LOCATION variables are not passed to the tests properly. This issue started appearing after we randomized the vars.sh file name [here](https://github.com/metal3-io/project-infra/blob/ef01400cb9c069290865fa01bd7e08b218c84499/jenkins/scripts/integration_test.sh#L129)
