### PR TITLE
Modify integration test to start with ci_run make target

### DIFF
--- a/jenkins/scripts/files/run_integration_tests.sh
+++ b/jenkins/scripts/files/run_integration_tests.sh
@@ -126,6 +126,6 @@ if [[ "${TESTS_FOR}" == "feature_tests_ubuntu" || "${TESTS_FOR}" == "feature_tes
 elif [[ "${TESTS_FOR}" == "e2e_tests" ]]; then
   make test-e2e
 else
-  make
+  make ci_run
   make test
 fi


### PR DESCRIPTION
The make target ci_config will skip the different installation in the host during CI run, as those installations are already done during image building.