### PR TITLE
drop nonexisting check for mariadb-image

### DIFF
--- a/prow/config/config.yaml
+++ b/prow/config/config.yaml
@@ -157,11 +157,6 @@ branch-protection:
             release-1.3:
               required_status_checks:
                 contexts: ["test-ubuntu-integration-release-1-3"]
-        mariadb-image:
-          branches:
-            main:
-              required_status_checks:
-                contexts: ["test-ubuntu-integration-main"]
         metal3-dev-env:
           branches:
             main:


### PR DESCRIPTION
Tide can't merge anything there as tide keeps waiting for this, but any steps to run it do not exist.