### PR TITLE
Bump golang to v1.20 for CAPM3 main branch prow tests

### DIFF
--- a/prow/manifests/overlays/metal3/config.yaml
+++ b/prow/manifests/overlays/metal3/config.yaml
@@ -452,6 +452,21 @@ presubmits:
     - name: gomod
       branches:
         - main
+      skip_if_only_changed: '(((^|/)OWNERS)|(\.md))$'
+      decorate: true
+      spec:
+        containers:
+          - args:
+              - ./hack/gomod.sh
+            command:
+              - sh
+            env:
+              - name: IS_CONTAINER
+                value: "TRUE"
+            image: docker.io/golang:1.20
+            imagePullPolicy: Always
+    - name: gomod
+      branches:
         - release-1.3
         - release-1.4
       skip_if_only_changed: '(((^|/)OWNERS)|(\.md))$'
@@ -486,6 +501,21 @@ presubmits:
     - name: gofmt
       branches:
         - main
+      skip_if_only_changed: '(((^|/)OWNERS)|(\.md))$'
+      decorate: true
+      spec:
+        containers:
+          - args:
+              - ./hack/gofmt.sh
+            command:
+              - sh
+            env:
+              - name: IS_CONTAINER
+                value: "TRUE"
+            image: docker.io/golang:1.20
+            imagePullPolicy: Always
+    - name: gofmt
+      branches:
         - release-1.3
         - release-1.4
       skip_if_only_changed: '(((^|/)OWNERS)|(\.md))$'
@@ -533,7 +563,6 @@ presubmits:
             imagePullPolicy: Always
     - name: golangci-lint
       branches:
-        - main
         - release-1.3
         - release-1.4
       skip_if_only_changed: '(((^|/)OWNERS)|(\.md))$'
@@ -568,6 +597,21 @@ presubmits:
     - name: govet
       branches:
         - main
+      skip_if_only_changed: '(((^|/)OWNERS)|(\.md))$'
+      decorate: true
+      spec:
+        containers:
+          - args:
+              - ./hack/govet.sh
+            command:
+              - sh
+            env:
+              - name: IS_CONTAINER
+                value: "TRUE"
+            image: docker.io/golang:1.20
+            imagePullPolicy: Always
+    - name: govet
+      branches:
         - release-1.3
         - release-1.4
       skip_if_only_changed: '(((^|/)OWNERS)|(\.md))$'
@@ -630,6 +674,21 @@ presubmits:
     - name: generate
       branches:
         - main
+      skip_if_only_changed: '(((^|/)OWNERS)|(\.md))$'
+      decorate: true
+      spec:
+        containers:
+          - args:
+              - ./hack/codegen.sh
+            command:
+              - sh
+            env:
+              - name: IS_CONTAINER
+                value: "TRUE"
+            image: docker.io/golang:1.20
+            imagePullPolicy: Always
+    - name: generate
+      branches:
         - release-1.3
         - release-1.4
       skip_if_only_changed: '(((^|/)OWNERS)|(\.md))$'
@@ -664,6 +723,21 @@ presubmits:
     - name: unit
       branches:
         - main
+      skip_if_only_changed: '(((^|/)OWNERS)|(\.md))$'
+      decorate: true
+      spec:
+        containers:
+          - args:
+              - ./hack/unit.sh
+            command:
+              - sh
+            env:
+              - name: IS_CONTAINER
+                value: "TRUE"
+            image: docker.io/golang:1.20
+            imagePullPolicy: Always
+    - name: unit
+      branches:
         - release-1.3
         - release-1.4
       skip_if_only_changed: '(((^|/)OWNERS)|(\.md))$'
@@ -714,6 +788,21 @@ presubmits:
     - name: build
       branches:
         - main
+      run_if_changed: '^api|^test|^Makefile$'
+      decorate: true
+      spec:
+        containers:
+          - args:
+              - ./hack/build.sh
+            command:
+              - sh
+            env:
+              - name: IS_CONTAINER
+                value: "TRUE"
+            image: docker.io/golang:1.20
+            imagePullPolicy: Always
+    - name: build
+      branches:
         - release-1.3
         - release-1.4
       run_if_changed: '^api|^test|^Makefile$'


### PR DESCRIPTION
This PR also drops golangci-lint prow test for CAPM3 main branch since it would be run through github workflow from now on. 