### PR TITLE
Fix 6hr timeout on e2e integration tests

### DIFF
--- a/jenkins/jobs/integration_tests.pipeline
+++ b/jenkins/jobs/integration_tests.pipeline
@@ -9,7 +9,7 @@ def TIMEOUT = 7200
 KEEP_TEST_ENV=(env.KEEP_TEST_ENV)
 
 if (env.TESTS_FOR) {
-  if ( (env.TESTS_FOR).startsWith('feature_tests') || (env.TESTS_FOR).startsWith('e2e_tests') ) {
+  if ( (env.TESTS_FOR).startsWith('feature_tests') || ( (env.TESTS_FOR).startsWith('e2e_tests') && !(env.GINKGO_FOCUS).equals('integration') && !(env.GINKGO_FOCUS).equals('basic'))) {
     // 6 hours
     TIMEOUT = 21600
   }


### PR DESCRIPTION
As title says.