### PR TITLE
Add release-1.4 branch configurations for CAPM3/IPAM repos

### DIFF
--- a/jenkins/README.md
+++ b/jenkins/README.md
@@ -27,6 +27,10 @@ the commands below. The job result will be posted as a comment.
   v1beta1 and branch main on Ubuntu
 * **/test-centos-integration-main** run integration tests with CAPM3 API version
   v1beta1 and branch main on CentOS
+* **/test-ubuntu-integration-release-1-4** run integration tests with CAPM3 API
+  version v1beta1 and branch release-1.4 on Ubuntu
+* **/test-centos-integration-release-1-4** run integration tests with CAPM3 API
+  version v1beta1 and branch release-1.4 on CentOS
 * **/test-ubuntu-integration-release-1-3** run integration tests with CAPM3 API
   version v1beta1 and branch release-1.3 on Ubuntu
 * **/test-centos-integration-release-1-3** run integration tests with CAPM3 API
@@ -49,6 +53,10 @@ clean up and deletion operations, there are separate triggers phrases as below:
   API version v1beta1 and branch main on Ubuntu
 * **/keep-test-centos-integration-main** run keep integration tests with CAPM3
   API version v1beta1 and branch main on CentOS
+* **/keep-test-ubuntu-integration-release-1-4** run keep integration tests with
+  CAPM3 API version v1beta1 and branch release-1.4 on Ubuntu
+* **/keep-test-centos-integration-release-1-4** run keep integration tests with
+  CAPM3 API version v1beta1 and branch release-1.4 on CentOS
 * **/keep-test-ubuntu-integration-release-1-3** run keep integration tests with
   CAPM3 API version v1beta1 and branch release-1.3 on Ubuntu
 * **/keep-test-centos-integration-release-1-3** run keep integration tests with

--- a/prow/manifests/overlays/metal3/config.yaml
+++ b/prow/manifests/overlays/metal3/config.yaml
@@ -128,6 +128,9 @@ branch-protection:
             release-1.3:
               required_status_checks:
                 contexts: ["test-ubuntu-integration-release-1-3"]
+            release-1.4:
+              required_status_checks:
+                contexts: ["test-ubuntu-integration-release-1-4"]
         ironic-image:
           branches:
             main:
@@ -156,6 +159,9 @@ branch-protection:
             release-1.3:
               required_status_checks:
                 contexts: ["test-ubuntu-integration-release-1-3"]
+            release-1.4:
+              required_status_checks:
+                contexts: ["test-ubuntu-integration-release-1-4"]
         mariadb-image:
           branches:
             main:
@@ -168,7 +174,7 @@ branch-protection:
                 contexts:
                   [
                     "test-ubuntu-e2e-integration-main",
-                    "test-centos-integration-release-1-3",
+                    "test-centos-integration-release-1-4",
                   ]
 
 deck:
@@ -453,6 +459,7 @@ presubmits:
       branches:
         - main
         - release-1.3
+        - release-1.4
       skip_if_only_changed: '(((^|/)OWNERS)|(\.md))$'
       decorate: true
       spec:
@@ -487,6 +494,7 @@ presubmits:
       branches:
         - main
         - release-1.3
+        - release-1.4
       skip_if_only_changed: '(((^|/)OWNERS)|(\.md))$'
       decorate: true
       spec:
@@ -535,6 +543,7 @@ presubmits:
       branches:
         - main
         - release-1.3
+        - release-1.4
       skip_if_only_changed: '(((^|/)OWNERS)|(\.md))$'
       decorate: true
       spec:
@@ -569,6 +578,7 @@ presubmits:
       branches:
         - main
         - release-1.3
+        - release-1.4
       skip_if_only_changed: '(((^|/)OWNERS)|(\.md))$'
       decorate: true
       spec:
@@ -631,6 +641,7 @@ presubmits:
       branches:
         - main
         - release-1.3
+        - release-1.4
       skip_if_only_changed: '(((^|/)OWNERS)|(\.md))$'
       decorate: true
       spec:
@@ -665,6 +676,7 @@ presubmits:
       branches:
         - main
         - release-1.3
+        - release-1.4
       skip_if_only_changed: '(((^|/)OWNERS)|(\.md))$'
       decorate: true
       spec:
@@ -715,6 +727,7 @@ presubmits:
       branches:
         - main
         - release-1.3
+        - release-1.4
       run_if_changed: '^api|^test|^Makefile$'
       decorate: true
       spec:
@@ -811,6 +824,7 @@ presubmits:
       branches:
         - main
         - release-1.3
+        - release-1.4
       skip_if_only_changed: '(((^|/)OWNERS)|(\.md))$'
       decorate: true
       spec:
@@ -874,6 +888,7 @@ presubmits:
       branches:
         - main
         - release-1.3
+        - release-1.4
       skip_if_only_changed: '(((^|/)OWNERS)|(\.md))$'
       decorate: true
       spec:
@@ -908,6 +923,7 @@ presubmits:
       branches:
         - main
         - release-1.3
+        - release-1.4
       skip_if_only_changed: '(((^|/)OWNERS)|(\.md))$'
       decorate: true
       spec:
@@ -942,6 +958,7 @@ presubmits:
       branches:
         - main
         - release-1.3
+        - release-1.4
       skip_if_only_changed: '(((^|/)OWNERS)|(\.md))$'
       decorate: true
       spec:
@@ -1004,6 +1021,7 @@ presubmits:
       branches:
         - main
         - release-1.3
+        - release-1.4
       skip_if_only_changed: '(((^|/)OWNERS)|(\.md))$'
       decorate: true
       spec:
@@ -1037,6 +1055,7 @@ presubmits:
       branches:
         - main
         - release-1.3
+        - release-1.4
       skip_if_only_changed: '(((^|/)OWNERS)|(\.md))$'
       decorate: true
       spec:


### PR DESCRIPTION
Updates the prow config and README for CAPM3 and IPAM release-1.4 configurations. The ansible required  tests would be replaced with e2e in future. 