### PR TITLE
Fix BMOBRANCH export

### DIFF
--- a/jenkins/scripts/integration_test_env.sh
+++ b/jenkins/scripts/integration_test_env.sh
@@ -18,7 +18,7 @@ then
     
     # BMOBRANCH should be main only if the periodic test is testing main branches
     # if not we dont define it here (dev-env decides it), and release periodic tests would be using latest BMO release
-    if [[ "${REPO_BRANCH}" == "main" ]]; then
+    if [[ "${CAPM3RELEASEBRANCH}" == "main" ]]; then
       export BMOBRANCH="main"
     fi
   fi


### PR DESCRIPTION
We were wrongly checking against REPO_BRANCH var since REPO_BRANCH refers to dev-env branch not the branch of CAPM3. We should check against CAPM3RELEASEBRANCH to make sure if the periodic test is running against main branch or release branch