### PR TITLE
re-enable IPA download in tests

### DIFF
--- a/jenkins/scripts/integration_test_env.sh
+++ b/jenkins/scripts/integration_test_env.sh
@@ -57,10 +57,6 @@ export ANSIBLE_FORCE_COLOR=true
 # Make 'changed' tasks the same color as 'succeeded' tasks in Jenkins output
 export ANSIBLE_COLOR_CHANGED="green"
 
-# Use the IPA which is already downloaded in the image, instead of downloading
-# from upstream.
-export IPA_DOWNLOAD_ENABLED="false"
-
 METAL3REPO="${METAL3REPO:-https://github.com/metal3-io/metal3-dev-env.git}"
 METAL3BRANCH="${METAL3BRANCH:-main}"
 CAPM3REPO="${CAPM3REPO:-https://github.com/metal3-io/cluster-api-provider-metal3}"


### PR DESCRIPTION
In fact the download was never disabled, dev-env is downloading IPA based on a different logic. Exporting the IPA_DOWNLOAD_ENABLED=false variable is not needed until there is an established process of pinning the IPA version for CI test jobs.

This variable is also blocking  https://github.com/metal3-io/metal3-dev-env/pull/1272 .