### PR TITLE
Add e2e integration as required job for release-1.4 branch

### DIFF
--- a/prow/manifests/overlays/metal3/config.yaml
+++ b/prow/manifests/overlays/metal3/config.yaml
@@ -130,7 +130,7 @@ branch-protection:
                 contexts: ["test-ubuntu-integration-release-1-3"]
             release-1.4:
               required_status_checks:
-                contexts: ["test-ubuntu-integration-release-1-4"]
+                contexts: ["test-ubuntu-e2e-integration-release-1-4"]
         ironic-image:
           branches:
             main:
@@ -161,7 +161,7 @@ branch-protection:
                 contexts: ["test-ubuntu-integration-release-1-3"]
             release-1.4:
               required_status_checks:
-                contexts: ["test-ubuntu-integration-release-1-4"]
+                contexts: ["test-ubuntu-e2e-integration-release-1-4"]
         mariadb-image:
           branches:
             main:


### PR DESCRIPTION
Gradually replacing integration tests with e2e-integration to be the required test. At this step we do that for release-1.4 branch. 