### PR TITLE
Add release-1.5 branch configurations

### DIFF
--- a/jenkins/README.md
+++ b/jenkins/README.md
@@ -27,6 +27,10 @@ the commands below. The job result will be posted as a comment.
   v1beta1 and branch main on Ubuntu
 * **/test-centos-integration-main** run integration tests with CAPM3 API version
   v1beta1 and branch main on CentOS
+* **/test-ubuntu-integration-release-1-5** run integration tests with CAPM3 API
+  version v1beta1 and branch release-1.5 on Ubuntu
+* **/test-centos-integration-release-1-5** run integration tests with CAPM3 API
+  version v1beta1 and branch release-1.5 on CentOS
 * **/test-ubuntu-integration-release-1-4** run integration tests with CAPM3 API
   version v1beta1 and branch release-1.4 on Ubuntu
 * **/test-centos-integration-release-1-4** run integration tests with CAPM3 API
@@ -35,10 +39,6 @@ the commands below. The job result will be posted as a comment.
   version v1beta1 and branch release-1.3 on Ubuntu
 * **/test-centos-integration-release-1-3** run integration tests with CAPM3 API
   version v1beta1 and branch release-1.3 on CentOS
-* **/test-ubuntu-integration-release-1-2** run integration tests with CAPM3 API
-  version v1beta1 and branch release-1.2 on Ubuntu
-* **/test-centos-integration-release-1-2** run integration tests with CAPM3 API
-  version v1beta1 and branch release-1.2 on CentOS
 
 Usually, after the integration test part is completed, Jenkins executes another
 script to clean up the environment first and then deletes the VM. However,
@@ -49,6 +49,10 @@ clean up and deletion operations, there are separate triggers phrases as below:
   API version v1beta1 and branch main on Ubuntu
 * **/keep-test-centos-integration-main** run keep integration tests with CAPM3
   API version v1beta1 and branch main on CentOS
+* **/keep-test-ubuntu-integration-release-1-5** run keep integration tests with
+  CAPM3 API version v1beta1 and branch release-1.5 on Ubuntu
+* **/keep-test-centos-integration-release-1-5** run keep integration tests with
+  CAPM3 API version v1beta1 and branch release-1.5 on CentOS
 * **/keep-test-ubuntu-integration-release-1-4** run keep integration tests with
   CAPM3 API version v1beta1 and branch release-1.4 on Ubuntu
 * **/keep-test-centos-integration-release-1-4** run keep integration tests with
@@ -57,10 +61,6 @@ clean up and deletion operations, there are separate triggers phrases as below:
   CAPM3 API version v1beta1 and branch release-1.3 on Ubuntu
 * **/keep-test-centos-integration-release-1-3** run keep integration tests with
   CAPM3 API version v1beta1 and branch release-1.3 on CentOS
-* **/keep-test-ubuntu-integration-release-1-2** run keep integration tests with
-  CAPM3 API version v1beta1 and branch release-1.2 on Ubuntu
-* **/keep-test-centos-integration-release-1-2** run keep integration tests with
-  CAPM3 API version v1beta1 and branch release-1.2 on CentOS
 
 Keep in mind that test VM created with these phrases will not be kept forever
 but deleted after 24 hours, to avoid garbage collection of VMs.
@@ -90,7 +90,7 @@ easier in certain cases:
 
 **Note:** Please remember to manually create a corresponding branch in
 cherry-pick bot's forked repositories (CAPM3, IPAM) in case a new release branch
-(i.e. release-1.4) is created upstream. That is because when the bot is used to
+(i.e. release-1.5) is created upstream. That is because when the bot is used to
 backport the patches to the new release branch, it has to track the new upstream
 branch to be able to open a PR against it in the future.
 

--- a/prow/manifests/overlays/metal3/config.yaml
+++ b/prow/manifests/overlays/metal3/config.yaml
@@ -136,15 +136,15 @@ branch-protection:
                     "test-centos-e2e-integration-main",
                     "test-ubuntu-integration-main",
                   ]
-            release-1.2:
-              required_status_checks:
-                contexts: ["test-ubuntu-integration-release-1-2"]
             release-1.3:
               required_status_checks:
                 contexts: ["test-ubuntu-integration-release-1-3"]
             release-1.4:
               required_status_checks:
                 contexts: ["test-ubuntu-e2e-integration-release-1-4"]
+            release-1.5:
+              required_status_checks:
+                contexts: ["test-ubuntu-e2e-integration-release-1-5"]
         ironic-image:
           branches:
             main:
@@ -164,15 +164,15 @@ branch-protection:
                     "test-centos-e2e-integration-main",
                     "test-ubuntu-integration-main",
                   ]
-            release-1.2:
-              required_status_checks:
-                contexts: ["test-ubuntu-integration-release-1-2"]
             release-1.3:
               required_status_checks:
                 contexts: ["test-ubuntu-integration-release-1-3"]
             release-1.4:
               required_status_checks:
                 contexts: ["test-ubuntu-e2e-integration-release-1-4"]
+            release-1.5:
+              required_status_checks:
+                contexts: ["test-ubuntu-e2e-integration-release-1-5"]
         mariadb-image:
           branches:
             main:
@@ -185,7 +185,7 @@ branch-protection:
                 contexts:
                   [
                     "test-ubuntu-e2e-integration-main",
-                    "test-centos-integration-release-1-4",
+                    "test-centos-integration-release-1-5",
                   ]
 
 deck:
@@ -469,6 +469,7 @@ presubmits:
     - name: gomod
       branches:
         - main
+        - release-1.5
       skip_if_only_changed: '(((^|/)OWNERS)|(\.md))$'
       decorate: true
       spec:
@@ -518,6 +519,7 @@ presubmits:
     - name: gofmt
       branches:
         - main
+        - release-1.5
       skip_if_only_changed: '(((^|/)OWNERS)|(\.md))$'
       decorate: true
       spec:
@@ -614,6 +616,7 @@ presubmits:
     - name: govet
       branches:
         - main
+        - release-1.5
       skip_if_only_changed: '(((^|/)OWNERS)|(\.md))$'
       decorate: true
       spec:
@@ -691,6 +694,7 @@ presubmits:
     - name: generate
       branches:
         - main
+        - release-1.5
       skip_if_only_changed: '(((^|/)OWNERS)|(\.md))$'
       decorate: true
       spec:
@@ -740,6 +744,7 @@ presubmits:
     - name: unit
       branches:
         - main
+        - release-1.5
       skip_if_only_changed: '(((^|/)OWNERS)|(\.md))$'
       decorate: true
       spec:
@@ -805,6 +810,7 @@ presubmits:
     - name: build
       branches:
         - main
+        - release-1.5
       run_if_changed: '^api|^test|^Makefile$'
       decorate: true
       spec:
@@ -932,6 +938,7 @@ presubmits:
     - name: gomod
       branches:
         - main
+        - release-1.5
       skip_if_only_changed: '(((^|/)OWNERS)|(\.md))$'
       decorate: true
       spec:
@@ -995,6 +1002,7 @@ presubmits:
     - name: gofmt
       branches:
         - main
+        - release-1.5
       skip_if_only_changed: '(((^|/)OWNERS)|(\.md))$'
       decorate: true
       spec:
@@ -1077,6 +1085,7 @@ presubmits:
     - name: govet
       branches:
         - main
+        - release-1.5
       skip_if_only_changed: '(((^|/)OWNERS)|(\.md))$'
       decorate: true
       spec:
@@ -1154,6 +1163,7 @@ presubmits:
     - name: unit
       branches:
         - main
+        - release-1.5
       skip_if_only_changed: '(((^|/)OWNERS)|(\.md))$'
       decorate: true
       spec:
@@ -1201,6 +1211,7 @@ presubmits:
     - name: generate
       branches:
         - main
+        - release-1.5
       skip_if_only_changed: '(((^|/)OWNERS)|(\.md))$'
       decorate: true
       spec:


### PR DESCRIPTION
This updates the prow config to include the release-1.5 branch for CAPM3 and IPAM. The "required status checks" are also updated to include the new branches and drop older requirements.