### PR TITLE
Prow: Fix needs-rebase servie namespace

### DIFF
--- a/prow/manifests/overlays/metal3/external-plugins/needs-rebase_service.yaml
+++ b/prow/manifests/overlays/metal3/external-plugins/needs-rebase_service.yaml
@@ -15,7 +15,7 @@
 apiVersion: v1
 kind: Service
 metadata:
-  namespace: default
+  namespace: prow
   name: needs-rebase
 spec:
   selector:
@@ -23,4 +23,4 @@ spec:
   ports:
   - port: 80
     targetPort: 8888
-  type: NodePort
+  type: ClusterIP


### PR DESCRIPTION
The namespace for the needs-rebase service was wrong (default instead of prow). This resulted in webhook requests not reaching the needs-rebase plugin.
Also, the service had type NodePort for no good reason. This is now changed to ClusterIP.