### PR TITLE
e2e integeration fix

### DIFF
--- a/jenkins/scripts/integration_test_env.sh
+++ b/jenkins/scripts/integration_test_env.sh
@@ -64,7 +64,7 @@ export IPA_DOWNLOAD_ENABLED="false"
 METAL3REPO="${METAL3REPO:-https://github.com/metal3-io/metal3-dev-env.git}"
 METAL3BRANCH="${METAL3BRANCH:-main}"
 CAPM3REPO="${CAPM3REPO:-https://github.com/metal3-io/cluster-api-provider-metal3}"
-CAPM3BRANCH="${CAPM3BRANCH:-main}"
+CAPM3BRANCH="${CAPM3BRANCH:-${CAPM3RELEASEBRANCH}}"
 
 # Container image registry value to override the default value in m3-dev-env
 export CONTAINER_REGISTRY=${CONTAINER_REGISTRY:-"registry.nordix.org/quay-io-proxy"}


### PR DESCRIPTION
Fixes this: https://jenkins.nordix.org/view/Metal3%20Periodic/job/metal3_daily_release-1-4_e2e_integration_test_ubuntu/34/consoleFull
Defaulting CAPM3BRANCH to CAPM3RELEASEBRANCH instead of main. We get CAPM3RELEASEBRANCH variable from jjb, which is different for each release.