### PR TITLE
Support multiple instances in BML

### DIFF
--- a/jenkins/scripts/bare_metal_lab/default_vars/vars.yaml
+++ b/jenkins/scripts/bare_metal_lab/default_vars/vars.yaml
@@ -28,3 +28,7 @@ bare_metal_hosts:
 
 EPHEMERAL_CLUSTER: "minikube"
 EXTERNAL_VLAN_ID: 3
+# In order to run multiple instances (one per jump host), we list the known
+# hosts and tell DNSMasq to ignore all other.
+DHCP_HOSTS: "{{ bare_metal_hosts | map(attribute='mac') | join(';') }}"
+DHCP_IGNORE: "tag:!known"

--- a/jenkins/scripts/bare_metal_lab/deploy-lab.yaml
+++ b/jenkins/scripts/bare_metal_lab/deploy-lab.yaml
@@ -3,6 +3,8 @@
   environment:
     EPHEMERAL_CLUSTER: "{{ EPHEMERAL_CLUSTER }}"
     EXTERNAL_VLAN_ID: "{{ EXTERNAL_VLAN_ID }}"
+    DHCP_HOSTS: "{{ DHCP_HOSTS }}"
+    DHCP_IGNORE: "{{ DHCP_IGNORE }}"
   vars_files:
     - default_vars/vars.yaml
   tasks:


### PR DESCRIPTION
This configures DNSMasq to ignore DHCP requests from unknown hosts in the BML. The idea is that this allows manual testing in the BML using the backup jumphost and spare hosts without interfering with the CI. So to be clear, the idea is not to run multiple CI jobs in parallel in the BMl.

Related to: https://github.com/metal3-io/metal3-dev-env/pull/1100