### PR TITLE
Prow: PodDisruptionBudget for hook and deck

### DIFF
--- a/prow/manifests/overlays/metal3/kustomization.yaml
+++ b/prow/manifests/overlays/metal3/kustomization.yaml
@@ -10,6 +10,7 @@ resources:
 - external-plugins/needs-rebase_deployment.yaml
 - external-plugins/needs-rebase_service.yaml
 - external-plugins/labels_cronjob.yaml
+- pdb.yaml
 
 commonLabels:
   app.kubernetes.io/instance: metal3

--- a/prow/manifests/overlays/metal3/pdb.yaml
+++ b/prow/manifests/overlays/metal3/pdb.yaml
@@ -1,0 +1,21 @@
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  name: hook
+  namespace: prow
+spec:
+  minAvailable: 1
+  selector:
+    matchLabels:
+      app: hook
+---
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  name: deck
+  namespace: prow
+spec:
+  minAvailable: 1
+  selector:
+    matchLabels:
+      app: deck


### PR DESCRIPTION
Kubernetes upgrades can cause disruptions to hook and deck when the old node is drained. Both of them run with 2 replicas, but without a PodDisruptionBudget both replicas would anyway get evicted if they run one the same node. Adding PodDisruptionBudgets for them with minAvailable=1 ensures that only 1 replica is evicted at a time.

The other components of prow are not sensitive in the same way to disruptions. They will just catch up when they become available again. But hook and deck must be avaialable in order to receive requests.