### PR TITLE
prow: uplift go in ipam release-1.2 branch to 1.18

### DIFF
--- a/prow/config/config.yaml
+++ b/prow/config/config.yaml
@@ -804,6 +804,21 @@ presubmits:
     - name: gomod
       branches:
         - release-1.2
+      skip_if_only_changed: '(((^|/)OWNERS)|(\.md))$'
+      decorate: true
+      spec:
+        containers:
+          - args:
+              - ./hack/gomod.sh
+            command:
+              - sh
+            env:
+              - name: IS_CONTAINER
+                value: "TRUE"
+            image: docker.io/golang:1.18
+            imagePullPolicy: Always
+    - name: gomod
+      branches:
         - release-1.1
       skip_if_only_changed: '(((^|/)OWNERS)|(\.md))$'
       decorate: true


### PR DESCRIPTION
IPAM release-1.12 check for gomod need to be uplifted to go 1.18, as release-1.2 hack/tools/ is based on go 1.18.