### PR TITLE
Bump markdownlint to v0.12.0 and pin sha digest

### DIFF
--- a/prow/config/config.yaml
+++ b/prow/config/config.yaml
@@ -13,7 +13,7 @@ plank:
   job_url_prefix_config:
     "*": https://prow.apps.test.metal3.io/view/
   report_templates:
-    '*': >-
+    "*": >-
         [Full PR test history](https://prow.apps.test.metal3.io/pr-history?org={{.Spec.Refs.Org}}&repo={{.Spec.Refs.Repo}}&pr={{with index .Spec.Refs.Pulls 0}}{{.Number}}{{end}}).
         [Your PR dashboard](https://prow.apps.test.metal3.io/pr?query=is:pr+state:open+author:{{with
         index .Spec.Refs.Pulls 0}}{{.Author}}{{end}}).
@@ -281,7 +281,7 @@ presubmits:
         env:
         - name: IS_CONTAINER
           value: "TRUE"
-        image: docker.io/pipelinecomponents/markdownlint:latest
+        image: registry.hub.docker.com/pipelinecomponents/markdownlint:0.12.0@sha256:0b8f9fcf0410257b2f3548f67ffe25934cfc9877a618b9f85afcf345a25804a2
         imagePullPolicy: Always
   - name: shellcheck
     run_if_changed: '((\.sh)|^Makefile)$'
@@ -533,7 +533,7 @@ presubmits:
         env:
         - name: IS_CONTAINER
           value: "TRUE"
-        image: docker.io/pipelinecomponents/markdownlint:latest
+        image: registry.hub.docker.com/pipelinecomponents/markdownlint:0.12.0@sha256:0b8f9fcf0410257b2f3548f67ffe25934cfc9877a618b9f85afcf345a25804a2
         imagePullPolicy: Always
   - name: shellcheck
     run_if_changed: '((\.sh)|^Makefile)$'
@@ -659,7 +659,7 @@ presubmits:
         env:
         - name: IS_CONTAINER
           value: "TRUE"
-        image: docker.io/pipelinecomponents/markdownlint:latest
+        image: registry.hub.docker.com/pipelinecomponents/markdownlint:0.12.0@sha256:0b8f9fcf0410257b2f3548f67ffe25934cfc9877a618b9f85afcf345a25804a2
         imagePullPolicy: Always
 
   metal3-io/project-infra:
@@ -692,7 +692,7 @@ presubmits:
         env:
         - name: IS_CONTAINER
           value: "TRUE"
-        image: docker.io/pipelinecomponents/markdownlint:latest
+        image: registry.hub.docker.com/pipelinecomponents/markdownlint:0.12.0@sha256:0b8f9fcf0410257b2f3548f67ffe25934cfc9877a618b9f85afcf345a25804a2
         imagePullPolicy: Always
 
   metal3-io/ip-address-manager:
@@ -858,7 +858,7 @@ presubmits:
         env:
         - name: IS_CONTAINER
           value: "TRUE"
-        image: docker.io/pipelinecomponents/markdownlint:latest
+        image: registry.hub.docker.com/pipelinecomponents/markdownlint:0.12.0@sha256:0b8f9fcf0410257b2f3548f67ffe25934cfc9877a618b9f85afcf345a25804a2
         imagePullPolicy: Always
   - name: shellcheck
     run_if_changed: '((\.sh)|^Makefile)$'
@@ -997,7 +997,7 @@ presubmits:
         env:
         - name: IS_CONTAINER
           value: "TRUE"
-        image: docker.io/pipelinecomponents/markdownlint:latest
+        image: registry.hub.docker.com/pipelinecomponents/markdownlint:0.12.0@sha256:0b8f9fcf0410257b2f3548f67ffe25934cfc9877a618b9f85afcf345a25804a2
         imagePullPolicy: Always
   - name: shellcheck
     run_if_changed: '((\.sh)|(^Makefile))$'


### PR DESCRIPTION
Use markdownlint image 0.12.0 pinned by SHA instead of latest.

In markdownlint 0.12.0 unordered lists are required to have 3 space prefix, while 0.11.1 needed only 2. This is due Kramdown dependency. This behavior changed and broke the markdown validations, preventing contributions, thanks to "latest" tag.

All of the Metal3 repositories (except one, PR pending) markdown files and their hack/markdownlint.sh validators have been fixed, and prow need to be up to date as well.

In addition, dependencies should be pinned by SHA, to guard against unintended changes via tag update. This also makes OpenSSF Scorecards happier.