### PR TITLE
prow: add shellcheck test for ironic-ipa-downloader

### DIFF
--- a/prow/config/config.yaml
+++ b/prow/config/config.yaml
@@ -1023,3 +1023,19 @@ presubmits:
           value: "TRUE"
         image: docker.io/garethr/kubeval:latest
         imagePullPolicy: Always
+
+  metal3-io/ironic-ipa-downloader:
+  - name: shellcheck
+    run_if_changed: '((\.sh)|^Makefile)$'
+    decorate: true
+    spec:
+      containers:
+        - args:
+            - ./hack/shellcheck.sh
+          command:
+            - sh
+          env:
+            - name: IS_CONTAINER
+              value: "TRUE"
+          image: docker.io/koalaman/shellcheck-alpine:stable
+          imagePullPolicy: Always


### PR DESCRIPTION
Depends on https://github.com/metal3-io/ironic-ipa-downloader/pull/37 merged first, or it'll block all PRs for ironic-ipa-downloader.