### PR TITLE
Prow: Upgrade cluster to v1.26.4 and document

### DIFF
--- a/prow/capo-cluster/kubeadmcontrolplane.yaml
+++ b/prow/capo-cluster/kubeadmcontrolplane.yaml
@@ -25,6 +25,6 @@ spec:
     infrastructureRef:
       apiVersion: infrastructure.cluster.x-k8s.io/v1alpha6
       kind: OpenStackMachineTemplate
-      name: prow-control-plane
+      name: prow-control-plane-v1-26-4
   replicas: 1
-  version: v1.26.3
+  version: v1.26.4

--- a/prow/capo-cluster/machinedeployment.yaml
+++ b/prow/capo-cluster/machinedeployment.yaml
@@ -19,5 +19,5 @@ spec:
       infrastructureRef:
         apiVersion: infrastructure.cluster.x-k8s.io/v1alpha6
         kind: OpenStackMachineTemplate
-        name: prow-md-0
-      version: v1.26.3
+        name: prow-md-0-v1-26-4
+      version: v1.26.4

--- a/prow/capo-cluster/openstackmachinetemplates.yaml
+++ b/prow/capo-cluster/openstackmachinetemplates.yaml
@@ -27,3 +27,33 @@ spec:
         name: prow-cloud-config
       image: ubuntu-2204-kube-v1.26.3
       sshKeyName: metal3ci-key
+---
+apiVersion: infrastructure.cluster.x-k8s.io/v1alpha6
+kind: OpenStackMachineTemplate
+metadata:
+  name: prow-control-plane-v1-26-4
+spec:
+  template:
+    spec:
+      cloudName: prow
+      flavor: 4C-4GB-100GB
+      identityRef:
+        kind: Secret
+        name: prow-cloud-config
+      image: ubuntu-2204-kube-v1.26.4
+      sshKeyName: metal3ci-key
+---
+apiVersion: infrastructure.cluster.x-k8s.io/v1alpha6
+kind: OpenStackMachineTemplate
+metadata:
+  name: prow-md-0-v1-26-4
+spec:
+  template:
+    spec:
+      cloudName: prow
+      flavor: 8C-16GB-100GB
+      identityRef:
+        kind: Secret
+        name: prow-cloud-config
+      image: ubuntu-2204-kube-v1.26.4
+      sshKeyName: metal3ci-key


### PR DESCRIPTION
- Add documentation for how to upgrade the Kubernetes cluster where Prow is running.
- Add documentation for how to replace or perform maintenance on the bastion host for the Prow cluster.
- Upgrade the Kubernetes cluster to v1.26.4.