### PR TITLE
add basic linters to ihwir

### DIFF
--- a/prow/config/config.yaml
+++ b/prow/config/config.yaml
@@ -1129,3 +1129,33 @@ presubmits:
                 value: "TRUE"
             image: docker.io/pipelinecomponents/markdownlint:0.12.0@sha256:0b8f9fcf0410257b2f3548f67ffe25934cfc9877a618b9f85afcf345a25804a2
             imagePullPolicy: Always
+
+  metal3-io/ironic-hardware-inventory-recorder-image:
+    - name: shellcheck
+      run_if_changed: '((\.sh)|^Makefile)$'
+      decorate: true
+      spec:
+        containers:
+          - args:
+              - ./hack/shellcheck.sh
+            command:
+              - sh
+            env:
+              - name: IS_CONTAINER
+                value: "TRUE"
+            image: docker.io/koalaman/shellcheck-alpine:v0.9.0@sha256:e19ed93c22423970d56568e171b4512c9244fc75dd9114045016b4a0073ac4b7
+            imagePullPolicy: Always
+    - name: markdownlint
+      run_if_changed: '\.md$'
+      decorate: true
+      spec:
+        containers:
+          - args:
+              - ./hack/markdownlint.sh
+            command:
+              - sh
+            env:
+              - name: IS_CONTAINER
+                value: "TRUE"
+            image: docker.io/pipelinecomponents/markdownlint:0.12.0@sha256:0b8f9fcf0410257b2f3548f67ffe25934cfc9877a618b9f85afcf345a25804a2
+            imagePullPolicy: Always


### PR DESCRIPTION
Add markdownlint and shellcheck for hw-inventory-recorder.

Actual linter scripts being added at: https://github.com/metal3-io/ironic-hardware-inventory-recorder-image/pull/18 