### PR TITLE
🌱 Add release-1.2 CAPM3/IPAM branch configurations

### DIFF
--- a/jenkins/README.md
+++ b/jenkins/README.md
@@ -25,6 +25,8 @@ The job result will be posted as a comment.
 
 * **/test-ubuntu-integration-main** run integration tests with CAPM3 API version v1beta1 and branch main on Ubuntu
 * **/test-centos-integration-main** run integration tests with CAPM3 API version v1beta1 and branch main on CentOS
+* **/test-ubuntu-integration-release-1-2** run integration tests with CAPM3 API version v1beta1 and branch release-1.2 on Ubuntu
+* **/test-centos-integration-release-1-2** run integration tests with CAPM3 API version v1beta1 and branch release-1.2 on CentOS
 * **/test-ubuntu-integration-release-1-1** run integration tests with CAPM3 API version v1beta1 and branch release-1.1 on Ubuntu
 * **/test-centos-integration-release-1-1** run integration tests with CAPM3 API version v1beta1 and branch release-1.1 on CentOS
 * **/test-ubuntu-integration-release-0-5** run integration tests with CAPM3 API version v1alpha5 and branch release-0.5 on Ubuntu
@@ -37,6 +39,8 @@ and deletion operations, there are separate triggers phrases as below:
 
 * **/keep-test-ubuntu-integration-main** run keep integration tests with CAPM3 API version v1beta1 and branch main on Ubuntu
 * **/keep-centos-integration-main** run keep integration tests with CAPM3 API version v1beta1 and branch main on CentOS
+* **/keep-ubuntu-integration-release-1-2** run keep integration tests with CAPM3 API version v1beta1 and branch release-1.2 on Ubuntu
+* **/keep-centos-integration-release-1-2** run keep integration tests with CAPM3 API version v1beta1 and branch release-1.2 on CentOS
 * **/keep-ubuntu-integration-release-1-1** run keep integration tests with CAPM3 API version v1beta1 and branch release-1.1 on Ubuntu
 * **/keep-centos-integration-release-1-1** run keep integration tests with CAPM3 API version v1beta1 and branch release-1.1 on CentOS
 * **/keep-ubuntu-integration-release-0-5** run keep integration tests with CAPM3 API version v1alpha5 and branch release-0.5 on Ubuntu

--- a/jenkins/README.md
+++ b/jenkins/README.md
@@ -51,7 +51,7 @@ but deleted after 24 hours, to avoid garbage collection of VMs.
 
 ## Cloud Resources cleanup
 
-There is a Jenkins [main job](https://jenkins.nordix.org/view/Metal3/job/metal3_main_integration_tests_cleanup/)
+There is a Jenkins [main job](https://jenkins.nordix.org/view/Metal3%20Periodic/job/metal3_daily_main_integration_tests_cleanup/)
 that cleans up all the leftover VMs from
 [CityCloud](https://www.citycloud.com/) every 6 hours which has failed to be
 deleted at the end of v1alphaX/v1betaX integration tests.
@@ -81,11 +81,11 @@ repository contains the jobs pipeline.
 
 ### Jenkins Job Builder, a.k.a. job definition
 
-We use [Jenkins Job Builder](https://docs.openstack.org/infra/jenkins-job-builder/index.html) (JJB) to
+We use [Jenkins Job Builder](https://docs.openstack.org/infra/jenkins-job-builder/attic/index.html) (JJB) to
 write Jenkins job definitions in YAML format. It helps us to keep job definitions in source control
 rather than writing/creating them directly in Jenkins UI. Your YAML formatted job definition
 will create a Jenkins job, which in turn executes your specified jenkins pipeline.
-Check [Job definitions](https://docs.openstack.org/infra/jenkins-job-builder/definition.html) to
+Check [Job definitions](https://docs.openstack.org/infra/jenkins-job-builder/attic/definition.html) to
 familiarize yourself with the JJB syntax. Our job definitions are stored in [Nordix Gerrit](https://gerrit.nordix.org/admin/repos/infra/cicd)
 instance under `cicd/jjb/metal3/` path. Please, note that [cicd](https://gerrit.nordix.org/admin/repos/infra/cicd)
 gerrit repository includes job defitinions for other projects as well that share the same Jenkins environment.

--- a/prow/config/config.yaml
+++ b/prow/config/config.yaml
@@ -100,6 +100,9 @@ branch-protection:
             release-1.1:
               required_status_checks:
                 contexts: ["test-ubuntu-integration-release-1-1"]
+            release-1.2:
+              required_status_checks:
+                contexts: ["test-ubuntu-integration-release-1-2"]
         ironic-image:
           branches:
             main:
@@ -121,6 +124,9 @@ branch-protection:
             release-1.1:
               required_status_checks:
                 contexts: ["test-ubuntu-integration-release-1-1"]
+            release-1.2:
+              required_status_checks:
+                contexts: ["test-ubuntu-integration-release-1-2"]
         mariadb-image:
           branches:
             main:
@@ -130,7 +136,7 @@ branch-protection:
           branches:
             main:
               required_status_checks:
-                contexts: ["test-centos-integration-release-1-1", "test-ubuntu-integration-main"]
+                contexts: ["test-centos-integration-release-1-2", "test-ubuntu-integration-main"]
 
 
 deck:
@@ -368,6 +374,7 @@ presubmits:
   - name: gomod
     branches:
     - main
+    - release-1.2
     - release-1.1
     skip_if_only_changed: '(((^|/)OWNERS)|(\.md))$'
     decorate: true
@@ -385,6 +392,7 @@ presubmits:
   - name: gofmt
     branches:
     - main
+    - release-1.2
     - release-1.1
     skip_if_only_changed: '(((^|/)OWNERS)|(\.md))$'
     decorate: true
@@ -432,6 +440,7 @@ presubmits:
   - name: golangci-lint
     branches:
     - main
+    - release-1.2
     - release-1.1
     skip_if_only_changed: '(((^|/)OWNERS)|(\.md))$'
     decorate: true
@@ -465,6 +474,7 @@ presubmits:
   - name: govet
     branches:
     - main
+    - release-1.2
     - release-1.1
     skip_if_only_changed: '(((^|/)OWNERS)|(\.md))$'
     decorate: true
@@ -526,6 +536,7 @@ presubmits:
   - name: generate
     branches:
     - main
+    - release-1.2
     - release-1.1
     skip_if_only_changed: '(((^|/)OWNERS)|(\.md))$'
     decorate: true
@@ -559,6 +570,7 @@ presubmits:
   - name: unit
     branches:
     - main
+    - release-1.2
     - release-1.1
     skip_if_only_changed: '(((^|/)OWNERS)|(\.md))$'
     decorate: true
@@ -671,6 +683,7 @@ presubmits:
   - name: gomod
     branches:
     - main
+    - release-1.2
     - release-1.1
     skip_if_only_changed: '(((^|/)OWNERS)|(\.md))$'
     decorate: true
@@ -702,6 +715,7 @@ presubmits:
   - name: gofmt
     branches:
     - main
+    - release-1.2
     - release-1.1
     skip_if_only_changed: '(((^|/)OWNERS)|(\.md))$'
     decorate: true
@@ -735,6 +749,7 @@ presubmits:
   - name: golangci-lint
     branches:
     - main
+    - release-1.2
     - release-1.1
     skip_if_only_changed: '(((^|/)OWNERS)|(\.md))$'
     decorate: true
@@ -752,6 +767,7 @@ presubmits:
   - name: govet
     branches:
     - main
+    - release-1.2
     - release-1.1
     skip_if_only_changed: '(((^|/)OWNERS)|(\.md))$'
     decorate: true
@@ -813,6 +829,7 @@ presubmits:
   - name: unit
     branches:
     - main
+    - release-1.2
     - release-1.1
     skip_if_only_changed: '(((^|/)OWNERS)|(\.md))$'
     decorate: true
@@ -846,6 +863,7 @@ presubmits:
   - name: generate
     branches:
     - main
+    - release-1.2
     - release-1.1
     skip_if_only_changed: '(((^|/)OWNERS)|(\.md))$'
     decorate: true


### PR DESCRIPTION
and also update dead links in the README

/hold

Prerequisites before taking this change in:

- release-1.2 branches created in both CAPM3/IPAM repos and new minor release: v1.2.0 is cut
- https://gerrit.nordix.org/c/infra/cicd/+/15169 needs to be merged
- https://github.com/metal3-io/metal3-dev-env/pull/1077 needs to be merged

After it lands:
- `required_status_checks` configurations in CAPM3/IPAM release-1.2 branches, in dev env main branch have to be configured 
- https://github.com/metal3-io/cluster-api-provider-metal3/pull/730