### PR TITLE
Remove BMOBRANCH export

### DIFF
--- a/jenkins/scripts/integration_test_env.sh
+++ b/jenkins/scripts/integration_test_env.sh
@@ -15,12 +15,6 @@ then
     export BUILD_BMO_LOCALLY="true"
     export BUILD_CAPM3_LOCALLY="true"
     export BUILD_IPAM_LOCALLY="true"
-    
-    # BMOBRANCH should be main only if the periodic test is testing main branches
-    # if not we dont define it here (dev-env decides it), and release periodic tests would be using latest BMO release
-    if [[ "${CAPM3RELEASEBRANCH}" == "main" ]]; then
-      export BMOBRANCH="main"
-    fi
   fi
 
 elif [ "${REPO_NAME}" == "baremetal-operator" ]


### PR DESCRIPTION
Removing dictating BMOBRANCH var from project-infra. This was set here to only set main branch periodic tests with main BMO branch and the PR jobs with release tag. But now, we cant afford to do that anymore since main branch BMO is nonbackwards compatible. So dev-env dictates which branch of BMO will be tested. Fixing that in the PR https://github.com/metal3-io/metal3-dev-env/pull/1208