### PR TITLE
prow: pin shellcheck to v0.8.0

### DIFF
--- a/prow/config/config.yaml
+++ b/prow/config/config.yaml
@@ -295,7 +295,7 @@ presubmits:
         env:
         - name: IS_CONTAINER
           value: "TRUE"
-        image: docker.io/koalaman/shellcheck-alpine:stable
+        image: docker.io/koalaman/shellcheck-alpine:v0.8.0@sha256:f42fde76d2d14a645a848826e54a4d650150e151d9c81057c898da89a82c8a56
         imagePullPolicy: Always
   - name: unit
     skip_if_only_changed: '(((^|/)OWNERS)|(\.md))$'
@@ -547,7 +547,7 @@ presubmits:
         env:
         - name: IS_CONTAINER
           value: "TRUE"
-        image: docker.io/koalaman/shellcheck-alpine:stable
+        image: docker.io/koalaman/shellcheck-alpine:v0.8.0@sha256:f42fde76d2d14a645a848826e54a4d650150e151d9c81057c898da89a82c8a56
         imagePullPolicy: Always
   - name: generate
     branches:
@@ -645,7 +645,7 @@ presubmits:
         env:
         - name: IS_CONTAINER
           value: "TRUE"
-        image: docker.io/koalaman/shellcheck-alpine:stable
+        image: docker.io/koalaman/shellcheck-alpine:v0.8.0@sha256:f42fde76d2d14a645a848826e54a4d650150e151d9c81057c898da89a82c8a56
         imagePullPolicy: Always
   - name: markdownlint
     run_if_changed: '\.md$'
@@ -872,7 +872,7 @@ presubmits:
         env:
         - name: IS_CONTAINER
           value: "TRUE"
-        image: docker.io/koalaman/shellcheck-alpine:stable
+        image: docker.io/koalaman/shellcheck-alpine:v0.8.0@sha256:f42fde76d2d14a645a848826e54a4d650150e151d9c81057c898da89a82c8a56
         imagePullPolicy: Always
   - name: unit
     branches:
@@ -1011,7 +1011,7 @@ presubmits:
         env:
         - name: IS_CONTAINER
           value: "TRUE"
-        image: docker.io/koalaman/shellcheck-alpine:stable
+        image: docker.io/koalaman/shellcheck-alpine:v0.8.0@sha256:f42fde76d2d14a645a848826e54a4d650150e151d9c81057c898da89a82c8a56
         imagePullPolicy: Always
   - name: unit
     skip_if_only_changed: '(((^|/)OWNERS)|(\.md))$'
@@ -1055,5 +1055,5 @@ presubmits:
           env:
             - name: IS_CONTAINER
               value: "TRUE"
-          image: docker.io/koalaman/shellcheck-alpine:stable
+          image: docker.io/koalaman/shellcheck-alpine:v0.8.0@sha256:f42fde76d2d14a645a848826e54a4d650150e151d9c81057c898da89a82c8a56
           imagePullPolicy: Always


### PR DESCRIPTION
Shellcheck v0.9.0 released today broke all the shellchecks. Relying on a stable/latest tags expose us to this kind of unexpected breakage so pinning down shellcheck image to v0.8.0 with a digest.