### PR TITLE
Prow: Resources and LimitRanges

### DIFF
--- a/prow/capo-cluster/kubeadmconfigtemplate.yaml
+++ b/prow/capo-cluster/kubeadmconfigtemplate.yaml
@@ -10,4 +10,6 @@ spec:
           kubeletExtraArgs:
             cloud-provider: external
             provider-id: "openstack:///'{{ instance_id }}'"
+            kube-reserved: cpu=200m,memory=100Mi
+            system-reserved: cpu=100m,memory=100Mi
           name: '{{ local_hostname }}'

--- a/prow/capo-cluster/kubeadmconfigtemplate.yaml
+++ b/prow/capo-cluster/kubeadmconfigtemplate.yaml
@@ -9,4 +9,5 @@ spec:
         nodeRegistration:
           kubeletExtraArgs:
             cloud-provider: external
+            provider-id: "openstack:///'{{ instance_id }}'"
           name: '{{ local_hostname }}'

--- a/prow/capo-cluster/kubeadmcontrolplane.yaml
+++ b/prow/capo-cluster/kubeadmcontrolplane.yaml
@@ -16,12 +16,16 @@ spec:
         kubeletExtraArgs:
           cloud-provider: external
           provider-id: "openstack:///'{{ instance_id }}'"
+          kube-reserved: cpu=200m,memory=100Mi
+          system-reserved: cpu=100m,memory=100Mi
         name: '{{ local_hostname }}'
     joinConfiguration:
       nodeRegistration:
         kubeletExtraArgs:
           cloud-provider: external
           provider-id: "openstack:///'{{ instance_id }}'"
+          kube-reserved: cpu=200m,memory=100Mi
+          system-reserved: cpu=100m,memory=100Mi
         name: '{{ local_hostname }}'
   machineTemplate:
     infrastructureRef:

--- a/prow/capo-cluster/kubeadmcontrolplane.yaml
+++ b/prow/capo-cluster/kubeadmcontrolplane.yaml
@@ -15,16 +15,18 @@ spec:
       nodeRegistration:
         kubeletExtraArgs:
           cloud-provider: external
+          provider-id: "openstack:///'{{ instance_id }}'"
         name: '{{ local_hostname }}'
     joinConfiguration:
       nodeRegistration:
         kubeletExtraArgs:
           cloud-provider: external
+          provider-id: "openstack:///'{{ instance_id }}'"
         name: '{{ local_hostname }}'
   machineTemplate:
     infrastructureRef:
       apiVersion: infrastructure.cluster.x-k8s.io/v1alpha6
       kind: OpenStackMachineTemplate
-      name: prow-control-plane-v1-26-5
+      name: prow-control-plane-v1-26-6
   replicas: 1
-  version: v1.26.5
+  version: v1.26.6

--- a/prow/capo-cluster/machinedeployment.yaml
+++ b/prow/capo-cluster/machinedeployment.yaml
@@ -19,5 +19,5 @@ spec:
       infrastructureRef:
         apiVersion: infrastructure.cluster.x-k8s.io/v1alpha6
         kind: OpenStackMachineTemplate
-        name: prow-md-0-v1-26-5
-      version: v1.26.5
+        name: prow-md-0-v1-26-6
+      version: v1.26.6

--- a/prow/capo-cluster/openstackmachinetemplates.yaml
+++ b/prow/capo-cluster/openstackmachinetemplates.yaml
@@ -1,36 +1,6 @@
 apiVersion: infrastructure.cluster.x-k8s.io/v1alpha6
 kind: OpenStackMachineTemplate
 metadata:
-  name: prow-control-plane-v1-26-4
-spec:
-  template:
-    spec:
-      cloudName: prow
-      flavor: 4C-4GB-100GB
-      identityRef:
-        kind: Secret
-        name: prow-cloud-config
-      image: ubuntu-2204-kube-v1.26.4
-      sshKeyName: metal3ci-key
----
-apiVersion: infrastructure.cluster.x-k8s.io/v1alpha6
-kind: OpenStackMachineTemplate
-metadata:
-  name: prow-md-0-v1-26-4
-spec:
-  template:
-    spec:
-      cloudName: prow
-      flavor: 8C-16GB-100GB
-      identityRef:
-        kind: Secret
-        name: prow-cloud-config
-      image: ubuntu-2204-kube-v1.26.4
-      sshKeyName: metal3ci-key
----
-apiVersion: infrastructure.cluster.x-k8s.io/v1alpha6
-kind: OpenStackMachineTemplate
-metadata:
   name: prow-control-plane-v1-26-5
 spec:
   template:
@@ -56,4 +26,34 @@ spec:
         kind: Secret
         name: prow-cloud-config
       image: ubuntu-2204-kube-v1.26.5
+      sshKeyName: metal3ci-key
+---
+apiVersion: infrastructure.cluster.x-k8s.io/v1alpha6
+kind: OpenStackMachineTemplate
+metadata:
+  name: prow-control-plane-v1-26-6
+spec:
+  template:
+    spec:
+      cloudName: prow
+      flavor: 4C-4GB-100GB
+      identityRef:
+        kind: Secret
+        name: prow-cloud-config
+      image: ubuntu-2204-kube-v1.26.6
+      sshKeyName: metal3ci-key
+---
+apiVersion: infrastructure.cluster.x-k8s.io/v1alpha6
+kind: OpenStackMachineTemplate
+metadata:
+  name: prow-md-0-v1-26-6
+spec:
+  template:
+    spec:
+      cloudName: prow
+      flavor: 8C-16GB-100GB
+      identityRef:
+        kind: Secret
+        name: prow-cloud-config
+      image: ubuntu-2204-kube-v1.26.6
       sshKeyName: metal3ci-key

--- a/prow/manifests/overlays/metal3/config.yaml
+++ b/prow/manifests/overlays/metal3/config.yaml
@@ -28,6 +28,23 @@ plank:
         entrypoint: gcr.io/k8s-prow/entrypoint:v20230329-c93d79fb7d
         initupload: gcr.io/k8s-prow/initupload:v20230329-c93d79fb7d
         sidecar: gcr.io/k8s-prow/sidecar:v20230329-c93d79fb7d
+      resources:
+        clonerefs:
+          requests:
+            cpu: 10m
+            memory: 10Mi
+        initupload:
+          requests:
+            cpu: 10m
+            memory: 10Mi
+        place_entrypoint:
+          requests:
+            cpu: 10m
+            memory: 10Mi
+        sidecar:
+          requests:
+            cpu: 10m
+            memory: 10Mi
 
 tide:
   merge_method:

--- a/prow/manifests/overlays/metal3/kustomization.yaml
+++ b/prow/manifests/overlays/metal3/kustomization.yaml
@@ -11,6 +11,7 @@ resources:
 - external-plugins/needs-rebase_service.yaml
 - external-plugins/labels_cronjob.yaml
 - pdb.yaml
+- limitrange.yaml
 
 commonLabels:
   app.kubernetes.io/instance: metal3

--- a/prow/manifests/overlays/metal3/limitrange.yaml
+++ b/prow/manifests/overlays/metal3/limitrange.yaml
@@ -1,0 +1,11 @@
+apiVersion: v1
+kind: LimitRange
+metadata:
+  name: default-requests
+  namespace: test-pods
+spec:
+  limits:
+  - defaultRequest:
+      cpu: 1000m
+      memory: 1Gi
+    type: Container


### PR DESCRIPTION
There are two commits in this PR. The first commit is for upgrading kubernetes to v1.26.6, the second is for reserving resources across the cluster. More details below (from commit messages):

    This upgrades the Kubernetes cluster to v1.26.6 and includes a "safety
    handle" that was recently added in CAPO templates, namely to set the
    provider ID directly through the kubelet. This prevents potential issues
    from differences between the OpenStackMachine and server names. If they
    differ for some reason, then the cloud controller will not be able to
    set the correct provider ID. By telling the kubelet to set the provider
    ID directly, we bypass this completely.

    This commit adds reserved resources for all nodes. It also sets resource
    requests on prow job init containers and sidecar and adds a LimitRange
    to set default requests for all prow job containers.
    
    The reserved resources is to make sure that the kubelet and other
    critical resources on the nodes get enough resources to function
    properly. The LimitRange is to get some kind of default for all jobs. It
    will not be a good match for most of them, but until we have precise
    knowledge it is better to set something than leaving it empty. This will
    also ensure that if we in the future forget to set resource requests
    when adding new jobs, they will still get the defaults.
    
    Finally, the init container and sidecar requests are there to avoid
    setting the (quite large) default requests on these containers. All jobs
    have the side car and the init containers and they do not consume much
    resources. Unless we set something for them, they would also get the
    defaults.