### PR TITLE
review approval shall not act as /approve

### DIFF
--- a/prow/config/plugins.yaml
+++ b/prow/config/plugins.yaml
@@ -80,6 +80,9 @@ approve:
     # A /lgtm from a single approver should not allow a PR to merge.
     lgtm_acts_as_approve: false
 
+    # Approving review shall not act as /approve
+    review_acts_as_approve: false
+
 external_plugins:
   Nordix/metal3-dev-tools:
     - name: needs-rebase


### PR DESCRIPTION
Approving a review has acted same as explicit /approve if you have approval rights in the OWNERS. Let's make it so that if you want to approve a PR, you need to be explicit about it.

This is really badly documented in PROW, but this comment is the key: https://github.com/kubernetes/test-infra/blob/adf0d415167f1cba4cff708033f4184ad8cf3f33/prow/plugins/approve/approve.go#LL367C49-L367C68