### PR TITLE
Remove golangci-lint prow test for IPAM main branch

### DIFF
--- a/prow/manifests/overlays/metal3/config.yaml
+++ b/prow/manifests/overlays/metal3/config.yaml
@@ -1043,22 +1043,6 @@ presubmits:
             imagePullPolicy: Always
     - name: golangci-lint
       branches:
-        - main
-      skip_if_only_changed: '(((^|/)OWNERS)|(\.md))$'
-      decorate: true
-      spec:
-        containers:
-          - args:
-              - ./hack/ensure-golangci-lint.sh
-            command:
-              - sh
-            env:
-              - name: IS_CONTAINER
-                value: "TRUE"
-            image: docker.io/golang:1.20
-            imagePullPolicy: Always
-    - name: golangci-lint
-      branches:
         - release-1.3
         - release-1.4
       skip_if_only_changed: '(((^|/)OWNERS)|(\.md))$'


### PR DESCRIPTION
This PR drops golangci-lint prow test for IPAM main branch since it would be run through github workflow from now on once https://github.com/metal3-io/ip-address-manager/pull/284 lands. 