### PR TITLE
move from kubeval to kubeconform

### DIFF
--- a/prow/config/config.yaml
+++ b/prow/config/config.yaml
@@ -374,7 +374,9 @@ presubmits:
             env:
               - name: IS_CONTAINER
                 value: "TRUE"
-            image: docker.io/garethr/kubeval:latest
+              - name: KUBECONFORM_PATH
+                value: "/"
+            image: ghcr.io/yannh/kubeconform:v0.5.0-alpine@sha256:ae1583859c7c9683b2f044a9cc911d9427030cd48ec33eeff6c0f23396780da9
             imagePullPolicy: Always
 
   metal3-io/cluster-api-provider-metal3:
@@ -636,7 +638,9 @@ presubmits:
             env:
               - name: IS_CONTAINER
                 value: "TRUE"
-            image: docker.io/garethr/kubeval:latest
+              - name: KUBECONFORM_PATH
+                value: "/"
+            image: ghcr.io/yannh/kubeconform:v0.5.0-alpine@sha256:ae1583859c7c9683b2f044a9cc911d9427030cd48ec33eeff6c0f23396780da9
             imagePullPolicy: Always
 
   metal3-io/metal3-dev-env:
@@ -960,7 +964,9 @@ presubmits:
             env:
               - name: IS_CONTAINER
                 value: "TRUE"
-            image: docker.io/garethr/kubeval:latest
+              - name: KUBECONFORM_PATH
+                value: "/"
+            image: ghcr.io/yannh/kubeconform:v0.5.0-alpine@sha256:ae1583859c7c9683b2f044a9cc911d9427030cd48ec33eeff6c0f23396780da9
             imagePullPolicy: Always
 
   metal3-io/hardware-classification-controller:
@@ -1046,7 +1052,9 @@ presubmits:
             env:
               - name: IS_CONTAINER
                 value: "TRUE"
-            image: docker.io/garethr/kubeval:latest
+              - name: KUBECONFORM_PATH
+                value: "/"
+            image: ghcr.io/yannh/kubeconform:v0.5.0-alpine@sha256:ae1583859c7c9683b2f044a9cc911d9427030cd48ec33eeff6c0f23396780da9
             imagePullPolicy: Always
 
   metal3-io/ironic-ipa-downloader:

--- a/prow/config/config.yaml
+++ b/prow/config/config.yaml
@@ -14,9 +14,9 @@ plank:
     "*": https://prow.apps.test.metal3.io/view/
   report_templates:
     "*": >-
-        [Full PR test history](https://prow.apps.test.metal3.io/pr-history?org={{.Spec.Refs.Org}}&repo={{.Spec.Refs.Repo}}&pr={{with index .Spec.Refs.Pulls 0}}{{.Number}}{{end}}).
-        [Your PR dashboard](https://prow.apps.test.metal3.io/pr?query=is:pr+state:open+author:{{with
-        index .Spec.Refs.Pulls 0}}{{.Author}}{{end}}).
+      [Full PR test history](https://prow.apps.test.metal3.io/pr-history?org={{.Spec.Refs.Org}}&repo={{.Spec.Refs.Repo}}&pr={{with index .Spec.Refs.Pulls 0}}{{.Number}}{{end}}).
+      [Your PR dashboard](https://prow.apps.test.metal3.io/pr?query=is:pr+state:open+author:{{with
+      index .Spec.Refs.Pulls 0}}{{.Author}}{{end}}).
   default_decoration_configs:
     "*":
       gcs_configuration:
@@ -33,35 +33,35 @@ tide:
   merge_method:
     metal3-io/project-config: merge
   queries:
-  - repos:
-    - metal3-io/baremetal-operator
-    - metal3-io/base-image
-    - metal3-io/cluster-api-provider-metal3
-    - metal3-io/ironic-client
-    - metal3-io/ironic-hardware-inventory-recorder-image
-    - metal3-io/ironic-image
-    - metal3-io/ironic-agent-image
-    - metal3-io/ironic-ipa-downloader
-    - metal3-io/ironic-prometheus-exporter
-    - metal3-io/mariadb-image
-    - metal3-io/metal3-dev-env
-    - metal3-io/metal3-docs
-    - metal3-io/metal3-helm-chart
-    - metal3-io/metal3-io.github.io
-    - metal3-io/metal3-smart-exporter
-    - metal3-io/project-infra
-    - metal3-io/static-ip-manager-image
-    - metal3-io/ip-address-manager
-    - metal3-io/hardware-classification-controller
-    labels:
-    - lgtm
-    - approved
-    missingLabels:
-    - needs-rebase
-    - do-not-merge
-    - do-not-merge/hold
-    - do-not-merge/invalid-owners-file
-    - do-not-merge/work-in-progress
+    - repos:
+        - metal3-io/baremetal-operator
+        - metal3-io/base-image
+        - metal3-io/cluster-api-provider-metal3
+        - metal3-io/ironic-client
+        - metal3-io/ironic-hardware-inventory-recorder-image
+        - metal3-io/ironic-image
+        - metal3-io/ironic-agent-image
+        - metal3-io/ironic-ipa-downloader
+        - metal3-io/ironic-prometheus-exporter
+        - metal3-io/mariadb-image
+        - metal3-io/metal3-dev-env
+        - metal3-io/metal3-docs
+        - metal3-io/metal3-helm-chart
+        - metal3-io/metal3-io.github.io
+        - metal3-io/metal3-smart-exporter
+        - metal3-io/project-infra
+        - metal3-io/static-ip-manager-image
+        - metal3-io/ip-address-manager
+        - metal3-io/hardware-classification-controller
+      labels:
+        - lgtm
+        - approved
+      missingLabels:
+        - needs-rebase
+        - do-not-merge
+        - do-not-merge/hold
+        - do-not-merge/invalid-owners-file
+        - do-not-merge/work-in-progress
   context_options:
     # Use branch protection options to define required and optional contexts
     from-branch-protection: true
@@ -88,7 +88,11 @@ branch-protection:
           branches:
             main:
               required_status_checks:
-                contexts: ["test-centos-integration-main", "test-ubuntu-integration-main"]
+                contexts:
+                  [
+                    "test-centos-integration-main",
+                    "test-ubuntu-integration-main",
+                  ]
         cluster-api-provider-metal3:
           branches:
             main:
@@ -136,924 +140,927 @@ branch-protection:
           branches:
             main:
               required_status_checks:
-                contexts: ["test-centos-integration-release-1-3", "test-ubuntu-integration-main"]
-
+                contexts:
+                  [
+                    "test-centos-integration-release-1-3",
+                    "test-ubuntu-integration-main",
+                  ]
 
 deck:
   spyglass:
     size_limit: 500000000 # 500MB
     lenses:
-    - lens:
-        name: metadata
-      required_files:
-      - started.json|finished.json
-    - lens:
-        config:
-        name: buildlog
-      required_files:
-      - build-log.txt
-    - lens:
-        name: junit
-      required_files:
-      - .*/junit.*\.xml
-    - lens:
-        name: podinfo
-      required_files:
-      - podinfo.json
+      - lens:
+          name: metadata
+        required_files:
+          - started.json|finished.json
+      - lens:
+          config:
+          name: buildlog
+        required_files:
+          - build-log.txt
+      - lens:
+          name: junit
+        required_files:
+          - .*/junit.*\.xml
+      - lens:
+          name: podinfo
+        required_files:
+          - podinfo.json
 
 periodics:
- - name: periodic-stale
-   interval: 1h
-   decorate: true
-   spec:
-     containers:
-     - image: gcr.io/k8s-prow/commenter:v20210916-3c87dfedd5
-       command:
-       - /app/robots/commenter/app.binary
-       args:
-       - |-
-         --query=org:metal3-io
-         -label:lifecycle/frozen
-         -label:lifecycle/stale
-       - --updated=2160h
-       - --token=/etc/token/token
-       - |-
-         --comment=Issues go stale after 90d of inactivity.
-         Mark the issue as fresh with `/remove-lifecycle stale`.
-         Stale issues will close after an additional 30d of inactivity.
+  - name: periodic-stale
+    interval: 1h
+    decorate: true
+    spec:
+      containers:
+        - image: gcr.io/k8s-prow/commenter:v20210916-3c87dfedd5
+          command:
+            - /app/robots/commenter/app.binary
+          args:
+            - |-
+              --query=org:metal3-io
+              -label:lifecycle/frozen
+              -label:lifecycle/stale
+            - --updated=2160h
+            - --token=/etc/token/token
+            - |-
+              --comment=Issues go stale after 90d of inactivity.
+              Mark the issue as fresh with `/remove-lifecycle stale`.
+              Stale issues will close after an additional 30d of inactivity.
 
-         If this issue is safe to close now please do so with `/close`.
+              If this issue is safe to close now please do so with `/close`.
 
-         /lifecycle stale
-       - --template
-       - --ceiling=10
-       - --confirm
-       volumeMounts:
-       - name: token
-         mountPath: /etc/token
-     volumes:
-     - name: token
-       secret:
-         secretName: github-token
- - name: periodic-stale-close
-   interval: 1h
-   decorate: true
-   spec:
-     containers:
-     - image: gcr.io/k8s-prow/commenter:v20210916-3c87dfedd5
-       command:
-       - /app/robots/commenter/app.binary
-       args:
-       - |-
-         --query=org:metal3-io
-         -label:lifecycle/frozen
-         label:lifecycle/stale
-       - --updated=720h
-       - --token=/etc/token/token
-       - |-
-         --comment=Stale issues close after 30d of inactivity. Reopen the issue with `/reopen`. Mark the issue as fresh with `/remove-lifecycle stale`.
+              /lifecycle stale
+            - --template
+            - --ceiling=10
+            - --confirm
+          volumeMounts:
+            - name: token
+              mountPath: /etc/token
+      volumes:
+        - name: token
+          secret:
+            secretName: github-token
+  - name: periodic-stale-close
+    interval: 1h
+    decorate: true
+    spec:
+      containers:
+        - image: gcr.io/k8s-prow/commenter:v20210916-3c87dfedd5
+          command:
+            - /app/robots/commenter/app.binary
+          args:
+            - |-
+              --query=org:metal3-io
+              -label:lifecycle/frozen
+              label:lifecycle/stale
+            - --updated=720h
+            - --token=/etc/token/token
+            - |-
+              --comment=Stale issues close after 30d of inactivity. Reopen the issue with `/reopen`. Mark the issue as fresh with `/remove-lifecycle stale`.
 
-         /close
-       - --template
-       - --ceiling=10
-       - --confirm
-       volumeMounts:
-       - name: token
-         mountPath: /etc/token
-     volumes:
-     - name: token
-       secret:
-         secretName: github-token
+              /close
+            - --template
+            - --ceiling=10
+            - --confirm
+          volumeMounts:
+            - name: token
+              mountPath: /etc/token
+      volumes:
+        - name: token
+          secret:
+            secretName: github-token
 
 presubmits:
   metal3-io/baremetal-operator:
-  - name: gofmt
-    run_if_changed: '\.go$'
-    decorate: true
-    spec:
-      containers:
-      - args:
-        - ./hack/gofmt.sh
-        command:
-        - sh
-        env:
-        - name: IS_CONTAINER
-          value: "TRUE"
-        image: docker.io/golang:1.19
-        imagePullPolicy: Always
-  - name: gosec
-    skip_if_only_changed: '(((^|/)OWNERS)|(\.md))$'
-    decorate: true
-    spec:
-      containers:
-      - args:
-        - ./hack/gosec.sh
-        command:
-        - sh
-        env:
-        - name: IS_CONTAINER
-          value: "TRUE"
-        image: docker.io/securego/gosec:latest
-        imagePullPolicy: Always
-  - name: gomod
-    skip_if_only_changed: '(((^|/)OWNERS)|(\.md))$'
-    decorate: true
-    spec:
-      containers:
-      - args:
-        - ./hack/gomod.sh
-        command:
-        - sh
-        env:
-        - name: IS_CONTAINER
-          value: "TRUE"
-        image: docker.io/golang:1.19
-        imagePullPolicy: Always
-  - name: markdownlint
-    run_if_changed: '\.md$'
-    decorate: true
-    spec:
-      containers:
-      - args:
-        - ./hack/markdownlint.sh
-        command:
-        - sh
-        env:
-        - name: IS_CONTAINER
-          value: "TRUE"
-        image: registry.hub.docker.com/pipelinecomponents/markdownlint:0.12.0@sha256:0b8f9fcf0410257b2f3548f67ffe25934cfc9877a618b9f85afcf345a25804a2
-        imagePullPolicy: Always
-  - name: shellcheck
-    run_if_changed: '((\.sh)|^Makefile)$'
-    decorate: true
-    spec:
-      containers:
-      - args:
-        - ./hack/shellcheck.sh
-        command:
-        - sh
-        env:
-        - name: IS_CONTAINER
-          value: "TRUE"
-        image: docker.io/koalaman/shellcheck-alpine:v0.9.0@sha256:e19ed93c22423970d56568e171b4512c9244fc75dd9114045016b4a0073ac4b7
-        imagePullPolicy: Always
-  - name: unit
-    skip_if_only_changed: '(((^|/)OWNERS)|(\.md))$'
-    decorate: true
-    spec:
-      containers:
-      - args:
-        - ./hack/unit.sh
-        command:
-        - sh
-        env:
-        - name: IS_CONTAINER
-          value: "TRUE"
-        - name: DEPLOY_KERNEL_URL
-          value: "http://172.22.0.1/images/ironic-python-agent.kernel"
-        - name: DEPLOY_RAMDISK_URL
-          value: "http://172.22.0.1/images/ironic-python-agent.initramfs"
-        - name: IRONIC_ENDPOINT
-          value: "http://localhost:6385/v1/"
-        - name: IRONIC_INSPECTOR_ENDPOINT
-          value: "http://localhost:5050/v1/"
-        image: docker.io/golang:1.19
-        imagePullPolicy: Always
-  - name: generate
-    skip_if_only_changed: '(((^|/)OWNERS)|(\.md))$'
-    decorate: true
-    spec:
-      containers:
-      - args:
-        - ./hack/generate.sh
-        command:
-        - sh
-        env:
-        - name: IS_CONTAINER
-          value: "TRUE"
-        - name: DEPLOY_KERNEL_URL
-          value: "http://172.22.0.1/images/ironic-python-agent.kernel"
-        - name: DEPLOY_RAMDISK_URL
-          value: "http://172.22.0.1/images/ironic-python-agent.initramfs"
-        - name: IRONIC_ENDPOINT
-          value: "http://localhost:6385/v1/"
-        - name: IRONIC_INSPECTOR_ENDPOINT
-          value: "http://localhost:5050/v1/"
-        image: docker.io/golang:1.19
-        imagePullPolicy: Always
-  - name: golint
-    run_if_changed: '\.go$'
-    decorate: true
-    spec:
-      containers:
-      - args:
-        - ./hack/golint.sh
-        command:
-        - sh
-        env:
-        - name: IS_CONTAINER
-          value: "TRUE"
-        image: registry.hub.docker.com/library/golang:1.19
-        imagePullPolicy: Always
-  - name: manifestlint
-    skip_if_only_changed: '(((^|/)OWNERS)|(\.md))$'
-    decorate: true
-    spec:
-      containers:
-      - args:
-        - ./hack/manifestlint.sh
-        command:
-        - sh
-        env:
-        - name: IS_CONTAINER
-          value: "TRUE"
-        image: docker.io/garethr/kubeval:latest
-        imagePullPolicy: Always
+    - name: gofmt
+      run_if_changed: '\.go$'
+      decorate: true
+      spec:
+        containers:
+          - args:
+              - ./hack/gofmt.sh
+            command:
+              - sh
+            env:
+              - name: IS_CONTAINER
+                value: "TRUE"
+            image: docker.io/golang:1.19
+            imagePullPolicy: Always
+    - name: gosec
+      skip_if_only_changed: '(((^|/)OWNERS)|(\.md))$'
+      decorate: true
+      spec:
+        containers:
+          - args:
+              - ./hack/gosec.sh
+            command:
+              - sh
+            env:
+              - name: IS_CONTAINER
+                value: "TRUE"
+            image: docker.io/securego/gosec:latest
+            imagePullPolicy: Always
+    - name: gomod
+      skip_if_only_changed: '(((^|/)OWNERS)|(\.md))$'
+      decorate: true
+      spec:
+        containers:
+          - args:
+              - ./hack/gomod.sh
+            command:
+              - sh
+            env:
+              - name: IS_CONTAINER
+                value: "TRUE"
+            image: docker.io/golang:1.19
+            imagePullPolicy: Always
+    - name: markdownlint
+      run_if_changed: '\.md$'
+      decorate: true
+      spec:
+        containers:
+          - args:
+              - ./hack/markdownlint.sh
+            command:
+              - sh
+            env:
+              - name: IS_CONTAINER
+                value: "TRUE"
+            image: registry.hub.docker.com/pipelinecomponents/markdownlint:0.12.0@sha256:0b8f9fcf0410257b2f3548f67ffe25934cfc9877a618b9f85afcf345a25804a2
+            imagePullPolicy: Always
+    - name: shellcheck
+      run_if_changed: '((\.sh)|^Makefile)$'
+      decorate: true
+      spec:
+        containers:
+          - args:
+              - ./hack/shellcheck.sh
+            command:
+              - sh
+            env:
+              - name: IS_CONTAINER
+                value: "TRUE"
+            image: docker.io/koalaman/shellcheck-alpine:v0.9.0@sha256:e19ed93c22423970d56568e171b4512c9244fc75dd9114045016b4a0073ac4b7
+            imagePullPolicy: Always
+    - name: unit
+      skip_if_only_changed: '(((^|/)OWNERS)|(\.md))$'
+      decorate: true
+      spec:
+        containers:
+          - args:
+              - ./hack/unit.sh
+            command:
+              - sh
+            env:
+              - name: IS_CONTAINER
+                value: "TRUE"
+              - name: DEPLOY_KERNEL_URL
+                value: "http://172.22.0.1/images/ironic-python-agent.kernel"
+              - name: DEPLOY_RAMDISK_URL
+                value: "http://172.22.0.1/images/ironic-python-agent.initramfs"
+              - name: IRONIC_ENDPOINT
+                value: "http://localhost:6385/v1/"
+              - name: IRONIC_INSPECTOR_ENDPOINT
+                value: "http://localhost:5050/v1/"
+            image: docker.io/golang:1.19
+            imagePullPolicy: Always
+    - name: generate
+      skip_if_only_changed: '(((^|/)OWNERS)|(\.md))$'
+      decorate: true
+      spec:
+        containers:
+          - args:
+              - ./hack/generate.sh
+            command:
+              - sh
+            env:
+              - name: IS_CONTAINER
+                value: "TRUE"
+              - name: DEPLOY_KERNEL_URL
+                value: "http://172.22.0.1/images/ironic-python-agent.kernel"
+              - name: DEPLOY_RAMDISK_URL
+                value: "http://172.22.0.1/images/ironic-python-agent.initramfs"
+              - name: IRONIC_ENDPOINT
+                value: "http://localhost:6385/v1/"
+              - name: IRONIC_INSPECTOR_ENDPOINT
+                value: "http://localhost:5050/v1/"
+            image: docker.io/golang:1.19
+            imagePullPolicy: Always
+    - name: golint
+      run_if_changed: '\.go$'
+      decorate: true
+      spec:
+        containers:
+          - args:
+              - ./hack/golint.sh
+            command:
+              - sh
+            env:
+              - name: IS_CONTAINER
+                value: "TRUE"
+            image: registry.hub.docker.com/library/golang:1.19
+            imagePullPolicy: Always
+    - name: manifestlint
+      skip_if_only_changed: '(((^|/)OWNERS)|(\.md))$'
+      decorate: true
+      spec:
+        containers:
+          - args:
+              - ./hack/manifestlint.sh
+            command:
+              - sh
+            env:
+              - name: IS_CONTAINER
+                value: "TRUE"
+            image: docker.io/garethr/kubeval:latest
+            imagePullPolicy: Always
 
   metal3-io/cluster-api-provider-metal3:
-  - name: gomod
-    branches:
-    - main
-    - release-1.3
-    skip_if_only_changed: '(((^|/)OWNERS)|(\.md))$'
-    decorate: true
-    spec:
-      containers:
-      - args:
-        - ./hack/gomod.sh
-        command:
-        - sh
-        env:
-        - name: IS_CONTAINER
-          value: "TRUE"
-        image: docker.io/golang:1.19
-        imagePullPolicy: Always
-  - name: gomod
-    branches:
-    - release-1.2
-    - release-1.1
-    skip_if_only_changed: '(((^|/)OWNERS)|(\.md))$'
-    decorate: true
-    spec:
-      containers:
-      - args:
-        - ./hack/gomod.sh
-        command:
-        - sh
-        env:
-        - name: IS_CONTAINER
-          value: "TRUE"
-        image: docker.io/golang:1.17
-        imagePullPolicy: Always
-  - name: gofmt
-    branches:
-    - main
-    - release-1.3
-    skip_if_only_changed: '(((^|/)OWNERS)|(\.md))$'
-    decorate: true
-    spec:
-      containers:
-      - args:
-        - ./hack/gofmt.sh
-        command:
-        - sh
-        env:
-        - name: IS_CONTAINER
-          value: "TRUE"
-        image: docker.io/golang:1.19
-        imagePullPolicy: Always
-  - name: gofmt
-    branches:
-    - release-1.2
-    - release-1.1
-    skip_if_only_changed: '(((^|/)OWNERS)|(\.md))$'
-    decorate: true
-    spec:
-      containers:
-      - args:
-        - ./hack/gofmt.sh
-        command:
-        - sh
-        env:
-        - name: IS_CONTAINER
-          value: "TRUE"
-        image: docker.io/golang:1.17
-        imagePullPolicy: Always
-  - name: gosec
-    skip_if_only_changed: '(((^|/)OWNERS)|(\.md))$'
-    decorate: true
-    spec:
-      containers:
-      - args:
-        - ./hack/gosec.sh
-        command:
-        - sh
-        env:
-        - name: IS_CONTAINER
-          value: "TRUE"
-        image: docker.io/securego/gosec:latest
-        imagePullPolicy: Always
-  - name: golangci-lint
-    branches:
-    - main
-    - release-1.3
-    skip_if_only_changed: '(((^|/)OWNERS)|(\.md))$'
-    decorate: true
-    spec:
-      containers:
-      - args:
-        - ./hack/ensure-golangci-lint.sh
-        command:
-        - sh
-        env:
-        - name: IS_CONTAINER
-          value: "TRUE"
-        image: docker.io/golang:1.19
-        imagePullPolicy: Always
-  - name: golangci-lint
-    branches:
-    - release-1.2
-    - release-1.1
-    skip_if_only_changed: '(((^|/)OWNERS)|(\.md))$'
-    decorate: true
-    spec:
-      containers:
-      - args:
-        - ./hack/ensure-golangci-lint.sh
-        command:
-        - sh
-        env:
-        - name: IS_CONTAINER
-          value: "TRUE"
-        image: docker.io/golang:1.17
-        imagePullPolicy: Always
-  - name: govet
-    branches:
-    - main
-    - release-1.3
-    skip_if_only_changed: '(((^|/)OWNERS)|(\.md))$'
-    decorate: true
-    spec:
-      containers:
-      - args:
-        - ./hack/govet.sh
-        command:
-        - sh
-        env:
-        - name: IS_CONTAINER
-          value: "TRUE"
-        image: docker.io/golang:1.19
-        imagePullPolicy: Always
-  - name: govet
-    branches:
-    - release-1.2
-    - release-1.1
-    skip_if_only_changed: '(((^|/)OWNERS)|(\.md))$'
-    decorate: true
-    spec:
-      containers:
-      - args:
-        - ./hack/govet.sh
-        command:
-        - sh
-        env:
-        - name: IS_CONTAINER
-          value: "TRUE"
-        image: docker.io/golang:1.17
-        imagePullPolicy: Always
-  - name: markdownlint
-    run_if_changed: '\.md$'
-    decorate: true
-    spec:
-      containers:
-      - args:
-        - ./hack/markdownlint.sh
-        command:
-        - sh
-        env:
-        - name: IS_CONTAINER
-          value: "TRUE"
-        image: registry.hub.docker.com/pipelinecomponents/markdownlint:0.12.0@sha256:0b8f9fcf0410257b2f3548f67ffe25934cfc9877a618b9f85afcf345a25804a2
-        imagePullPolicy: Always
-  - name: shellcheck
-    run_if_changed: '((\.sh)|^Makefile)$'
-    decorate: true
-    spec:
-      containers:
-      - args:
-        - ./hack/shellcheck.sh
-        command:
-        - sh
-        env:
-        - name: IS_CONTAINER
-          value: "TRUE"
-        image: docker.io/koalaman/shellcheck-alpine:v0.9.0@sha256:e19ed93c22423970d56568e171b4512c9244fc75dd9114045016b4a0073ac4b7
-        imagePullPolicy: Always
-  - name: generate
-    branches:
-    - main
-    - release-1.3
-    skip_if_only_changed: '(((^|/)OWNERS)|(\.md))$'
-    decorate: true
-    spec:
-      containers:
-      - args:
-        - ./hack/codegen.sh
-        command:
-        - sh
-        env:
-        - name: IS_CONTAINER
-          value: "TRUE"
-        image: docker.io/golang:1.19
-        imagePullPolicy: Always
-  - name: generate
-    branches:
-    - release-1.2
-    - release-1.1
-    skip_if_only_changed: '(((^|/)OWNERS)|(\.md))$'
-    decorate: true
-    spec:
-      containers:
-      - args:
-        - ./hack/codegen.sh
-        command:
-        - sh
-        env:
-        - name: IS_CONTAINER
-          value: "TRUE"
-        image: docker.io/golang:1.17
-        imagePullPolicy: Always
-  - name: unit
-    branches:
-    - main
-    - release-1.3
-    skip_if_only_changed: '(((^|/)OWNERS)|(\.md))$'
-    decorate: true
-    spec:
-      containers:
-      - args:
-        - ./hack/unit.sh
-        command:
-        - sh
-        env:
-        - name: IS_CONTAINER
-          value: "TRUE"
-        image: docker.io/golang:1.19
-        imagePullPolicy: Always
-  - name: unit
-    branches:
-    - release-1.2
-    - release-1.1
-    skip_if_only_changed: '(((^|/)OWNERS)|(\.md))$'
-    decorate: true
-    spec:
-      containers:
-      - args:
-        - ./hack/unit.sh
-        command:
-        - sh
-        env:
-        - name: IS_CONTAINER
-          value: "TRUE"
-        image: docker.io/golang:1.17
-        imagePullPolicy: Always
-  - name: manifestlint
-    skip_if_only_changed: '(((^|/)OWNERS)|(\.md))$'
-    decorate: true
-    spec:
-      containers:
-      - args:
-        - ./hack/manifestlint.sh
-        command:
-        - sh
-        env:
-        - name: IS_CONTAINER
-          value: "TRUE"
-        image: docker.io/garethr/kubeval:latest
-        imagePullPolicy: Always
+    - name: gomod
+      branches:
+        - main
+        - release-1.3
+      skip_if_only_changed: '(((^|/)OWNERS)|(\.md))$'
+      decorate: true
+      spec:
+        containers:
+          - args:
+              - ./hack/gomod.sh
+            command:
+              - sh
+            env:
+              - name: IS_CONTAINER
+                value: "TRUE"
+            image: docker.io/golang:1.19
+            imagePullPolicy: Always
+    - name: gomod
+      branches:
+        - release-1.2
+        - release-1.1
+      skip_if_only_changed: '(((^|/)OWNERS)|(\.md))$'
+      decorate: true
+      spec:
+        containers:
+          - args:
+              - ./hack/gomod.sh
+            command:
+              - sh
+            env:
+              - name: IS_CONTAINER
+                value: "TRUE"
+            image: docker.io/golang:1.17
+            imagePullPolicy: Always
+    - name: gofmt
+      branches:
+        - main
+        - release-1.3
+      skip_if_only_changed: '(((^|/)OWNERS)|(\.md))$'
+      decorate: true
+      spec:
+        containers:
+          - args:
+              - ./hack/gofmt.sh
+            command:
+              - sh
+            env:
+              - name: IS_CONTAINER
+                value: "TRUE"
+            image: docker.io/golang:1.19
+            imagePullPolicy: Always
+    - name: gofmt
+      branches:
+        - release-1.2
+        - release-1.1
+      skip_if_only_changed: '(((^|/)OWNERS)|(\.md))$'
+      decorate: true
+      spec:
+        containers:
+          - args:
+              - ./hack/gofmt.sh
+            command:
+              - sh
+            env:
+              - name: IS_CONTAINER
+                value: "TRUE"
+            image: docker.io/golang:1.17
+            imagePullPolicy: Always
+    - name: gosec
+      skip_if_only_changed: '(((^|/)OWNERS)|(\.md))$'
+      decorate: true
+      spec:
+        containers:
+          - args:
+              - ./hack/gosec.sh
+            command:
+              - sh
+            env:
+              - name: IS_CONTAINER
+                value: "TRUE"
+            image: docker.io/securego/gosec:latest
+            imagePullPolicy: Always
+    - name: golangci-lint
+      branches:
+        - main
+        - release-1.3
+      skip_if_only_changed: '(((^|/)OWNERS)|(\.md))$'
+      decorate: true
+      spec:
+        containers:
+          - args:
+              - ./hack/ensure-golangci-lint.sh
+            command:
+              - sh
+            env:
+              - name: IS_CONTAINER
+                value: "TRUE"
+            image: docker.io/golang:1.19
+            imagePullPolicy: Always
+    - name: golangci-lint
+      branches:
+        - release-1.2
+        - release-1.1
+      skip_if_only_changed: '(((^|/)OWNERS)|(\.md))$'
+      decorate: true
+      spec:
+        containers:
+          - args:
+              - ./hack/ensure-golangci-lint.sh
+            command:
+              - sh
+            env:
+              - name: IS_CONTAINER
+                value: "TRUE"
+            image: docker.io/golang:1.17
+            imagePullPolicy: Always
+    - name: govet
+      branches:
+        - main
+        - release-1.3
+      skip_if_only_changed: '(((^|/)OWNERS)|(\.md))$'
+      decorate: true
+      spec:
+        containers:
+          - args:
+              - ./hack/govet.sh
+            command:
+              - sh
+            env:
+              - name: IS_CONTAINER
+                value: "TRUE"
+            image: docker.io/golang:1.19
+            imagePullPolicy: Always
+    - name: govet
+      branches:
+        - release-1.2
+        - release-1.1
+      skip_if_only_changed: '(((^|/)OWNERS)|(\.md))$'
+      decorate: true
+      spec:
+        containers:
+          - args:
+              - ./hack/govet.sh
+            command:
+              - sh
+            env:
+              - name: IS_CONTAINER
+                value: "TRUE"
+            image: docker.io/golang:1.17
+            imagePullPolicy: Always
+    - name: markdownlint
+      run_if_changed: '\.md$'
+      decorate: true
+      spec:
+        containers:
+          - args:
+              - ./hack/markdownlint.sh
+            command:
+              - sh
+            env:
+              - name: IS_CONTAINER
+                value: "TRUE"
+            image: registry.hub.docker.com/pipelinecomponents/markdownlint:0.12.0@sha256:0b8f9fcf0410257b2f3548f67ffe25934cfc9877a618b9f85afcf345a25804a2
+            imagePullPolicy: Always
+    - name: shellcheck
+      run_if_changed: '((\.sh)|^Makefile)$'
+      decorate: true
+      spec:
+        containers:
+          - args:
+              - ./hack/shellcheck.sh
+            command:
+              - sh
+            env:
+              - name: IS_CONTAINER
+                value: "TRUE"
+            image: docker.io/koalaman/shellcheck-alpine:v0.9.0@sha256:e19ed93c22423970d56568e171b4512c9244fc75dd9114045016b4a0073ac4b7
+            imagePullPolicy: Always
+    - name: generate
+      branches:
+        - main
+        - release-1.3
+      skip_if_only_changed: '(((^|/)OWNERS)|(\.md))$'
+      decorate: true
+      spec:
+        containers:
+          - args:
+              - ./hack/codegen.sh
+            command:
+              - sh
+            env:
+              - name: IS_CONTAINER
+                value: "TRUE"
+            image: docker.io/golang:1.19
+            imagePullPolicy: Always
+    - name: generate
+      branches:
+        - release-1.2
+        - release-1.1
+      skip_if_only_changed: '(((^|/)OWNERS)|(\.md))$'
+      decorate: true
+      spec:
+        containers:
+          - args:
+              - ./hack/codegen.sh
+            command:
+              - sh
+            env:
+              - name: IS_CONTAINER
+                value: "TRUE"
+            image: docker.io/golang:1.17
+            imagePullPolicy: Always
+    - name: unit
+      branches:
+        - main
+        - release-1.3
+      skip_if_only_changed: '(((^|/)OWNERS)|(\.md))$'
+      decorate: true
+      spec:
+        containers:
+          - args:
+              - ./hack/unit.sh
+            command:
+              - sh
+            env:
+              - name: IS_CONTAINER
+                value: "TRUE"
+            image: docker.io/golang:1.19
+            imagePullPolicy: Always
+    - name: unit
+      branches:
+        - release-1.2
+        - release-1.1
+      skip_if_only_changed: '(((^|/)OWNERS)|(\.md))$'
+      decorate: true
+      spec:
+        containers:
+          - args:
+              - ./hack/unit.sh
+            command:
+              - sh
+            env:
+              - name: IS_CONTAINER
+                value: "TRUE"
+            image: docker.io/golang:1.17
+            imagePullPolicy: Always
+    - name: manifestlint
+      skip_if_only_changed: '(((^|/)OWNERS)|(\.md))$'
+      decorate: true
+      spec:
+        containers:
+          - args:
+              - ./hack/manifestlint.sh
+            command:
+              - sh
+            env:
+              - name: IS_CONTAINER
+                value: "TRUE"
+            image: docker.io/garethr/kubeval:latest
+            imagePullPolicy: Always
 
   metal3-io/metal3-dev-env:
-  - name: shellcheck
-    run_if_changed: '((\.sh)|^Makefile)$'
-    decorate: true
-    spec:
-      containers:
-      - args:
-        - ./hack/shellcheck.sh
-        command:
-        - sh
-        env:
-        - name: IS_CONTAINER
-          value: "TRUE"
-        image: docker.io/koalaman/shellcheck-alpine:v0.9.0@sha256:e19ed93c22423970d56568e171b4512c9244fc75dd9114045016b4a0073ac4b7
-        imagePullPolicy: Always
-  - name: markdownlint
-    run_if_changed: '\.md$'
-    decorate: true
-    spec:
-      containers:
-      - args:
-        - ./hack/markdownlint.sh
-        command:
-        - sh
-        env:
-        - name: IS_CONTAINER
-          value: "TRUE"
-        image: registry.hub.docker.com/pipelinecomponents/markdownlint:0.12.0@sha256:0b8f9fcf0410257b2f3548f67ffe25934cfc9877a618b9f85afcf345a25804a2
-        imagePullPolicy: Always
+    - name: shellcheck
+      run_if_changed: '((\.sh)|^Makefile)$'
+      decorate: true
+      spec:
+        containers:
+          - args:
+              - ./hack/shellcheck.sh
+            command:
+              - sh
+            env:
+              - name: IS_CONTAINER
+                value: "TRUE"
+            image: docker.io/koalaman/shellcheck-alpine:v0.9.0@sha256:e19ed93c22423970d56568e171b4512c9244fc75dd9114045016b4a0073ac4b7
+            imagePullPolicy: Always
+    - name: markdownlint
+      run_if_changed: '\.md$'
+      decorate: true
+      spec:
+        containers:
+          - args:
+              - ./hack/markdownlint.sh
+            command:
+              - sh
+            env:
+              - name: IS_CONTAINER
+                value: "TRUE"
+            image: registry.hub.docker.com/pipelinecomponents/markdownlint:0.12.0@sha256:0b8f9fcf0410257b2f3548f67ffe25934cfc9877a618b9f85afcf345a25804a2
+            imagePullPolicy: Always
 
   metal3-io/project-infra:
-  - name: check-prow-config
-    skip_if_only_changed: '(((^|/)OWNERS)|(\.md))$'
-    decorate: true
-    spec:
-      containers:
-      - image: gcr.io/k8s-prow/checkconfig:v20210916-7657ce97bf
-        args:
-        - "/checkconfig"
-        - "--config-path"
-        - "prow/config/config.yaml"
-        - "--plugin-config"
-        - "prow/config/plugins.yaml"
-        - "--strict"
-        resources:
-          requests:
-            memory: "500Mi"
+    - name: check-prow-config
+      skip_if_only_changed: '(((^|/)OWNERS)|(\.md))$'
+      decorate: true
+      spec:
+        containers:
+          - image: gcr.io/k8s-prow/checkconfig:v20210916-7657ce97bf
+            args:
+              - "/checkconfig"
+              - "--config-path"
+              - "prow/config/config.yaml"
+              - "--plugin-config"
+              - "prow/config/plugins.yaml"
+              - "--strict"
+            resources:
+              requests:
+                memory: "500Mi"
   metal3-io/metal3-docs:
-  - name: markdownlint
-    run_if_changed: '\.md$'
-    decorate: true
-    spec:
-      containers:
-      - args:
-        - ./hack/markdownlint.sh
-        command:
-        - sh
-        env:
-        - name: IS_CONTAINER
-          value: "TRUE"
-        image: registry.hub.docker.com/pipelinecomponents/markdownlint:0.12.0@sha256:0b8f9fcf0410257b2f3548f67ffe25934cfc9877a618b9f85afcf345a25804a2
-        imagePullPolicy: Always
+    - name: markdownlint
+      run_if_changed: '\.md$'
+      decorate: true
+      spec:
+        containers:
+          - args:
+              - ./hack/markdownlint.sh
+            command:
+              - sh
+            env:
+              - name: IS_CONTAINER
+                value: "TRUE"
+            image: registry.hub.docker.com/pipelinecomponents/markdownlint:0.12.0@sha256:0b8f9fcf0410257b2f3548f67ffe25934cfc9877a618b9f85afcf345a25804a2
+            imagePullPolicy: Always
 
   metal3-io/ip-address-manager:
-  - name: gomod
-    branches:
-    - main
-    - release-1.3
-    skip_if_only_changed: '(((^|/)OWNERS)|(\.md))$'
-    decorate: true
-    spec:
-      containers:
-      - args:
-        - ./hack/gomod.sh
-        command:
-        - sh
-        env:
-        - name: IS_CONTAINER
-          value: "TRUE"
-        image: docker.io/golang:1.19
-        imagePullPolicy: Always
-  - name: gomod
-    branches:
-    - release-1.2
-    - release-1.1
-    skip_if_only_changed: '(((^|/)OWNERS)|(\.md))$'
-    decorate: true
-    spec:
-      containers:
-      - args:
-        - ./hack/gomod.sh
-        command:
-        - sh
-        env:
-        - name: IS_CONTAINER
-          value: "TRUE"
-        image: docker.io/golang:1.17
-        imagePullPolicy: Always
-  - name: gosec
-    skip_if_only_changed: '(((^|/)OWNERS)|(\.md))$'
-    decorate: true
-    spec:
-      containers:
-      - args:
-        - ./hack/gosec.sh
-        command:
-        - sh
-        env:
-        - name: IS_CONTAINER
-          value: "TRUE"
-        image: docker.io/securego/gosec:latest
-        imagePullPolicy: Always
-  - name: gofmt
-    branches:
-    - main
-    - release-1.3
-    skip_if_only_changed: '(((^|/)OWNERS)|(\.md))$'
-    decorate: true
-    spec:
-      containers:
-      - args:
-        - ./hack/gofmt.sh
-        command:
-        - sh
-        env:
-        - name: IS_CONTAINER
-          value: "TRUE"
-        image: docker.io/golang:1.19
-        imagePullPolicy: Always
-  - name: gofmt
-    branches:
-    - release-1.2
-    - release-1.1
-    skip_if_only_changed: '(((^|/)OWNERS)|(\.md))$'
-    decorate: true
-    spec:
-      containers:
-      - args:
-        - ./hack/gofmt.sh
-        command:
-        - sh
-        env:
-        - name: IS_CONTAINER
-          value: "TRUE"
-        image: docker.io/golang:1.17
-        imagePullPolicy: Always
-  - name: golangci-lint
-    branches:
-    - main
-    - release-1.3
-    skip_if_only_changed: '(((^|/)OWNERS)|(\.md))$'
-    decorate: true
-    spec:
-      containers:
-      - args:
-        - ./hack/ensure-golangci-lint.sh
-        command:
-        - sh
-        env:
-        - name: IS_CONTAINER
-          value: "TRUE"
-        image: docker.io/golang:1.19
-        imagePullPolicy: Always
-  - name: golangci-lint
-    branches:
-    - release-1.2
-    - release-1.1
-    skip_if_only_changed: '(((^|/)OWNERS)|(\.md))$'
-    decorate: true
-    spec:
-      containers:
-      - args:
-        - ./hack/ensure-golangci-lint.sh
-        command:
-        - sh
-        env:
-        - name: IS_CONTAINER
-          value: "TRUE"
-        image: docker.io/golang:1.17
-        imagePullPolicy: Always
-  - name: govet
-    branches:
-    - main
-    - release-1.3
-    skip_if_only_changed: '(((^|/)OWNERS)|(\.md))$'
-    decorate: true
-    spec:
-      containers:
-      - args:
-        - ./hack/govet.sh
-        command:
-        - sh
-        env:
-        - name: IS_CONTAINER
-          value: "TRUE"
-        image: docker.io/golang:1.19
-        imagePullPolicy: Always
-  - name: govet
-    branches:
-    - release-1.2
-    - release-1.1
-    skip_if_only_changed: '(((^|/)OWNERS)|(\.md))$'
-    decorate: true
-    spec:
-      containers:
-      - args:
-        - ./hack/govet.sh
-        command:
-        - sh
-        env:
-        - name: IS_CONTAINER
-          value: "TRUE"
-        image: docker.io/golang:1.17
-        imagePullPolicy: Always
-  - name: markdownlint
-    run_if_changed: '\.md$'
-    decorate: true
-    spec:
-      containers:
-      - args:
-        - ./hack/markdownlint.sh
-        command:
-        - sh
-        env:
-        - name: IS_CONTAINER
-          value: "TRUE"
-        image: registry.hub.docker.com/pipelinecomponents/markdownlint:0.12.0@sha256:0b8f9fcf0410257b2f3548f67ffe25934cfc9877a618b9f85afcf345a25804a2
-        imagePullPolicy: Always
-  - name: shellcheck
-    run_if_changed: '((\.sh)|^Makefile)$'
-    decorate: true
-    spec:
-      containers:
-      - args:
-        - ./hack/shellcheck.sh
-        command:
-        - sh
-        env:
-        - name: IS_CONTAINER
-          value: "TRUE"
-        image: docker.io/koalaman/shellcheck-alpine:v0.9.0@sha256:e19ed93c22423970d56568e171b4512c9244fc75dd9114045016b4a0073ac4b7
-        imagePullPolicy: Always
-  - name: unit
-    branches:
-    - main
-    - release-1.3
-    skip_if_only_changed: '(((^|/)OWNERS)|(\.md))$'
-    decorate: true
-    spec:
-      containers:
-      - args:
-        - ./hack/unit.sh
-        command:
-        - sh
-        env:
-        - name: IS_CONTAINER
-          value: "TRUE"
-        image: docker.io/golang:1.19
-  - name: unit
-    branches:
-    - release-1.2
-    - release-1.1
-    skip_if_only_changed: '(((^|/)OWNERS)|(\.md))$'
-    decorate: true
-    spec:
-      containers:
-      - args:
-        - ./hack/unit.sh
-        command:
-        - sh
-        env:
-        - name: IS_CONTAINER
-          value: "TRUE"
-        image: docker.io/golang:1.17
-        imagePullPolicy: Always
-  - name: generate
-    branches:
-    - main
-    - release-1.3
-    skip_if_only_changed: '(((^|/)OWNERS)|(\.md))$'
-    decorate: true
-    spec:
-      containers:
-      - args:
-        - ./hack/codegen.sh
-        command:
-        - sh
-        env:
-        - name: IS_CONTAINER
-          value: "TRUE"
-        image: docker.io/golang:1.19
-        imagePullPolicy: Always
-  - name: generate
-    branches:
-    - release-1.2
-    - release-1.1
-    skip_if_only_changed: '(((^|/)OWNERS)|(\.md))$'
-    decorate: true
-    spec:
-      containers:
-      - args:
-        - ./hack/codegen.sh
-        command:
-        - sh
-        env:
-        - name: IS_CONTAINER
-          value: "TRUE"
-        image: docker.io/golang:1.17
-        imagePullPolicy: Always
-  - name: manifestlint
-    skip_if_only_changed: '(((^|/)OWNERS)|(\.md))$'
-    decorate: true
-    spec:
-      containers:
-      - args:
-        - ./hack/manifestlint.sh
-        command:
-        - sh
-        env:
-        - name: IS_CONTAINER
-          value: "TRUE"
-        image: docker.io/garethr/kubeval:latest
-        imagePullPolicy: Always
+    - name: gomod
+      branches:
+        - main
+        - release-1.3
+      skip_if_only_changed: '(((^|/)OWNERS)|(\.md))$'
+      decorate: true
+      spec:
+        containers:
+          - args:
+              - ./hack/gomod.sh
+            command:
+              - sh
+            env:
+              - name: IS_CONTAINER
+                value: "TRUE"
+            image: docker.io/golang:1.19
+            imagePullPolicy: Always
+    - name: gomod
+      branches:
+        - release-1.2
+        - release-1.1
+      skip_if_only_changed: '(((^|/)OWNERS)|(\.md))$'
+      decorate: true
+      spec:
+        containers:
+          - args:
+              - ./hack/gomod.sh
+            command:
+              - sh
+            env:
+              - name: IS_CONTAINER
+                value: "TRUE"
+            image: docker.io/golang:1.17
+            imagePullPolicy: Always
+    - name: gosec
+      skip_if_only_changed: '(((^|/)OWNERS)|(\.md))$'
+      decorate: true
+      spec:
+        containers:
+          - args:
+              - ./hack/gosec.sh
+            command:
+              - sh
+            env:
+              - name: IS_CONTAINER
+                value: "TRUE"
+            image: docker.io/securego/gosec:latest
+            imagePullPolicy: Always
+    - name: gofmt
+      branches:
+        - main
+        - release-1.3
+      skip_if_only_changed: '(((^|/)OWNERS)|(\.md))$'
+      decorate: true
+      spec:
+        containers:
+          - args:
+              - ./hack/gofmt.sh
+            command:
+              - sh
+            env:
+              - name: IS_CONTAINER
+                value: "TRUE"
+            image: docker.io/golang:1.19
+            imagePullPolicy: Always
+    - name: gofmt
+      branches:
+        - release-1.2
+        - release-1.1
+      skip_if_only_changed: '(((^|/)OWNERS)|(\.md))$'
+      decorate: true
+      spec:
+        containers:
+          - args:
+              - ./hack/gofmt.sh
+            command:
+              - sh
+            env:
+              - name: IS_CONTAINER
+                value: "TRUE"
+            image: docker.io/golang:1.17
+            imagePullPolicy: Always
+    - name: golangci-lint
+      branches:
+        - main
+        - release-1.3
+      skip_if_only_changed: '(((^|/)OWNERS)|(\.md))$'
+      decorate: true
+      spec:
+        containers:
+          - args:
+              - ./hack/ensure-golangci-lint.sh
+            command:
+              - sh
+            env:
+              - name: IS_CONTAINER
+                value: "TRUE"
+            image: docker.io/golang:1.19
+            imagePullPolicy: Always
+    - name: golangci-lint
+      branches:
+        - release-1.2
+        - release-1.1
+      skip_if_only_changed: '(((^|/)OWNERS)|(\.md))$'
+      decorate: true
+      spec:
+        containers:
+          - args:
+              - ./hack/ensure-golangci-lint.sh
+            command:
+              - sh
+            env:
+              - name: IS_CONTAINER
+                value: "TRUE"
+            image: docker.io/golang:1.17
+            imagePullPolicy: Always
+    - name: govet
+      branches:
+        - main
+        - release-1.3
+      skip_if_only_changed: '(((^|/)OWNERS)|(\.md))$'
+      decorate: true
+      spec:
+        containers:
+          - args:
+              - ./hack/govet.sh
+            command:
+              - sh
+            env:
+              - name: IS_CONTAINER
+                value: "TRUE"
+            image: docker.io/golang:1.19
+            imagePullPolicy: Always
+    - name: govet
+      branches:
+        - release-1.2
+        - release-1.1
+      skip_if_only_changed: '(((^|/)OWNERS)|(\.md))$'
+      decorate: true
+      spec:
+        containers:
+          - args:
+              - ./hack/govet.sh
+            command:
+              - sh
+            env:
+              - name: IS_CONTAINER
+                value: "TRUE"
+            image: docker.io/golang:1.17
+            imagePullPolicy: Always
+    - name: markdownlint
+      run_if_changed: '\.md$'
+      decorate: true
+      spec:
+        containers:
+          - args:
+              - ./hack/markdownlint.sh
+            command:
+              - sh
+            env:
+              - name: IS_CONTAINER
+                value: "TRUE"
+            image: registry.hub.docker.com/pipelinecomponents/markdownlint:0.12.0@sha256:0b8f9fcf0410257b2f3548f67ffe25934cfc9877a618b9f85afcf345a25804a2
+            imagePullPolicy: Always
+    - name: shellcheck
+      run_if_changed: '((\.sh)|^Makefile)$'
+      decorate: true
+      spec:
+        containers:
+          - args:
+              - ./hack/shellcheck.sh
+            command:
+              - sh
+            env:
+              - name: IS_CONTAINER
+                value: "TRUE"
+            image: docker.io/koalaman/shellcheck-alpine:v0.9.0@sha256:e19ed93c22423970d56568e171b4512c9244fc75dd9114045016b4a0073ac4b7
+            imagePullPolicy: Always
+    - name: unit
+      branches:
+        - main
+        - release-1.3
+      skip_if_only_changed: '(((^|/)OWNERS)|(\.md))$'
+      decorate: true
+      spec:
+        containers:
+          - args:
+              - ./hack/unit.sh
+            command:
+              - sh
+            env:
+              - name: IS_CONTAINER
+                value: "TRUE"
+            image: docker.io/golang:1.19
+    - name: unit
+      branches:
+        - release-1.2
+        - release-1.1
+      skip_if_only_changed: '(((^|/)OWNERS)|(\.md))$'
+      decorate: true
+      spec:
+        containers:
+          - args:
+              - ./hack/unit.sh
+            command:
+              - sh
+            env:
+              - name: IS_CONTAINER
+                value: "TRUE"
+            image: docker.io/golang:1.17
+            imagePullPolicy: Always
+    - name: generate
+      branches:
+        - main
+        - release-1.3
+      skip_if_only_changed: '(((^|/)OWNERS)|(\.md))$'
+      decorate: true
+      spec:
+        containers:
+          - args:
+              - ./hack/codegen.sh
+            command:
+              - sh
+            env:
+              - name: IS_CONTAINER
+                value: "TRUE"
+            image: docker.io/golang:1.19
+            imagePullPolicy: Always
+    - name: generate
+      branches:
+        - release-1.2
+        - release-1.1
+      skip_if_only_changed: '(((^|/)OWNERS)|(\.md))$'
+      decorate: true
+      spec:
+        containers:
+          - args:
+              - ./hack/codegen.sh
+            command:
+              - sh
+            env:
+              - name: IS_CONTAINER
+                value: "TRUE"
+            image: docker.io/golang:1.17
+            imagePullPolicy: Always
+    - name: manifestlint
+      skip_if_only_changed: '(((^|/)OWNERS)|(\.md))$'
+      decorate: true
+      spec:
+        containers:
+          - args:
+              - ./hack/manifestlint.sh
+            command:
+              - sh
+            env:
+              - name: IS_CONTAINER
+                value: "TRUE"
+            image: docker.io/garethr/kubeval:latest
+            imagePullPolicy: Always
 
   metal3-io/hardware-classification-controller:
-  - name: gofmt
-    run_if_changed: '\.go$'
-    decorate: true
-    spec:
-      containers:
-      - args:
-        - ./hack/gofmt.sh
-        command:
-        - sh
-        env:
-        - name: IS_CONTAINER
-          value: "TRUE"
-        image: docker.io/golang:1.17
-        imagePullPolicy: Always
-  - name: govet
-    run_if_changed: '\.go$'
-    decorate: true
-    spec:
-      containers:
-      - args:
-        - ./hack/govet.sh
-        command:
-        - sh
-        env:
-        - name: IS_CONTAINER
-          value: "TRUE"
-        image: docker.io/golang:1.17
-        imagePullPolicy: Always
-  - name: markdownlint
-    run_if_changed: '\.md$'
-    decorate: true
-    spec:
-      containers:
-      - args:
-        - ./hack/markdownlint.sh
-        command:
-        - sh
-        env:
-        - name: IS_CONTAINER
-          value: "TRUE"
-        image: registry.hub.docker.com/pipelinecomponents/markdownlint:0.12.0@sha256:0b8f9fcf0410257b2f3548f67ffe25934cfc9877a618b9f85afcf345a25804a2
-        imagePullPolicy: Always
-  - name: shellcheck
-    run_if_changed: '((\.sh)|(^Makefile))$'
-    decorate: true
-    spec:
-      containers:
-      - args:
-        - ./hack/shellcheck.sh
-        command:
-        - sh
-        env:
-        - name: IS_CONTAINER
-          value: "TRUE"
-        image: docker.io/koalaman/shellcheck-alpine:v0.9.0@sha256:e19ed93c22423970d56568e171b4512c9244fc75dd9114045016b4a0073ac4b7
-        imagePullPolicy: Always
-  - name: unit
-    skip_if_only_changed: '(((^|/)OWNERS)|(\.md))$'
-    decorate: true
-    spec:
-      containers:
-      - args:
-        - ./hack/unit.sh
-        command:
-        - sh
-        env:
-        - name: IS_CONTAINER
-          value: "TRUE"
-        image: docker.io/golang:1.16
-        imagePullPolicy: Always
-  - name: manifestlint
-    skip_if_only_changed: '(((^|/)OWNERS)|(\.md))$'
-    decorate: true
-    spec:
-      containers:
-      - args:
-        - ./hack/manifestlint.sh
-        command:
-        - sh
-        env:
-        - name: IS_CONTAINER
-          value: "TRUE"
-        image: docker.io/garethr/kubeval:latest
-        imagePullPolicy: Always
+    - name: gofmt
+      run_if_changed: '\.go$'
+      decorate: true
+      spec:
+        containers:
+          - args:
+              - ./hack/gofmt.sh
+            command:
+              - sh
+            env:
+              - name: IS_CONTAINER
+                value: "TRUE"
+            image: docker.io/golang:1.17
+            imagePullPolicy: Always
+    - name: govet
+      run_if_changed: '\.go$'
+      decorate: true
+      spec:
+        containers:
+          - args:
+              - ./hack/govet.sh
+            command:
+              - sh
+            env:
+              - name: IS_CONTAINER
+                value: "TRUE"
+            image: docker.io/golang:1.17
+            imagePullPolicy: Always
+    - name: markdownlint
+      run_if_changed: '\.md$'
+      decorate: true
+      spec:
+        containers:
+          - args:
+              - ./hack/markdownlint.sh
+            command:
+              - sh
+            env:
+              - name: IS_CONTAINER
+                value: "TRUE"
+            image: registry.hub.docker.com/pipelinecomponents/markdownlint:0.12.0@sha256:0b8f9fcf0410257b2f3548f67ffe25934cfc9877a618b9f85afcf345a25804a2
+            imagePullPolicy: Always
+    - name: shellcheck
+      run_if_changed: '((\.sh)|(^Makefile))$'
+      decorate: true
+      spec:
+        containers:
+          - args:
+              - ./hack/shellcheck.sh
+            command:
+              - sh
+            env:
+              - name: IS_CONTAINER
+                value: "TRUE"
+            image: docker.io/koalaman/shellcheck-alpine:v0.9.0@sha256:e19ed93c22423970d56568e171b4512c9244fc75dd9114045016b4a0073ac4b7
+            imagePullPolicy: Always
+    - name: unit
+      skip_if_only_changed: '(((^|/)OWNERS)|(\.md))$'
+      decorate: true
+      spec:
+        containers:
+          - args:
+              - ./hack/unit.sh
+            command:
+              - sh
+            env:
+              - name: IS_CONTAINER
+                value: "TRUE"
+            image: docker.io/golang:1.16
+            imagePullPolicy: Always
+    - name: manifestlint
+      skip_if_only_changed: '(((^|/)OWNERS)|(\.md))$'
+      decorate: true
+      spec:
+        containers:
+          - args:
+              - ./hack/manifestlint.sh
+            command:
+              - sh
+            env:
+              - name: IS_CONTAINER
+                value: "TRUE"
+            image: docker.io/garethr/kubeval:latest
+            imagePullPolicy: Always
 
   metal3-io/ironic-ipa-downloader:
-  - name: shellcheck
-    run_if_changed: '((\.sh)|^Makefile)$'
-    decorate: true
-    spec:
-      containers:
-        - args:
-            - ./hack/shellcheck.sh
-          command:
-            - sh
-          env:
-            - name: IS_CONTAINER
-              value: "TRUE"
-          image: docker.io/koalaman/shellcheck-alpine:v0.9.0@sha256:e19ed93c22423970d56568e171b4512c9244fc75dd9114045016b4a0073ac4b7
-          imagePullPolicy: Always
+    - name: shellcheck
+      run_if_changed: '((\.sh)|^Makefile)$'
+      decorate: true
+      spec:
+        containers:
+          - args:
+              - ./hack/shellcheck.sh
+            command:
+              - sh
+            env:
+              - name: IS_CONTAINER
+                value: "TRUE"
+            image: docker.io/koalaman/shellcheck-alpine:v0.9.0@sha256:e19ed93c22423970d56568e171b4512c9244fc75dd9114045016b4a0073ac4b7
+            imagePullPolicy: Always


### PR DESCRIPTION
kubeval is not maintained anymore, and suggest moving to kubeconform. Change manifestlint.sh to use kubeconform.
    
Pin kubeconform image with a version and a digest.

Fix indentation of prow config.