### PR TITLE
Prow: Bump ingress-nginx to v1.7.1

### DIFF
--- a/prow/infra/ingress-controller-job-patch.yaml
+++ b/prow/infra/ingress-controller-job-patch.yaml
@@ -1,0 +1,8 @@
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: not-important
+  namespace: ingress-nginx
+spec:
+  # Make sure that the job is deleted after it finishes so we don't get issues next time we apply.
+  ttlSecondsAfterFinished: 600

--- a/prow/infra/kustomization.yaml
+++ b/prow/infra/kustomization.yaml
@@ -1,9 +1,15 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
-- https://github.com/kubernetes/ingress-nginx/deploy/static/provider/cloud?ref=controller-v1.7.0
+- https://github.com/kubernetes/ingress-nginx/deploy/static/provider/cloud?ref=controller-v1.7.1
 - cluster-issuer-http.yaml
 - storageclass.yaml
 
 patches:
 - path: service.yaml
+# Patch the ingress controller jobs with TTL to avoid issues when upgrading.
+- path: ingress-controller-job-patch.yaml
+  target:
+    # Target all jobs in the namespace (overrides name/namespace in the patch file)
+    kind: Job
+    namespace: ingress-nginx


### PR DESCRIPTION
Also added TTL for the Jobs that comes with ingress-nginx. They are supposed to run each time we upgrade, but if the previous job is still there, then we get a naming collision.