### PR TITLE
Unpin node image for bml

### DIFF
--- a/jenkins/scripts/files/run_integration_tests.sh
+++ b/jenkins/scripts/files/run_integration_tests.sh
@@ -76,9 +76,7 @@ then
   # https://wiki.nordix.org/pages/viewpage.action?spaceKey=CPI&title=Bare+Metal+Lab
   # In the bare metal lab, the external network has vlan id 3
   export EXTERNAL_VLAN_ID="3"
-  # Pin node image to be used in BML to CENTOS_8_NODE_IMAGE_K8S_v1.23.3.qcow2
-  export IMAGE_NAME="CENTOS_8_NODE_IMAGE_K8S_v1.23.3.qcow2"
-  export IMAGE_LOCATION="https://artifactory.nordix.org/artifactory/metal3/images/k8s_v1.23.3"
+  
   make test
   exit 0
 fi


### PR DESCRIPTION
We have a fix to Centos 9 issue in bml [here](https://github.com/metal3-io/metal3-dev-env/pull/1131), unpining node image for bml