### PR TITLE
Fix make target for dev-env PRs

### DIFF
--- a/jenkins/scripts/files/run_integration_tests.sh
+++ b/jenkins/scripts/files/run_integration_tests.sh
@@ -141,6 +141,9 @@ if [[ "${TESTS_FOR}" == "feature_tests_ubuntu" || "${TESTS_FOR}" == "feature_tes
     make feature_tests
 elif [[ "${TESTS_FOR}" == "e2e_tests" ]]; then
     make test-e2e
+elif [[ "${TESTS_FOR}" != "e2e_tests" && "${REPO_NAME}" == "metal3-dev-env" ]]; then
+    make 
+    make test
 else
     make ci_run
     make test


### PR DESCRIPTION
we need to test 01_  script also for dev-env PRs which is currently skipped since we use ci_run make target. This PR correct  for the dev-env PRs to use make command which includes the script. 