### PR TITLE
Prow: Resource requests for prow components

### DIFF
--- a/prow/manifests/overlays/metal3/kustomization.yaml
+++ b/prow/manifests/overlays/metal3/kustomization.yaml
@@ -95,3 +95,17 @@ images:
   newTag: v20230329-c93d79fb7d
 - name: gcr.io/k8s-prow/needs-rebase
   newTag: v20230329-c93d79fb7d
+
+patches:
+- path: patches/crier.yaml
+- path: patches/deck.yaml
+- path: patches/ghproxy.yaml
+- path: patches/hook.yaml
+- path: patches/horologium.yaml
+- path: patches/prow-controller-manager.yaml
+- path: patches/sinker.yaml
+- path: patches/statusreconciler.yaml
+- path: patches/tide.yaml
+# External plugins
+- path: patches/cherrypicker.yaml
+- path: patches/needs-rebase.yaml

--- a/prow/manifests/overlays/metal3/patches/cherrypicker.yaml
+++ b/prow/manifests/overlays/metal3/patches/cherrypicker.yaml
@@ -1,0 +1,14 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  namespace: prow
+  name: cherrypicker
+spec:
+  template:
+    spec:
+      containers:
+      - name: cherrypicker
+        resources:
+          requests:
+            cpu: 50m
+            memory: 20Mi

--- a/prow/manifests/overlays/metal3/patches/crier.yaml
+++ b/prow/manifests/overlays/metal3/patches/crier.yaml
@@ -1,0 +1,14 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  namespace: prow
+  name: crier
+spec:
+  template:
+    spec:
+      containers:
+      - name: crier
+        resources:
+          requests:
+            cpu: 100m
+            memory: 60Mi

--- a/prow/manifests/overlays/metal3/patches/deck.yaml
+++ b/prow/manifests/overlays/metal3/patches/deck.yaml
@@ -1,0 +1,14 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  namespace: prow
+  name: deck
+spec:
+  template:
+    spec:
+      containers:
+      - name: deck
+        resources:
+          requests:
+            cpu: 130m
+            memory: 80Mi

--- a/prow/manifests/overlays/metal3/patches/ghproxy.yaml
+++ b/prow/manifests/overlays/metal3/patches/ghproxy.yaml
@@ -1,0 +1,15 @@
+
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  namespace: prow
+  name: ghproxy
+spec:
+  template:
+    spec:
+      containers:
+      - name: ghproxy
+        resources:
+          requests:
+            cpu: 120m
+            memory: 20Mi

--- a/prow/manifests/overlays/metal3/patches/hook.yaml
+++ b/prow/manifests/overlays/metal3/patches/hook.yaml
@@ -1,0 +1,14 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  namespace: prow
+  name: hook
+spec:
+  template:
+    spec:
+      containers:
+      - name: hook
+        resources:
+          requests:
+            cpu: 120m
+            memory: 40Mi

--- a/prow/manifests/overlays/metal3/patches/horologium.yaml
+++ b/prow/manifests/overlays/metal3/patches/horologium.yaml
@@ -1,0 +1,14 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  namespace: prow
+  name: horologium
+spec:
+  template:
+    spec:
+      containers:
+      - name: horologium
+        resources:
+          requests:
+            cpu: 50m
+            memory: 25Mi

--- a/prow/manifests/overlays/metal3/patches/needs-rebase.yaml
+++ b/prow/manifests/overlays/metal3/patches/needs-rebase.yaml
@@ -1,0 +1,14 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  namespace: prow
+  name: needs-rebase
+spec:
+  template:
+    spec:
+      containers:
+      - name: needs-rebase
+        resources:
+          requests:
+            cpu: 50m
+            memory: 20Mi

--- a/prow/manifests/overlays/metal3/patches/prow-controller-manager.yaml
+++ b/prow/manifests/overlays/metal3/patches/prow-controller-manager.yaml
@@ -1,0 +1,14 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  namespace: prow
+  name: prow-controller-manager
+spec:
+  template:
+    spec:
+      containers:
+      - name: prow-controller-manager
+        resources:
+          requests:
+            cpu: 130m
+            memory: 50Mi

--- a/prow/manifests/overlays/metal3/patches/sinker.yaml
+++ b/prow/manifests/overlays/metal3/patches/sinker.yaml
@@ -1,0 +1,14 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  namespace: prow
+  name: sinker
+spec:
+  template:
+    spec:
+      containers:
+      - name: sinker
+        resources:
+          requests:
+            cpu: 100m
+            memory: 50Mi

--- a/prow/manifests/overlays/metal3/patches/statusreconciler.yaml
+++ b/prow/manifests/overlays/metal3/patches/statusreconciler.yaml
@@ -1,0 +1,14 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: statusreconciler
+  namespace: prow
+spec:
+  template:
+    spec:
+      containers:
+      - name: statusreconciler
+        resources:
+          requests:
+            cpu: 50m
+            memory: 20Mi

--- a/prow/manifests/overlays/metal3/patches/tide.yaml
+++ b/prow/manifests/overlays/metal3/patches/tide.yaml
@@ -1,0 +1,14 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  namespace: prow
+  name: tide
+spec:
+  template:
+    spec:
+      containers:
+      - name: tide
+        resources:
+          requests:
+            cpu: 100m
+            memory: 120Mi


### PR DESCRIPTION
This adds resoure requests for CPU and memory for all prow components and external plugins, except the label sync CronJob. We do not currently have data for it, and it is in no way critical.

The requests are based on what I could see in the cluster:

```console
❯ k -n prow top pods
NAME                                       CPU(cores)   MEMORY(bytes)
cherrypicker-6f88fc569d-m2pzb              3m           20Mi
crier-84d95f9cfc-7474n                     34m          54Mi
deck-69dc9f8756-6pmtq                      26m          76Mi
deck-69dc9f8756-ffrwz                      25m          60Mi
ghproxy-79f7d7c4b8-qnd89                   13m          19Mi
hook-65bbf9cdfc-7lgxk                      11m          35Mi
hook-65bbf9cdfc-qpkwh                      15m          36Mi
horologium-55c4d4bf97-fkjtw                5m           23Mi
needs-rebase-5656cfcb87-zpph7              6m           16Mi
prow-controller-manager-56f94b9c46-7hdtj   23m          41Mi
sinker-768647d76-ww94j                     16m          39Mi
statusreconciler-6f76cd8b54-jpqkh          1m           19Mi
tide-747d944d8b-7zw7t                      18m          113Mi
```