### PR TITLE
change the ipa-downloader required test to centos

### DIFF
--- a/prow/manifests/overlays/metal3/config.yaml
+++ b/prow/manifests/overlays/metal3/config.yaml
@@ -154,7 +154,7 @@ branch-protection:
           branches:
             main:
               required_status_checks:
-                contexts: ["test-ubuntu-integration-main"]
+                contexts: ["test-centos-integration-main"]
         ip-address-manager:
           branches:
             main:


### PR DESCRIPTION
ipa-downloader is an init container, which is k8s concept. On Ubuntu integration, it is manually executed (using wrong image, currently), so it is not actually testing it properly. Centos one is running the init container as it should be running, so making it the mandatory test for ipa-downloader repo.