### PR TITLE
add shellcheck to ironic-image

### DIFF
--- a/prow/manifests/overlays/metal3/config.yaml
+++ b/prow/manifests/overlays/metal3/config.yaml
@@ -1120,6 +1120,20 @@ presubmits:
             imagePullPolicy: Always
 
   metal3-io/ironic-image:
+    - name: shellcheck
+      run_if_changed: '((\.sh)|^Makefile)$'
+      decorate: true
+      spec:
+        containers:
+          - args:
+              - ./hack/shellcheck.sh
+            command:
+              - sh
+            env:
+              - name: IS_CONTAINER
+                value: "TRUE"
+            image: docker.io/koalaman/shellcheck-alpine:v0.9.0@sha256:e19ed93c22423970d56568e171b4512c9244fc75dd9114045016b4a0073ac4b7
+            imagePullPolicy: Always
     - name: markdownlint
       run_if_changed: '\.md$'
       decorate: true


### PR DESCRIPTION
Actual linter scripts are added in another PR in ironic-image repo.
https://github.com/metal3-io/ironic-image/pull/412