### PR TITLE
remove static-ip-manager-image from prow

### DIFF
--- a/prow/config/config.yaml
+++ b/prow/config/config.yaml
@@ -49,7 +49,6 @@ tide:
         - metal3-io/metal3-docs
         - metal3-io/metal3-io.github.io
         - metal3-io/project-infra
-        - metal3-io/static-ip-manager-image
         - metal3-io/ip-address-manager
         - Nordix/metal3-dev-tools
         - Nordix/metal3-clusterapi-docs


### PR DESCRIPTION
static-ip-manager-image repo has been archived, and can be removed from prow config.