### PR TITLE
Prow: Disable ghproxy pushgateway

### DIFF
--- a/prow/manifests/base/ghproxy.yaml
+++ b/prow/manifests/base/ghproxy.yaml
@@ -38,7 +38,6 @@ spec:
         args:
         - --cache-dir=/cache
         - --cache-sizeGB=99
-        - --push-gateway=pushgateway
         - --serve-metrics=true
         ports:
         - containerPort: 8888


### PR DESCRIPTION
We are not running a pushgateway so there is no point trying to push any metrics to it. This was causing lots of error messages in the ghproxy logs.