### PR TITLE
Change flavor for e2e feature test host vms

### DIFF
--- a/jenkins/scripts/integration_test.sh
+++ b/jenkins/scripts/integration_test.sh
@@ -74,8 +74,12 @@ elif [[ "${GINKGO_FOCUS}" == "pivoting" ]] || [[ "${GINKGO_FOCUS}" == "remediati
 fi
 echo "Running in region: ${OS_REGION_NAME}"
 
-if [[ "${TESTS_FOR}" == "e2e_tests"* && ( "${GINKGO_FOCUS}" != "integration" && "${GINKGO_FOCUS}" != "basic" ) ]]; then
+if [[ "${GINKGO_FOCUS}" == "pivoting" ]] || [[ "${GINKGO_FOCUS}" == "remediation" ]] ||
+  [[ "${GINKGO_FOCUS}" == "features" ]] || [[ "${GINKGO_FOCUS}" == "k8s-upgrade" ]]; then
   # Four node cluster
+  TEST_EXECUTER_FLAVOR="${TEST_EXECUTER_FLAVOR:-8C-24GB-300GB}"
+elif [[ "${GINKGO_FOCUS}" == "clusterctl-upgrade" ]]; then
+  # Five node cluster
   TEST_EXECUTER_FLAVOR="${TEST_EXECUTER_FLAVOR:-8C-32GB-300GB}"
 else
   # Two node cluster


### PR DESCRIPTION
This PR sets `8C-24GB-300GB` flavor for pivoting, remediation, k8s-upgrade features tests VMs and keeps `8C-32GB-300GB` flavor for Clusterctl-upgrade test, since it uses 5 nodes. 
- [x] Create  `8C-24GB-300GB` flavor in all regions and projects
- [x] Tests PR several times in different hours of the day to ensure reducing RAM does not affect feature tests duration