### PR TITLE
Spread tests across projects and regions in cloud

### DIFF
--- a/jenkins/scripts/integration_clean.sh
+++ b/jenkins/scripts/integration_clean.sh
@@ -81,3 +81,10 @@ export OS_REGION_NAME="Fra1"
 export OS_AUTH_URL="https://fra1.citycloud.com:5000"
 echo "Running in region: ${OS_REGION_NAME}"
 cleanup
+
+# Run in dev2  project Karlskrona 
+export OS_PROJECT_NAME="dev2"
+export OS_TENANT_NAME="dev2"
+export OS_REGION_NAME="Kna1"
+export OS_AUTH_URL="https://kna1.citycloud.com:5000"
+cleanup

--- a/jenkins/scripts/integration_delete.sh
+++ b/jenkins/scripts/integration_delete.sh
@@ -20,15 +20,21 @@ source "${CI_DIR}/utils.sh"
 TEST_EXECUTER_PORT_NAME="${TEST_EXECUTER_PORT_NAME:-${TEST_EXECUTER_VM_NAME}-int-port}"
 TEST_EXECUTER_FIP_TAG="${TEST_EXECUTER_FIP_TAG:-${TEST_EXECUTER_VM_NAME}-floating-ip}"
 
-# Run feature tests, e2e tests, main and release* tests in the Frankfurt region
-if [[ "${TESTS_FOR}" == "feature_tests"* ]] || [[ "${TESTS_FOR}" == "e2e_tests"* ]] ||
-        [[ "${UPDATED_BRANCH}" == "main" ]] || [[ "${UPDATED_BRANCH}" == "release"* ]]; then
+# Run:
+#   - e2e features, clusterctl-upgrade tests in the Frankfurt region
+#   - ansible, e2e, basic integration, k8s-upgrade tests in Karlskrona region
+#   - keep tests in dev2 project Karlskrona region
+if [[ "${KEEP_TEST_ENV}" == "true" ]]; then
+    export OS_PROJECT_NAME="dev2"
+    export OS_TENANT_NAME="dev2"  
+elif [[ "${GINKGO_FOCUS}" == "pivoting" ]] || [[ "${GINKGO_FOCUS}" == "remediation" ]] ||
+        [[ "${GINKGO_FOCUS}" == "features" ]] || [[ "${GINKGO_FOCUS}" == "clusterctl-upgrade" ]]; then
     export OS_REGION_NAME="Fra1"
     export OS_AUTH_URL="https://fra1.citycloud.com:5000"
 fi
 echo "Running in region: ${OS_REGION_NAME}"
 
-if [[ "${OS_REGION_NAME}" != "Kna1" ]]; then
+if [[ "${OS_REGION_NAME}" == "Fra1" ]] || [[ "${OS_PROJECT_NAME}" == "dev2" ]]; then
     # Find executer floating ip
     TEST_EXECUTER_FIP_ID="$(openstack floating ip list --tags "${TEST_EXECUTER_FIP_TAG}" -f value -c ID)"
 

--- a/jenkins/scripts/integration_test.sh
+++ b/jenkins/scripts/integration_test.sh
@@ -60,11 +60,17 @@ if [[ "${IRONIC_INSTALL_TYPE}" == "source" ]]; then
   fi
 fi
 
-# Run feature tests, e2e tests, main and release* tests in the Frankfurt region
-if [[ "${TESTS_FOR}" == "feature_tests"* ]] || [[ "${TESTS_FOR}" == "e2e_tests"* ]] ||
-  [[ "${UPDATED_BRANCH}" == "main" ]] || [[ "${UPDATED_BRANCH}" == "release"* ]]; then
-  export OS_REGION_NAME="Fra1"
-  export OS_AUTH_URL="https://fra1.citycloud.com:5000"
+# Run:
+#   - e2e features, clusterctl-upgrade tests in the Frankfurt region
+#   - ansible, e2e, basic integration, k8s-upgrade tests in Karlskrona region
+#   - keep tests in dev2 project Karlskrona region
+if [[ "${KEEP_TEST_ENV}" == "true" ]]; then
+    export OS_PROJECT_NAME="dev2"
+    export OS_TENANT_NAME="dev2"
+elif [[ "${GINKGO_FOCUS}" == "pivoting" ]] || [[ "${GINKGO_FOCUS}" == "remediation" ]] ||
+        [[ "${GINKGO_FOCUS}" == "features" ]] || [[ "${GINKGO_FOCUS}" == "clusterctl-upgrade" ]]; then
+    export OS_REGION_NAME="Fra1"
+    export OS_AUTH_URL="https://fra1.citycloud.com:5000"
 fi
 echo "Running in region: ${OS_REGION_NAME}"
 
@@ -94,7 +100,7 @@ openstack server create -f json \
 TEST_EXECUTER_IP="$(openstack port show -f json "${TEST_EXECUTER_PORT_NAME}" |
   jq -r '.fixed_ips[0].ip_address')"
 
-if [[ "${OS_REGION_NAME}" != "Kna1" ]]; then
+if [[ "${OS_REGION_NAME}" == "Fra1" ]] || [[ "${OS_PROJECT_NAME}" == "dev2" ]]; then
   # Create floating IP
   FLOATING_IP="$(openstack floating ip create -f value -c name \
     --tag "${TEST_EXECUTER_FIP_TAG}" \

--- a/jenkins/scripts/integration_test_clean.sh
+++ b/jenkins/scripts/integration_test_clean.sh
@@ -22,9 +22,15 @@ source "${CI_DIR}/utils.sh"
 
 TEST_EXECUTER_PORT_NAME="${TEST_EXECUTER_PORT_NAME:-${TEST_EXECUTER_VM_NAME}-int-port}"
 
-# Run feature tests, e2e tests, main and release* tests in the Frankfurt region
-if [[ "${TESTS_FOR}" == "feature_tests"* ]] || [[ "${TESTS_FOR}" == "e2e_tests"* ]] ||
-        [[ "${UPDATED_BRANCH}" == "main" ]] || [[ "${UPDATED_BRANCH}" == "release"* ]]; then
+# Run:
+#   - e2e features, clusterctl-upgrade tests in the Frankfurt region
+#   - ansible, e2e, basic integration, k8s-upgrade tests in Karlskrona region
+#   - keep tests in dev2 project Karlskrona region
+if [[ "${KEEP_TEST_ENV}" == "true" ]]; then
+    export OS_PROJECT_NAME="dev2"
+    export OS_TENANT_NAME="dev2"
+elif [[ "${GINKGO_FOCUS}" == "pivoting" ]] || [[ "${GINKGO_FOCUS}" == "remediation" ]] ||
+        [[ "${GINKGO_FOCUS}" == "features" ]] || [[ "${GINKGO_FOCUS}" == "clusterctl-upgrade" ]]; then
     export OS_REGION_NAME="Fra1"
     export OS_AUTH_URL="https://fra1.citycloud.com:5000"
 fi
@@ -34,7 +40,7 @@ echo "Running in region: ${OS_REGION_NAME}"
 TEST_EXECUTER_IP="$(openstack port show -f json "${TEST_EXECUTER_PORT_NAME}" |
     jq -r '.fixed_ips[0].ip_address')"
 
-if [[ "${OS_REGION_NAME}" != "Kna1" ]]; then
+if [[ "${OS_REGION_NAME}" == "Fra1" ]] || [[ "${OS_PROJECT_NAME}" == "dev2" ]]; then
     FLOATING_IP="$(openstack floating ip list --fixed-ip-address "${TEST_EXECUTER_IP}" \
         -c "Floating IP Address" -f value)"
     TEST_EXECUTER_IP="${FLOATING_IP}"

--- a/jenkins/scripts/ironic_image_build_test_delete.sh
+++ b/jenkins/scripts/ironic_image_build_test_delete.sh
@@ -17,7 +17,7 @@ TEST_EXECUTER_FIP_TAG="${TEST_EXECUTER_FIP_TAG:-${TEST_EXECUTER_VM_NAME}-floatin
 
 echo "Running in region: ${OS_REGION_NAME}"
 
-if [[ "${OS_REGION_NAME}" != "Kna1" ]]; then
+if [[ "${OS_REGION_NAME}" == "Fra1" ]] || [[ "${OS_PROJECT_NAME}" == "dev2" ]]; then
     # Find executer floating ip
     TEST_EXECUTER_FIP_ID="$(openstack floating ip list --tags "${TEST_EXECUTER_FIP_TAG}" -f value -c ID)"
 


### PR DESCRIPTION
This PR spreads tests across regions and projects as following:
   - e2e features, clusterclt-upgrade tests in Frankfurt region
   - ansible, e2e, basic integration, k8s-upgrade tests in Karlskrona region
   - keep tests in dev2 project Karlskrona region
 
- [x] Create automated `metal3 image` sharing step to `dev2 project `after every image build job