### PR TITLE
prow: add metal3-io/.github to prow

### DIFF
--- a/prow/config/config.yaml
+++ b/prow/config/config.yaml
@@ -36,6 +36,7 @@ tide:
     Nordix/metal3-clusterapi-docs: rebase
   queries:
     - repos:
+        - metal3-io/.github
         - metal3-io/baremetal-operator
         - metal3-io/cluster-api-provider-metal3
         - metal3-io/ironic-client

--- a/prow/config/plugins.yaml
+++ b/prow/config/plugins.yaml
@@ -51,6 +51,7 @@ plugins:
       - wip
       - yuks
       - require-matching-label
+  metal3-io/.github:
   metal3-io/baremetal-operator:
   metal3-io/cluster-api-provider-metal3:
   metal3-io/ip-address-manager:


### PR DESCRIPTION
Activate prow for the .github special repository.