### PR TITLE
add markdownlint for ironic-image

### DIFF
--- a/prow/config/config.yaml
+++ b/prow/config/config.yaml
@@ -1100,6 +1100,22 @@ presubmits:
             image: docker.io/koalaman/shellcheck-alpine:v0.9.0@sha256:e19ed93c22423970d56568e171b4512c9244fc75dd9114045016b4a0073ac4b7
             imagePullPolicy: Always
 
+  metal3-io/ironic-image:
+    - name: markdownlint
+      run_if_changed: '\.md$'
+      decorate: true
+      spec:
+        containers:
+          - args:
+              - ./hack/markdownlint.sh
+            command:
+              - sh
+            env:
+              - name: IS_CONTAINER
+                value: "TRUE"
+            image: docker.io/pipelinecomponents/markdownlint:0.12.0@sha256:0b8f9fcf0410257b2f3548f67ffe25934cfc9877a618b9f85afcf345a25804a2
+            imagePullPolicy: Always
+
   metal3-io/mariadb-image:
     - name: shellcheck
       run_if_changed: '((\.sh)|^Makefile)$'


### PR DESCRIPTION
Actual linter scripts are added in another PR in ironic-image repo in https://github.com/metal3-io/ironic-image/pull/413

