### PR TITLE
Fix BMOBRANCH=main only for main periodic test

### DIFF
--- a/jenkins/scripts/integration_test_env.sh
+++ b/jenkins/scripts/integration_test_env.sh
@@ -9,13 +9,18 @@ then
   export M3_DEV_ENV_PATH="${HOME}/tested_repo"
 
   # If the target repo and branch are the same as the source repo and branch
-  # we're running a periodic test, that is not for a PR, so we build the image
-  # for CAPM3 to verify the process (not BMO due to the build time for BMO image)
+  # we're running a periodic test, that is not for a PR, so we build the CAPM3, BMO and IPAM images)
 
   if [[ "${UPDATED_BRANCH}" == "${REPO_BRANCH}" ]] && [[ "${UPDATED_REPO}" == *"${REPO_ORG}/${REPO_NAME}"* ]]; then
     export BUILD_BMO_LOCALLY="true"
     export BUILD_CAPM3_LOCALLY="true"
-    export BMOBRANCH="main"
+    export BUILD_IPAM_LOCALLY="true"
+    
+    # BMOBRANCH should be main only if the periodic test is testing main branches
+    # if not we dont define it here (dev-env decides it), and release periodic tests would be using latest BMO release
+    if [[ "${REPO_BRANCH}" == "main" ]]; then
+      export BMOBRANCH="main"
+    fi
   fi
 
 elif [ "${REPO_NAME}" == "baremetal-operator" ]


### PR DESCRIPTION
This PR also noticed that the comment that we are not building BMO image is incorrect since we were. So since we were building CAPM3 and BMO images already for peiodic tests, this PR also adds the option to build IPAM image locally for periodic tests. 