### PR TITLE
🌱 Add missing IPAM repo to plugins repos list

### DIFF
--- a/prow/config/plugins.yaml
+++ b/prow/config/plugins.yaml
@@ -29,8 +29,8 @@ plugins:
     - require-matching-label
   metal3-io/baremetal-operator:
   metal3-io/base-image:
-  metal3-io/cluster-api-provider-baremetal:
   metal3-io/cluster-api-provider-metal3:
+  metal3-io/ip-address-manager:
   metal3-io/ironic-client:
   metal3-io/ironic-hardware-inventory-recorder-image:
   metal3-io/ironic-image:


### PR DESCRIPTION
also remove archived `metal3-io/cluster-api-provider-baremetal` from the list