### PR TITLE
Prow synchronize images

### DIFF
--- a/prow/manifests/overlays/metal3/config.yaml
+++ b/prow/manifests/overlays/metal3/config.yaml
@@ -24,10 +24,10 @@ plank:
         path_strategy: explicit
       s3_credentials_secret: s3-credentials
       utility_images:
-        clonerefs: gcr.io/k8s-prow/clonerefs:v20210916-3c87dfedd5
-        entrypoint: gcr.io/k8s-prow/entrypoint:v20210916-3c87dfedd5
-        initupload: gcr.io/k8s-prow/initupload:v20210916-3c87dfedd5
-        sidecar: gcr.io/k8s-prow/sidecar:v20210916-3c87dfedd5
+        clonerefs: gcr.io/k8s-prow/clonerefs:v20230329-c93d79fb7d
+        entrypoint: gcr.io/k8s-prow/entrypoint:v20230329-c93d79fb7d
+        initupload: gcr.io/k8s-prow/initupload:v20230329-c93d79fb7d
+        sidecar: gcr.io/k8s-prow/sidecar:v20230329-c93d79fb7d
 
 tide:
   merge_method:

--- a/prow/manifests/overlays/metal3/kustomization.yaml
+++ b/prow/manifests/overlays/metal3/kustomization.yaml
@@ -66,3 +66,30 @@ secretGenerator:
   name: cherrypick-bot-github-token
   namespace: prow
   type: Opaque
+
+images:
+- name: gcr.io/k8s-prow/crier
+  newTag: v20230329-c93d79fb7d
+- name: gcr.io/k8s-prow/deck
+  newTag: v20230329-c93d79fb7d
+- name: gcr.io/k8s-prow/ghproxy
+  newTag: v20230329-c93d79fb7d
+- name: gcr.io/k8s-prow/hook
+  newTag: v20230329-c93d79fb7d
+- name: gcr.io/k8s-prow/horologium
+  newTag: v20230329-c93d79fb7d
+- name: gcr.io/k8s-prow/prow-controller-manager
+  newTag: v20230329-c93d79fb7d
+- name: gcr.io/k8s-prow/sinker
+  newTag: v20230329-c93d79fb7d
+- name: gcr.io/k8s-prow/status-reconciler
+  newTag: v20230329-c93d79fb7d
+- name: gcr.io/k8s-prow/tide
+  newTag: v20230329-c93d79fb7d
+# External plugins
+- name: gcr.io/k8s-prow/cherrypicker
+  newTag: v20230329-c93d79fb7d
+- name: gcr.io/k8s-prow/label_sync
+  newTag: v20230329-c93d79fb7d
+- name: gcr.io/k8s-prow/needs-rebase
+  newTag: v20230329-c93d79fb7d


### PR DESCRIPTION
We previously had some components running with older image tags. This synchronizes all container images to use the same tag. All image tags are now set through kustomize to make it easier to find them and update all at once.

This updates the following images (in addition to the util images):

- gcr.io/k8s-prow/label_sync - previous tag: v20211111-bce61c7c4a
- gcr.io/k8s-prow/prow-controller-manager - previous tag: v20211102-f06db4e3d1
- gcr.io/k8s-prow/needs-rebase - previous tag: v20210916-3c87dfedd5
- gcr.io/k8s-prow/cherrypicker - previous tag: v20211111-bce61c7c4a