### PR TITLE
add markdownlint linter and fix markdown issues

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # metal3.io Project Infrastructure
 
-We operate a CI Cluster which runs [Prow](prow/README.md) to provide CI and some
-github automation.
+We operate a CI Cluster which runs [Prow](prow/README.md) to provide CI and
+some GitHub automation.
 
 We also run a [Jenkins](jenkins/README.md) server for some additional CI jobs.

--- a/hack/markdownlint.sh
+++ b/hack/markdownlint.sh
@@ -1,0 +1,19 @@
+#!/bin/sh
+
+set -eux
+
+IS_CONTAINER="${IS_CONTAINER:-false}"
+CONTAINER_RUNTIME="${CONTAINER_RUNTIME:-podman}"
+
+if [ "${IS_CONTAINER}" != "false" ]; then
+    TOP_DIR="${1:-.}"
+    find "${TOP_DIR}" -type d \( -path ./vendor -o -path ./.github \) -prune -o -name '*.md' -exec mdl --style all --warnings {} \+
+else
+    "${CONTAINER_RUNTIME}" run --rm \
+        --env IS_CONTAINER=TRUE \
+        --volume "${PWD}:/workdir:ro,z" \
+        --entrypoint sh \
+        --workdir /workdir \
+        docker.io/pipelinecomponents/markdownlint:0.12.0@sha256:0b8f9fcf0410257b2f3548f67ffe25934cfc9877a618b9f85afcf345a25804a2 \
+        /workdir/hack/markdownlint.sh "$@"
+fi

--- a/jenkins/README.md
+++ b/jenkins/README.md
@@ -13,72 +13,103 @@ publicly visible will get admin rights on the CI jobs. This means:
 
 * They can start the jobs on their PR directly
 * They can start the jobs for PR of authors that are not in the organization
-* They can add authors to whitelist (by commenting **/ok-to-test** on the PR) so that
-   the authors can start jobs on their PR themselves
+* They can add authors to whitelist (by commenting **/ok-to-test** on the PR) so
+  that the authors can start jobs on their PR themselves
 
 ## Jenkins commands
 
 We have multiple jobs that run some integration tests. The jobs can be
-triggered on PR from metal3-dev-env, baremetal-operator, ironic-image, ip-address-manager
-and cluster-api-provider-metal3 repositories by commenting the commands below.
-The job result will be posted as a comment.
+triggered on PR from metal3-dev-env, baremetal-operator, ironic-image,
+ip-address-manager and cluster-api-provider-metal3 repositories by commenting
+the commands below. The job result will be posted as a comment.
 
-* **/test-ubuntu-integration-main** run integration tests with CAPM3 API version v1beta1 and branch main on Ubuntu
-* **/test-centos-integration-main** run integration tests with CAPM3 API version v1beta1 and branch main on CentOS
-* **/test-ubuntu-integration-release-1-3** run integration tests with CAPM3 API version v1beta1 and branch release-1.3 on Ubuntu
-* **/test-centos-integration-release-1-3** run integration tests with CAPM3 API version v1beta1 and branch release-1.3 on CentOS
-* **/test-ubuntu-integration-release-1-2** run integration tests with CAPM3 API version v1beta1 and branch release-1.2 on Ubuntu
-* **/test-centos-integration-release-1-2** run integration tests with CAPM3 API version v1beta1 and branch release-1.2 on CentOS
-* **/test-ubuntu-integration-release-1-1** run integration tests with CAPM3 API version v1beta1 and branch release-1.1 on Ubuntu
-* **/test-centos-integration-release-1-1** run integration tests with CAPM3 API version v1beta1 and branch release-1.1 on CentOS
+* **/test-ubuntu-integration-main** run integration tests with CAPM3 API version
+  v1beta1 and branch main on Ubuntu
+* **/test-centos-integration-main** run integration tests with CAPM3 API version
+  v1beta1 and branch main on CentOS
+* **/test-ubuntu-integration-release-1-3** run integration tests with CAPM3 API
+  version v1beta1 and branch release-1.3 on Ubuntu
+* **/test-centos-integration-release-1-3** run integration tests with CAPM3 API
+  version v1beta1 and branch release-1.3 on CentOS
+* **/test-ubuntu-integration-release-1-2** run integration tests with CAPM3 API
+  version v1beta1 and branch release-1.2 on Ubuntu
+* **/test-centos-integration-release-1-2** run integration tests with CAPM3 API
+  version v1beta1 and branch release-1.2 on CentOS
+* **/test-ubuntu-integration-release-1-1** run integration tests with CAPM3 API
+  version v1beta1 and branch release-1.1 on Ubuntu
+* **/test-centos-integration-release-1-1** run integration tests with CAPM3 API
+  version v1beta1 and branch release-1.1 on CentOS
 
 Usually, after the integration test part is completed, Jenkins executes another
-script to clean up the environment first and then deletes the VM. However, sometimes
-it may be desirable to keep the VM for debugging purposes. To avoid clean up
-and deletion operations, there are separate triggers phrases as below:
+script to clean up the environment first and then deletes the VM. However,
+sometimes it may be desirable to keep the VM for debugging purposes. To avoid
+clean up and deletion operations, there are separate triggers phrases as below:
 
-* **/keep-test-ubuntu-integration-main** run keep integration tests with CAPM3 API version v1beta1 and branch main on Ubuntu
-* **/keep-test-centos-integration-main** run keep integration tests with CAPM3 API version v1beta1 and branch main on CentOS
-* **/keep-test-ubuntu-integration-release-1-3** run keep integration tests with CAPM3 API version v1beta1 and branch release-1.3 on Ubuntu
-* **/keep-test-centos-integration-release-1-3** run keep integration tests with CAPM3 API version v1beta1 and branch release-1.3 on CentOS
-* **/keep-test-ubuntu-integration-release-1-2** run keep integration tests with CAPM3 API version v1beta1 and branch release-1.2 on Ubuntu
-* **/keep-test-centos-integration-release-1-2** run keep integration tests with CAPM3 API version v1beta1 and branch release-1.2 on CentOS
-* **/keep-test-ubuntu-integration-release-1-1** run keep integration tests with CAPM3 API version v1beta1 and branch release-1.1 on Ubuntu
-* **/keep-test-centos-integration-release-1-1** run keep integration tests with CAPM3 API version v1beta1 and branch release-1.1 on CentOS
+* **/keep-test-ubuntu-integration-main** run keep integration tests with CAPM3
+  API version v1beta1 and branch main on Ubuntu
+* **/keep-test-centos-integration-main** run keep integration tests with CAPM3
+  API version v1beta1 and branch main on CentOS
+* **/keep-test-ubuntu-integration-release-1-3** run keep integration tests with
+  CAPM3 API version v1beta1 and branch release-1.3 on Ubuntu
+* **/keep-test-centos-integration-release-1-3** run keep integration tests with
+  CAPM3 API version v1beta1 and branch release-1.3 on CentOS
+* **/keep-test-ubuntu-integration-release-1-2** run keep integration tests with
+  CAPM3 API version v1beta1 and branch release-1.2 on Ubuntu
+* **/keep-test-centos-integration-release-1-2** run keep integration tests with
+  CAPM3 API version v1beta1 and branch release-1.2 on CentOS
+* **/keep-test-ubuntu-integration-release-1-1** run keep integration tests with
+  CAPM3 API version v1beta1 and branch release-1.1 on Ubuntu
+* **/keep-test-centos-integration-release-1-1** run keep integration tests with
+  CAPM3 API version v1beta1 and branch release-1.1 on CentOS
 
 Keep in mind that test VM created with these phrases will not be kept forever
 but deleted after 24 hours, to avoid garbage collection of VMs.
 
 ### E2E tests
 
-E2E tests are gradually replacing the previous Ansible tests for more details about e2e triggers please check: <https://github.com/metal3-io/cluster-api-provider-metal3#e2e-test>
+E2E tests are gradually replacing the previous Ansible tests for more details
+about e2e triggers please check:
+<https://github.com/metal3-io/cluster-api-provider-metal3#e2e-test>
 
 ## Prow commands
 
-There are some plugins supported by prow and makes the life of the developer easier in certain cases:
+There are some plugins supported by prow and makes the life of the developer
+easier in certain cases:
 
-1. `cherry-pick` plugin can be used for cherrypicking PRs across branches by commenting:
-   * **/cherry-pick <release-x.y>** where <release-x.y> is any supported release branch, where the backport PR will be opened by the [cherry picker bot](https://github.com/metal3-cherrypick-bot).
-1. `transfer-issue` plugin can be used for transferring issues across repositories in the same GitHub organization by commenting:
-    * **/transfer-issue < target repo-name >** on the issue. One simple example could be transferring the issue from cluster-api-provider-metal3 to ip-address-manager repository. This can be archived by using: **/transfer-issue ip-address-manager**.
+1. `cherry-pick` plugin can be used for cherrypicking PRs across branches by
+   commenting:
+   * **/cherry-pick release-x.y** where `release-x.y` is any supported release
+     branch, where the backport PR will be opened by the
+     [cherry picker bot](https://github.com/metal3-cherrypick-bot).
+1. `transfer-issue` plugin can be used for transferring issues across
+   repositories in the same GitHub organization by commenting:
+   * **/transfer-issue target-repo-name** on the issue. One simple example
+     could be transferring the issue from cluster-api-provider-metal3 to
+     ip-address-manager repository. This can be archived by using:
+     **/transfer-issue ip-address-manager**.
 
-**Note:** Please remember to manually create a corresponding branch in cherry-pick bot's forked repositories (CAPM3, IPAM) in case a new release branch (i.e. release-1.4) is created upstream.
-That is because when the bot is used to backport the patches to the new release branch, it has to track the new upstream branch to be able to open a PR against it in the future.
+**Note:** Please remember to manually create a corresponding branch in
+cherry-pick bot's forked repositories (CAPM3, IPAM) in case a new release branch
+(i.e. release-1.4) is created upstream. That is because when the bot is used to
+backport the patches to the new release branch, it has to track the new upstream
+branch to be able to open a PR against it in the future.
 
 ## Cloud Resources cleanup
 
-There is a Jenkins [main job](https://jenkins.nordix.org/view/Metal3%20Periodic/job/metal3_daily_main_integration_tests_cleanup/)
-that cleans up all the leftover VMs from
-[CityCloud](https://www.citycloud.com/) every 6 hours which has failed to be
-deleted at the end of v1alphaX/v1betaX integration tests.
+There is a Jenkins
+[main job](https://jenkins.nordix.org/view/Metal3%20Periodic/job/metal3_daily_main_integration_tests_cleanup/)
+that cleans up all the leftover VMs from [CityCloud](https://www.citycloud.com/)
+every 6 hours which has failed to be deleted at the end of v1alphaX/v1betaX
+integration tests.
 
-## "I'm waiting for a metal3-io member to verify that this patch is reasonable to test"
+## "I'm waiting for metal3-io member to verify this patch is reasonable to test"
 
 For all the PRs from authors that are not whitelisted, the bot will add a
-comment "*I'm waiting for a metal3-io member to verify that this patch is reasonable to test*".
-This means that the author is not in the whitelist and that someone from the metal3-io organization should
-review the PR and run the required tests suggested by the Github or add the author to
-whitelist if trusted.
+comment "*I'm waiting for a metal3-io member to verify that this patch is
+reasonable to test*". This means that the author is not in the whitelist and
+that someone from the metal3-io organization should review the PR and run the
+required tests suggested by the Github or add the author to whitelist if
+trusted.
 
 ## Job logs
 
@@ -86,8 +117,8 @@ Pods, CRDs logs are collected at the end of each Jenkins job run and
 archived so that they can be later used for debugging purposes. You can
 find the archived logs under the  "*Build artifacts*" section of the
 [job](https://jenkins.nordix.org/view/Metal3/job/metal3_bmo_main_integration_test_ubuntu/).
-Please note that the logs will be removed 30 days after creation or after 100 subsequent job runs,
-whichever occurs first.
+Please note that the logs will be removed 30 days after creation or after 100
+subsequent job runs, whichever occurs first.
 
 ## Configuration
 
@@ -97,77 +128,100 @@ repository contains the jobs pipeline.
 
 ### Jenkins Job Builder, a.k.a. job definition
 
-We use [Jenkins Job Builder](https://docs.openstack.org/infra/jenkins-job-builder/attic/index.html) (JJB) to
-write Jenkins job definitions in YAML format. It helps us to keep job definitions in source control
-rather than writing/creating them directly in Jenkins UI. Your YAML formatted job definition
-will create a Jenkins job, which in turn executes your specified jenkins pipeline.
-Check [Job definitions](https://docs.openstack.org/infra/jenkins-job-builder/attic/definition.html) to
-familiarize yourself with the JJB syntax. Our job definitions are stored in [Nordix Gerrit](https://gerrit.nordix.org/admin/repos/infra/cicd)
-instance under `cicd/jjb/metal3/` path. Please, note that [cicd](https://gerrit.nordix.org/admin/repos/infra/cicd)
-gerrit repository includes job defitinions for other projects as well that share the same Jenkins environment.
+We use
+[Jenkins Job Builder](https://docs.openstack.org/infra/jenkins-job-builder/attic/index.html)
+(JJB) to write Jenkins job definitions in YAML format. It helps us to keep job
+definitions in source control rather than writing/creating them directly in
+Jenkins UI. Your YAML formatted job definition will create a Jenkins job, which
+in turn executes your specified jenkins pipeline. Check
+[Job definitions](https://docs.openstack.org/infra/jenkins-job-builder/attic/definition.html)
+to familiarize yourself with the JJB syntax. Our job definitions are stored in
+[Nordix Gerrit](https://gerrit.nordix.org/admin/repos/infra/cicd) instance under
+`cicd/jjb/metal3/` path. Please, note that
+[cicd](https://gerrit.nordix.org/admin/repos/infra/cicd)
+gerrit repository includes job defitinions for other projects as well that share
+the same Jenkins environment.
 
-When you add/remove a new job definition in `cicd/jjb/metal3/` path, you will be able to see that job
-added/removed in Jenkins UI under the [Metal3 view](https://jenkins.nordix.org/view/Metal3/).
+When you add/remove a new job definition in `cicd/jjb/metal3/` path, you will
+be able to see that job added/removed in Jenkins UI under the
+[Metal3 view](https://jenkins.nordix.org/view/Metal3/).
 
 ![webhook](images/jenkins_metal3_view.png)
 
 ### Job Declarative Pipeline
 
-We use [declarative pipeline syntax](https://www.jenkins.io/doc/book/pipeline/syntax/) to tell what we want to do
-when Jenkins executes our pipeline. Pipelines are stored in [metal3-io/project-infra](https://github.com/metal3-io/project-infra/tree/main/jenkins/jobs) repository.
-In a nutshell, pipelines defines sequence of steps to be executed. Each step can run a script or perform something else. For example, [integration_tests.pipeline](https://github.com/metal3-io/project-infra/blob/main/jenkins/jobs/integration_tests.pipeline) executes following scripts
+We use
+[declarative pipeline syntax](https://www.jenkins.io/doc/book/pipeline/syntax/)
+to tell what we want to do when Jenkins executes our pipeline. Pipelines are
+stored in
+[metal3-io/project-infra](https://github.com/metal3-io/project-infra/tree/main/jenkins/jobs)
+repository. In a nutshell, pipelines defines sequence of steps to be executed.
+Each step can run a script or perform something else. For example,
+[integration_tests.pipeline](https://github.com/metal3-io/project-infra/blob/main/jenkins/jobs/integration_tests.pipeline)
+executes following scripts:
 
-1. [clones](https://github.com/metal3-io/project-infra/blob/0a6cc3f9f8592914a316c27ea2411ccb48aba7c3/jenkins/jobs/integration_tests.pipeline#L65) git repository
-2. [jenkins/scripts/integration_test.sh](https://github.com/metal3-io/project-infra/blob/main/jenkins/scripts/integration_test.sh)
-3. [jenkins/scripts/fetch_logs.sh](https://github.com/metal3-io/project-infra/blob/main/jenkins/scripts/fetch_logs.sh)
-4. [jenkins/scripts/integration_test_clean.sh](https://github.com/metal3-io/project-infra/blob/main/jenkins/scripts/integration_test_clean.sh)
-5. [jenkins/scripts/integration_delete.sh](https://github.com/metal3-io/project-infra/blob/main/jenkins/scripts/integration_delete.sh)
+1. [clones](https://github.com/metal3-io/project-infra/blob/0a6cc3f9f8592914a316c27ea2411ccb48aba7c3/jenkins/jobs/integration_tests.pipeline#L65)
+   git repository
+1. [jenkins/scripts/integration_test.sh](https://github.com/metal3-io/project-infra/blob/main/jenkins/scripts/integration_test.sh)
+1. [jenkins/scripts/fetch_logs.sh](https://github.com/metal3-io/project-infra/blob/main/jenkins/scripts/fetch_logs.sh)
+1. [jenkins/scripts/integration_test_clean.sh](https://github.com/metal3-io/project-infra/blob/main/jenkins/scripts/integration_test_clean.sh)
+1. [jenkins/scripts/integration_delete.sh](https://github.com/metal3-io/project-infra/blob/main/jenkins/scripts/integration_delete.sh)
 
 ### GitHub Pull Request Builder, a.k.a. ghprb
 
-For our Jenkins to work with GitHub we need [GitHub Pull Request Builder](https://plugins.jenkins.io/ghprb/), a.k.a. ghprb plugin installed in Jenkins. This is already done by Nordix admins. The plugin handles everything related to your PR. In short, ghprb exposes a webhook endpoint where GutHub webhook service can send webhook calls to. Current Jenkins ghprb webhook is exposed at <https://jenkins.nordix.org/ghprbhook/>, and most of the Metal3 GitHub repositories have webhooks configured to redirect webhook calls to that URL.
-When configuring GitHub webhooks:
+For our Jenkins to work with GitHub we need
+[GitHub Pull Request Builder](https://plugins.jenkins.io/ghprb/), a.k.a. ghprb
+plugin installed in Jenkins. This is already done by Nordix admins. The plugin
+handles everything related to your PR. In short, ghprb exposes a webhook
+endpoint where GutHub webhook service can send webhook calls to. Current Jenkins
+ghprb webhook is exposed at <https://jenkins.nordix.org/ghprbhook/>, and most
+of the Metal3 GitHub repositories have webhooks configured to redirect webhook
+calls to that URL. When configuring GitHub webhooks:
 
 1. Paste the ghprb URL in **Payload URL**;
-
 1. select application/json for the **Content Type**;
-
 1. check the following scopes for **Which events would you like to trigger this webhook?**;
-
    * `Issue comments`
    * `Pull requests`
 
-We use [metal3-jenkins](https://github.com/metal3-jenkins) GitHub bot account which reports
-job status on a pull request. The bot is a public member of Metal3 GitHub org. To use this bot
-with Jenkins ghprb, a GitHub personal access token was generated with the following scopes checked:
+We use [metal3-jenkins](https://github.com/metal3-jenkins) GitHub bot account
+which reports job status on a pull request. The bot is a public member of Metal3
+GitHub org. To use this bot with Jenkins ghprb, a GitHub personal access token
+was generated with the following scopes checked:
 
 ![token-scopes](../prow/images/token-scopes.png)
 
-To use the token in Jenkins, `metal3-jenkins-github-token` secret is created in Jenkins credentials.
-See the usage [reference](https://github.com/metal3-io/project-infra/blob/12660dd59d368c86e471007d86ca781cf2539ec9/jenkins/jobs/integration_tests.pipeline#L3).
+To use the token in Jenkins, `metal3-jenkins-github-token` secret is created
+in Jenkins credentials. See the usage
+[reference](https://github.com/metal3-io/project-infra/blob/12660dd59d368c86e471007d86ca781cf2539ec9/jenkins/jobs/integration_tests.pipeline#L3).
 
-You can see ghprb logs in [here](https://jenkins.nordix.org/log/GHPRB/) only if you have admin rights in the Nordix Jenkins.
+You can see ghprb logs in [here](https://jenkins.nordix.org/log/GHPRB/) only if
+you have admin rights in the Nordix Jenkins.
 
-Sometimes, when changing the credentials related to ghprb, the system might still be using the old credentials. If you see that your changes aren't
+Sometimes, when changing the credentials related to ghprb, the system might
+still be using the old credentials. If you see that your changes aren't
 taking affect, you could try to clean up the ghprb cache in Jenkins.
 
 ### Some other secrets in Jenkins
 
-* `metal3-jenkins-github-username-token` - stores the username of the metal3-jenkins GitHub bot account.
-   Used by Jenkins Job Builders.
+* `metal3-jenkins-github-username-token` stores the username of the
+   metal3-jenkins GitHub bot account. Used by Jenkins Job Builders.
+* `metal3-clusterctl-github-token` stores a GitHub token for use in Metal3
+   integration tests with no permissions. This is to avoid GitHub API
+   limitations for unauthenticated users. Used by
+   [pipeline](https://github.com/metal3-io/project-infra/blob/12660dd59d368c86e471007d86ca781cf2539ec9/jenkins/jobs/integration_tests.pipeline#L88).
 
-* `metal3-clusterctl-github-token` - stores a GitHub token for use in Metal3
-   integration tests with no permissions. This is to avoid GitHub API limitations for unauthenticated
-   users. Used by [pipeline](https://github.com/metal3-io/project-infra/blob/12660dd59d368c86e471007d86ca781cf2539ec9/jenkins/jobs/integration_tests.pipeline#L88).
-
-Sometimes, your changes might not take effect and you need to flash out Jenkins cache.
+Sometimes, your changes might not take effect and you need to flash out Jenkins
+cache.
 
 ### Job image
 
-We use raw images backed from Ceph in CityCloud to run all the jobs (nightly builds, on pull requests) in CI.
+We use raw images backed from Ceph in CityCloud to run all the jobs (nightly
+builds, on pull requests) in CI.
 
 ## Contact
 
 In case of issues or question on the Jenkins CI, please contact the maintainers
-by email to estjorvas [at] est.tech or by posting your message on the
-[\#cluster-api-baremetal](https://kubernetes.slack.com/messages/CHD49TLE7) channel on Kubernetes Slack.
+by email to estjorvas \[at\] est.tech or by posting your message on the
+[\#cluster-api-baremetal](https://kubernetes.slack.com/messages/CHD49TLE7)
+channel on Kubernetes Slack.

--- a/jenkins/scripts/bare_metal_lab/README.md
+++ b/jenkins/scripts/bare_metal_lab/README.md
@@ -1,7 +1,8 @@
 # Baremetal Lab Setup
 
-The Bare Metal Lab needs some special treatment compared to other pipelines since it does not use VMs for the target cluster.
-This is taken care of in the `deploy-lab.yaml` playbook.
+The Bare Metal Lab needs some special treatment compared to other pipelines
+since it does not use VMs for the target cluster. This is taken care of in the
+`deploy-lab.yaml` playbook.
 
 ## Ansible installation
 
@@ -9,8 +10,10 @@ This is taken care of in the `deploy-lab.yaml` playbook.
 
 ## Running the playbook
 
-* Comment/uncomment the hosts you want to use in the `vars` section of `deploy-lab.yaml`
-* Set environment variables `BML_ILO_USERNAME` and `BML_ILO_PASSWORD` for the login to the bare metal hosts
+* Comment/uncomment the hosts you want to use in the `vars` section of
+  `deploy-lab.yaml`
+* Set environment variables `BML_ILO_USERNAME` and `BML_ILO_PASSWORD` for the
+  login to the bare metal hosts
 
 Then:
 
@@ -18,13 +21,18 @@ Then:
 
 ## Running tests for pull requests on Github
 
-You can trigger builds to run in the bare metal lab by adding the following line as a comment on the PR:
+You can trigger builds to run in the bare metal lab by adding the following
+line as a comment on the PR:
 
-```
+```text
 /test-integration-bml-centos
 ```
 
-**Note:** Concurrent builds are disabled for the BML, since they would run on the same host and interfere with each other.
-This means that if there is already one build job running in the BML, a new one will not start before the first has finished.
-Github won't show the usual *Details* link for this specific run but build status can be checked from the [Jenkins dashboard](https://jenkins.nordix.org/job/metal3_metal3io_project_infra_bml_integration_tests_centos/) where the build will be scheduled and stay in pending at this time.
+**Note:** Concurrent builds are disabled for the BML, since they would run on
+the same host and interfere with each other. This means that if there is already
+one build job running in the BML, a new one will not start before the first has
+finished. Github won't show the usual *Details* link for this specific run but
+build status can be checked from the
+[Jenkins dashboard](https://jenkins.nordix.org/job/metal3_metal3io_project_infra_bml_integration_tests_centos/)
+where the build will be scheduled and stay in pending at this time.
 Once the build starts, the status will be updated with a link.

--- a/prow/README.md
+++ b/prow/README.md
@@ -1,15 +1,14 @@
 # Prow
 
-Metal3 Prow dashboard: https://prow.apps.test.metal3.io
+Metal3 Prow dashboard: <https://prow.apps.test.metal3.io>
 
 ## Access Controls
 
-* To merge, patches must have `/approve` and `/lgtm`, which apply the `approved` and `lgtm` labels
-
-* The use of `/approve` and `/lgtm` is controlled by the `OWNERS` file in each repository.
-  See the [OWNERS spec](https://go.k8s.io/owners) for more details about how
-  to manage access to all or part of a repo with this file.
-
+* To merge, patches must have `/approve` and `/lgtm`, which apply the
+  `approved` and `lgtm` labels
+* The use of `/approve` and `/lgtm` is controlled by the `OWNERS` file in each
+  repository. See the [OWNERS spec](https://go.k8s.io/owners) for more details
+  about how to manage access to all or part of a repo with this file.
 * Tests will run automatically for PRs authored by **public** members of the
   `metal3-io` github organization.  Members of the github org can run
   `/ok-to-test` for PRs authored by those not in the github org.
@@ -19,84 +18,92 @@ more information about who can run each prow command.
 
 ## GCS bucket
 
-Google Cloud Storage (GCS) is required to store job artifacts. Follow the docs to set
-up GCS and create a bucket with enough permissions.
+Google Cloud Storage (GCS) is required to store job artifacts. Follow the docs
+to set up GCS and create a bucket with enough permissions.
 
 1. Create a [bucket](https://cloud.google.com/storage/docs/creating-buckets)
-1. Create a [service account](https://cloud.google.com/iam/docs/creating-managing-service-accounts)
-1. On the created bucket, grant `storage.objects.create` access for the service account and `storage.objectViewer`
-   permission to `allUser`.
+1. Create a
+   [service account](https://cloud.google.com/iam/docs/creating-managing-service-accounts)
+1. On the created bucket, grant `storage.objects.create` access for the service
+   account and `storage.objectViewer` permission to `allUser`.
 
 ## Setup
 
-Prow was set up by following these instructions: https://github.com/kubernetes/test-infra/blob/master/prow/getting_started_deploy.md
+Prow was set up by following these instructions:
+<https://github.com/kubernetes/test-infra/blob/master/prow/getting_started_deploy.md>
 
 1. Create DNS record(s) to point to your cluster.
-
-1. Prow components are running on `default` namespace, while `test-pods` namespace
-   is used by pods running the actual CI jobs.
-
-1. [ghProxy](https://github.com/kubernetes/test-infra/tree/master/ghproxy) is a reverse proxy,
-   and is meant to reduce API token usage. We need persistent volume for ghProxy, and for that
-   purpose we rely on `hostPath` type of `PersistentVolume` in our cluster due to the limitation
-   in the underlying infrastructure. Ideally, you should use a dynamic storage provisioner.
+1. Prow components are running on `default` namespace, while `test-pods`
+   namespace is used by pods running the actual CI jobs.
+1. [ghProxy](https://github.com/kubernetes/test-infra/tree/master/ghproxy) is a
+   reverse proxy, and is meant to reduce API token usage. We need persistent
+   volume for ghProxy, and for that purpose we rely on `hostPath` type of
+   `PersistentVolume` in our cluster due to the limitation in the underlying
+   infrastructure. Ideally, you should use a dynamic storage provisioner.
 
    Create a /mnt/prow directory to store the persistent volume data:
 
-     ```shell
-     $ sudo mkdir /mnt/prow
-     ```
+   ```shell
+   sudo mkdir /mnt/prow
+   ```
 
-     Create the PersistentVolume:
+   Create the PersistentVolume:
 
-     ```shell
-     $ kubectl apply -f persistent_volume.yaml
-     ```
+   ```shell
+   kubectl apply -f persistent_volume.yaml
+   ```
 
-1. Grant a user `cluster-admin` role in all namespaces to create cluster resources.
+1. Grant a user `cluster-admin` role in all namespaces to create cluster
+   resources.
 
-    ```shell
-    $ kubectl create clusterrolebinding cluster-admin-binding-"${USER}" \
+   ```shell
+   $ kubectl create clusterrolebinding cluster-admin-binding-"${USER}" \
       --clusterrole=cluster-admin --user="${USER}"
-    ```
+   ```
 
-1. Create HMAC token for webhook validation and generate a secret out of it. Don't forget to add this token
-   on GitHub webhook configuration.
+1. Create HMAC token for webhook validation and generate a secret out of it.
+   Don't forget to add this token on GitHub webhook configuration.
 
-    ```shell
-    $ openssl rand -hex 20 > /path/hmac-token
-    $ kubectl create secret generic hmac-token --from-file=hmac=/path/hmac-token
-    ```
+   ```shell
+   openssl rand -hex 20 > /path/hmac-token
+   kubectl create secret generic hmac-token --from-file=hmac=/path/hmac-token
+   ```
 
-1. Create a personal access token for the GitHub
-   bot account. This should be done from [metal3-io-bot](https://github.com/metal3-io-bot)
-   GitHub bot account. You can follow this [link](https://github.com/settings/tokens)
-   to create the token. When generating the token, make sure you have only the following scopes checked in.
+1. Create a personal access token for the GitHub bot account. This should be
+   done from [metal3-io-bot](https://github.com/metal3-io-bot) GitHub bot
+   account. You can follow this [link](https://github.com/settings/tokens)
+   to create the token. When generating the token, make sure you have only the
+   following scopes checked in.
 
-   - `repo` scope for full control of private repositories
-   - `admin:org_hook` for a github org
-
+   * `repo` scope for full control of private repositories
+   * `admin:org_hook` for a github org
 
    ![token-scopes](images/token-scopes.png)
 
-    Create a secret out of that token:
-    ```shell
-    $ kubectl create secret generic github-token --from-file=token=/path/github-token
-    ```
+   Create a secret out of that token:
+
+   ```shell
+   kubectl create secret generic github-token \
+       --from-file=token=/path/github-token
+   ```
 
 1. Create a secret with the GCS credentials
 
    ```shell
-   $ kubectl create secret generic gcs-credentials --from-file=service-account.json=service-account.json
+   kubectl create secret generic gcs-credentials \
+       --from-file=service-account.json=service-account.json
    ```
 
-1. While applying prow manifests, we are going to create an Ingress object to redirect traffic to the deck and hook services.
-   We are installing [NGINX Ingress controller](https://kubernetes.github.io/ingress-nginx/deploy/) with helm, but you can
-   install your preferred one.
+1. While applying prow manifests, we are going to create an Ingress object to
+   redirect traffic to the deck and hook services. We are installing
+   [NGINX Ingress controller](https://kubernetes.github.io/ingress-nginx/deploy/)
+   with helm, but you can install your preferred one.
 
    ```shell
    helm repo add ingress-nginx https://kubernetes.github.io/ingress-nginx
-   helm install ingress-nginx/ingress-nginx --set controller.hostNetwork=true,controller.service.type="",controller.kind=DaemonSet --generate-name
+   helm install ingress-nginx/ingress-nginx \
+       --set controller.hostNetwork=true,controller.service.type=""\
+   ,controller.kind=DaemonSet --generate-name
    helm repo update
    ```
 
@@ -106,44 +113,49 @@ Prow was set up by following these instructions: https://github.com/kubernetes/t
    kubectl apply -f manifests/*
    ```
 
-   This will create a couple of Deployments, Services, ServiceAccounts, Roles, RoleBindings and Ingress resources.
+   This will create a couple of Deployments, Services, ServiceAccounts, Roles,
+   RoleBindings and Ingress resources.
 
 ## Secure Ingress with Cert-Manager and Let's Encrypt
 
 1. Install [cert-manager](https://github.com/jetstack/cert-manager)
 
-   ```
+   ```shell
    $ helm repo add jetstack https://charts.jetstack.io
    $ helm repo update
    $ helm install \
    cert-manager jetstack/cert-manager \
-   --namespace cert-manager \
-   --create-namespace \
-   --version v1.3.1 \
-   --set installCRDs=true
+      --namespace cert-manager \
+      --create-namespace \
+      --version v1.3.1 \
+      --set installCRDs=true
    ```
 
    Verify that you have the following pods running
+
    ```shell
    $ kubectl get pods --namespace cert-manager
 
-     NAME                                       READY   STATUS    RESTARTS   AGE
-     cert-manager-5c6866597-zw7kh               1/1     Running   0          2m
-     cert-manager-cainjector-577f6d9fd7-tr77l   1/1     Running   0          2m
-     cert-manager-webhook-787858fcdb-nlzsq      1/1     Running   0          2m
+   NAME                                       READY   STATUS    RESTARTS   AGE
+   cert-manager-5c6866597-zw7kh               1/1     Running   0          2m
+   cert-manager-cainjector-577f6d9fd7-tr77l   1/1     Running   0          2m
+   cert-manager-webhook-787858fcdb-nlzsq      1/1     Running   0          2m
    ```
 
 1. Create a secret containing your Cloudflare API token.
 
    ```shell
-   $ kubectl create secret generic cloudflare-api-token-secret --from-literal "apikey=<API_KEY>" --namespace=cert-manager
+   kubectl create secret generic cloudflare-api-token-secret \
+       --from-literal "apikey=<API_KEY>" --namespace=cert-manager
    ```
 
-   metal3.io domain DNS configurations are managed via Cloudflare. We use [DNS-01 challenge](https://letsencrypt.org/docs/challenge-types/#dns-01-challenge) in our [`ClusterIssuer`](https://cert-manager.io/docs/concepts/issuer/)
-   to prove that we own metal3.io domain. As such, we need to provide Cloudflare api key so
-   that validation of the domain with DNS-01 challange passes. Cloudflare api key is stored
-   as K8S secret, and the only thing you need to do is - add the name of the secret in
-   cluster-issuer solvers configuration.
+   metal3.io domain DNS configurations are managed via Cloudflare. We use
+   [DNS-01 challenge](https://letsencrypt.org/docs/challenge-types/#dns-01-challenge)
+   in our [`ClusterIssuer`](https://cert-manager.io/docs/concepts/issuer/)
+   to prove that we own metal3.io domain. As such, we need to provide Cloudflare
+   API key so that validation of the domain with DNS-01 challange passes.
+   Cloudflare API key is stored as K8S secret, and the only thing you need to
+   do is add the name of the secret in cluster-issuer solvers configuration.
 
    ```shell
    apiKeySecretRef:
@@ -151,58 +163,92 @@ Prow was set up by following these instructions: https://github.com/kubernetes/t
       key: apikey
    ```
 
-1. Create a ClusterIssuer that contacts [Let’s Encrypt](https://letsencrypt.org/) in order to issue certificates.
+1. Create a ClusterIssuer that contacts
+   [Let’s Encrypt](https://letsencrypt.org/) in order to issue certificates.
 
    ```shell
-   $ kubectl apply -f ssl/cluster_issuer.yaml
+   kubectl apply -f ssl/cluster_issuer.yaml
    ```
 
 1. Update the Ingress to include tls
 
-   You need to annotate the Ingress with `cert-manager.io/cluster-issuer: letsencrypt-prod` to trigger certificats to be automatically created. See the list of available annotations [here](https://cert-manager.io/docs/usage/ingress/#supported-annotations)
+   You need to annotate the Ingress with
+   `cert-manager.io/cluster-issuer: letsencrypt-prod` to trigger certificats to
+   be automatically created. See the list of available annotations
+   [here](https://cert-manager.io/docs/usage/ingress/#supported-annotations)
 
    ```shell
-   $ kubectl annotate ingress prow cert-manager.io/cluster-issuer=letsencrypt-prod
+   kubectl annotate ingress prow cert-manager.io/cluster-issuer=letsencrypt-prod
    ```
 
-   Edit the ingress to add the following under the spec
+   Edit the ingress to add the following under the spec:
 
-   ```
+   ```yaml
    spec:
       tls:
       - hosts:
          - prow.apps.test.metal3.io
-        secretName: metal3-io-tls
+         secretName: metal3-io-tls
    ```
 
 ## GitHub webhook configuration
 
-GitHub webhook needs to be configured with a payload URL pointing to the hook service. For that you need
+GitHub webhook needs to be configured with a payload URL pointing to the hook
+service. For that you need
+
 1. HMAC token generated earlier
-2. https://PROW_URL/hook, in our case it is https://prow.apps.test.metal3.io/hook
+1. <https://PROW_URL/hook>, in our case it is
+   <https://prow.apps.test.metal3.io/hook>
 
-Add the URL and token as below. Select **"Send me everything"**, and for Content ype: **application/json**.
+   Add the URL and token as below. Select **"Send me everything"**, and for
+   Content type: **application/json**.
 
-![webhook](images/webhook.png)
+   ![webhook configuration](images/webhook.png)
 
 ## Enabling Metal3 prow for new org/repo
 
-Metal3 prow is currently working with two Github organizations(orgs): `metal3-io` and `Nordix`. For `Nordix` we have enabled prow only for two repositories, namely: metal3-dev-tools and metal3-clusterapi-docs. We don't foresee enabling Metal3 prow for any other Github org, however we might need to enable prow in other repositories in existing Github orgs for example. In any case we should follow the steps below to enable prow:
+Metal3 prow is currently working with two Github organizations(orgs):
+`metal3-io` and `Nordix`. For `Nordix` we have enabled prow only for two
+repositories, namely: metal3-dev-tools and metal3-clusterapi-docs. We don't
+foresee enabling Metal3 prow for any other Github org, however we might need to
+enable prow in other repositories in existing Github orgs for example.
+In any case we should follow the steps below to enable prow:
 
-1. Add/check `metal3-io-bot` user in the Github org with `admin` access. Check the image 
+1. Add/check `metal3-io-bot` user in the Github org with `admin` access. Check
+   the image
 
-![](images/metal3-io-bot.png)
+   ![metal3-io bot access rights](images/metal3-io-bot.png)
 
-2. Enable prow webhook as described in [GitHub webhook configuration](#github-webhook-configuration) section. For `metal3-io` the webhook is enabled in org level. For the two repositories in `Nordix` org we have enabled them on individual repositories. Keep in mind that the HMAC token and hook URL are the same as described in [GitHub webhook configuration](#github-webhook-configuration). The webhook should look happy (green tick) as shown in the image below once you have configured it correctly and communication has been established between Github and prow hook. 
+1. Enable prow webhook as described in
+   [GitHub webhook configuration](#github-webhook-configuration) section. For
+   `metal3-io` the webhook is enabled in org level. For the two repositories in
+   `Nordix` org we have enabled them on individual repositories. Keep in mind
+   that the HMAC token and hook URL are the same as described in
+   [GitHub webhook configuration](#github-webhook-configuration). The webhook
+   should look happy (green tick) as shown in the image below once you have
+   configured it correctly and communication has been established between
+   Github and prow hook.
 
-![](images/green_webhook.png)
+   ![successful webhook example](images/green_webhook.png)
 
-3. Check the general settings and branch protection settings of Github repository and make sure the settings are correct. Take any existing repository which has prow enabled as example (i.e. `Nordix/metal3-dev-tools`).
+1. Check the general settings and branch protection settings of Github
+   repository and make sure the settings are correct. Take any existing
+   repository which has prow enabled as example (i.e. `Nordix/metal3-dev-tools`)
 
-4. Add the `OWNERS` file in the repository. 
+1. Add the `OWNERS` file in the repository.
 
-5. Add the repository entry and related configurations in the files `prow/config/config.yaml` and `prow/config/plugins.yaml` in `metal3-io/project-infra` repository. An example PR is [here](https://github.com/metal3-io/project-infra/pull/473/). 
+1. Add the repository entry and related configurations in the files
+   `prow/config/config.yaml` and `prow/config/plugins.yaml` in
+   `metal3-io/project-infra` repository. An example PR is
+   [here](https://github.com/metal3-io/project-infra/pull/473/).
 
-6. One small tweak might still be needed. We have experienced the default `merge_method` of prow which is `merge` didn't work for Nordix repos. The other two options for `merge_method` are: `rebase` and `squash`. We have enabled `rebase` for Nordix repos but kept `merge` for metal3-io org. An example is shown in this [PR](https://github.com/metal3-io/project-infra/pull/476/).
+1. One small tweak might still be needed. We have experienced the default
+   `merge_method` of prow which is `merge` didn't work for Nordix repos. The
+   other two options for `merge_method` are: `rebase` and `squash`. We have
+   enabled `rebase` for Nordix repos but kept `merge` for metal3-io org. An
+   example is shown in this
+   [PR](https://github.com/metal3-io/project-infra/pull/476/).
 
-7. At this point you should see the prow tests you have configured as presubmits for the repository, running on open PRs and tide is enabled and waiting for appropriate labels. 
+1. At this point you should see the prow tests you have configured as presubmits
+   for the repository, running on open PRs and tide is enabled and waiting for
+   appropriate labels.

--- a/prow/config/config.yaml
+++ b/prow/config/config.yaml
@@ -776,6 +776,20 @@ presubmits:
             resources:
               requests:
                 memory: "500Mi"
+    - name: markdownlint
+      run_if_changed: '\.md$'
+      decorate: true
+      spec:
+        containers:
+          - args:
+              - ./hack/markdownlint.sh
+            command:
+              - sh
+            env:
+              - name: IS_CONTAINER
+                value: "TRUE"
+            image: docker.io/pipelinecomponents/markdownlint:0.12.0@sha256:0b8f9fcf0410257b2f3548f67ffe25934cfc9877a618b9f85afcf345a25804a2
+            imagePullPolicy: Always
   metal3-io/metal3-docs:
     - name: markdownlint
       run_if_changed: '\.md$'

--- a/prow/ssl/README.md
+++ b/prow/ssl/README.md
@@ -4,7 +4,7 @@ Managed by [cert-manager](https://cert-manager.io).
 
 ## Installation Process
 
-```
+```bash
 oc create namespace cert-manager
 oc apply --validate=false -f https://github.com/jetstack/cert-manager/releases/download/v0.12.0/cert-manager-openshift.yaml
 ```
@@ -13,25 +13,28 @@ oc apply --validate=false -f https://github.com/jetstack/cert-manager/releases/d
 
 Create Secret `cloudflare-apikey-secret`:
 
-```
-kubectl create secret generic cloudflare-apikey-secret --from-literal "apikey=<API_KEY>" --namespace=cert-manager
+```bash
+kubectl create secret generic cloudflare-apikey-secret \
+    --from-literal "apikey=<API_KEY>" --namespace=cert-manager
 ```
 
 Create letsencrypt `ClusterIssuer`:
 
-```
+```bash
 oc apply -f cluster-issuer.yaml
 ```
 
 Create a request for a certificate to use for Ingress:
 
-```
+```bash
 oc apply -f certificate.yaml
 ```
 
 Configure the cluster to use the new certificate
 ([docs](https://docs.openshift.com/container-platform/4.2/networking/ingress-operator.html)):
 
-```
-oc patch --type=merge --namespace openshift-ingress-operator ingresscontrollers/default --patch '{"spec":{"defaultCertificate":{"name":"metal3-io-tls"}}}'
+```bash
+oc patch --type=merge --namespace openshift-ingress-operator \
+    ingresscontrollers/default --patch \
+    '{"spec":{"defaultCertificate":{"name":"metal3-io-tls"}}}'
 ```


### PR DESCRIPTION
We have a lot of documentation in this repo, formatted in markdown, but it is not linted. Fix all the issues and add markdownlint linter to keep the files clean.