### PR TITLE
Move ephemeral cluster from jumphost to internal server

### DIFF
--- a/jenkins/scripts/bml_cleanup.sh
+++ b/jenkins/scripts/bml_cleanup.sh
@@ -12,19 +12,21 @@ echo "Cleaning up the lab"
 # Execute remote script
 # shellcheck disable=SC2029
 
-TEST_EXECUTER_IP="129.192.80.20"
+JUMPHOST_IP="129.192.80.20"
+TEST_EXECUTER_IP="192.168.1.3"
 
 ssh \
   -o StrictHostKeyChecking=no \
   -o UserKnownHostsFile=/dev/null \
   -o ServerAliveInterval=15 \
   -o ServerAliveCountMax=10 \
-  -i "${METAL3_CI_USER_KEY}" \
-  "${METAL3_CI_USER}"@"${TEST_EXECUTER_IP}" \
-  -o SendEnv="GITHUB_TOKEN" \
   -o SendEnv="BML_ILO_USERNAME" \
   -o SendEnv="BML_ILO_PASSWORD" \
+  -o SendEnv="GITHUB_TOKEN" \
   -o SendEnv="REPO_NAME" \
   -o SendEnv="BML_METAL3_DEV_ENV_REPO" \
   -o SendEnv="BML_METAL3_DEV_ENV_BRANCH" \
-  ANSIBLE_FORCE_COLOR=true ansible-playbook -v /tmp/bare_metal_lab/cleanup-lab.yaml --skip-tags "clone"
+  -i "${METAL3_CI_USER_KEY}" \
+  -o ProxyCommand="ssh -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -i ${METAL3_CI_USER_KEY} -W %h:%p ${METAL3_CI_USER}@${JUMPHOST_IP}" \
+  "${METAL3_CI_USER}"@"${TEST_EXECUTER_IP}" \
+  ANSIBLE_FORCE_COLOR=true ansible-playbook -v /tmp/bare_metal_lab/deploy-lab.yaml --skip-tags "clone"


### PR DESCRIPTION
This PR moves running ephemeral cluster from jumphost to internal server in bml. 
1. Jumphost is critical for our lab. Dependencies of project always change and require newer package versions. It creates a risk of breaking OS at any point. OS that we test in CI already newer version than in jumphost. We have already seen package conflicts several times. 
2. After changes Ephemeral cluster (minikube) runs on internal server. We still use jumphost as a proxy to reach internal server.