### PR TITLE
Run golint and gofmt on more changes in BMO

### DIFF
--- a/prow/manifests/overlays/metal3/config.yaml
+++ b/prow/manifests/overlays/metal3/config.yaml
@@ -321,7 +321,7 @@ presubmits:
             imagePullPolicy: Always
   metal3-io/baremetal-operator:
     - name: gofmt
-      run_if_changed: '\.go$'
+      skip_if_only_changed: '(((^|/)OWNERS)|(\.md))$'
       decorate: true
       spec:
         containers:
@@ -435,7 +435,7 @@ presubmits:
             image: docker.io/golang:1.19
             imagePullPolicy: Always
     - name: golint
-      run_if_changed: '\.go$'
+      skip_if_only_changed: '(((^|/)OWNERS)|(\.md))$'
       decorate: true
       spec:
         containers:


### PR DESCRIPTION
Golint and gofmt were configured to only run then .go files were changed, but these jobs could also be affected by changes to go.mod and other files (e.g. version changes).