### PR TITLE
add missing default value to KEEP_TEST_ENV

### DIFF
--- a/jenkins/scripts/fetch_logs.sh
+++ b/jenkins/scripts/fetch_logs.sh
@@ -10,6 +10,7 @@ set -eu
 #  integration_delete.sh
 #
 BARE_METAL_LAB="${BARE_METAL_LAB:-false}"
+KEEP_TEST_ENV="${KEEP_TEST_ENV:-false}"
 
 CI_DIR="$(dirname "$(readlink -f "${0}")")"
 IMAGE_OS="${IMAGE_OS:-ubuntu}"


### PR DESCRIPTION
This commit:
  - Adds a default value to the KEEP_TEST_ENV variable that is used during log fetching. The missing default value was causing "unbound variable" error.