### PR TITLE
update kubeconform to v0.6.2

### DIFF
--- a/prow/manifests/overlays/metal3/config.yaml
+++ b/prow/manifests/overlays/metal3/config.yaml
@@ -445,7 +445,7 @@ presubmits:
                 value: "TRUE"
               - name: KUBECONFORM_PATH
                 value: "/"
-            image: ghcr.io/yannh/kubeconform:v0.5.0-alpine@sha256:ae1583859c7c9683b2f044a9cc911d9427030cd48ec33eeff6c0f23396780da9
+            image: ghcr.io/yannh/kubeconform:v0.6.2-alpine@sha256:49b5f6b320d30c1b8b72a7abdf02740ac9dc36a3ba23b934d1c02f7b37e6e740
             imagePullPolicy: Always
 
   metal3-io/cluster-api-provider-metal3:
@@ -709,7 +709,7 @@ presubmits:
                 value: "TRUE"
               - name: KUBECONFORM_PATH
                 value: "/"
-            image: ghcr.io/yannh/kubeconform:v0.5.0-alpine@sha256:ae1583859c7c9683b2f044a9cc911d9427030cd48ec33eeff6c0f23396780da9
+            image: ghcr.io/yannh/kubeconform:v0.6.2-alpine@sha256:49b5f6b320d30c1b8b72a7abdf02740ac9dc36a3ba23b934d1c02f7b37e6e740
             imagePullPolicy: Always
     - name: build
       branches:
@@ -1082,7 +1082,7 @@ presubmits:
                 value: "TRUE"
               - name: KUBECONFORM_PATH
                 value: "/"
-            image: ghcr.io/yannh/kubeconform:v0.5.0-alpine@sha256:ae1583859c7c9683b2f044a9cc911d9427030cd48ec33eeff6c0f23396780da9
+            image: ghcr.io/yannh/kubeconform:v0.6.2-alpine@sha256:49b5f6b320d30c1b8b72a7abdf02740ac9dc36a3ba23b934d1c02f7b37e6e740
             imagePullPolicy: Always
 
   metal3-io/ironic-ipa-downloader:


### PR DESCRIPTION
Update kubeconform linter to v0.6.2.

Each of the repos has separate PR to bump kubeconform for local use as well.