### PR TITLE
build capm3 if almost any file changes

### DIFF
--- a/prow/manifests/overlays/metal3/config.yaml
+++ b/prow/manifests/overlays/metal3/config.yaml
@@ -733,7 +733,7 @@ presubmits:
         - main
         - release-1.3
         - release-1.4
-      run_if_changed: '^api|^test|^Makefile$'
+      skip_if_only_changed: '(((^|/)OWNERS)|(\.md))$'
       decorate: true
       spec:
         containers:


### PR DESCRIPTION
Currently this job only builds if `api/` or `test/` or `Makefile` change, but `make build` also builds the main binary from top-level. It might be confusing to users to see this job pass/fail differently from other jobs that build top-level as well, so triggering the build job here as well.