### PR TITLE
Fix unbound variables for dev tools integration tests

### DIFF
--- a/jenkins/scripts/fetch_logs.sh
+++ b/jenkins/scripts/fetch_logs.sh
@@ -11,6 +11,8 @@ set -eu
 #
 BARE_METAL_LAB="${BARE_METAL_LAB:-false}"
 KEEP_TEST_ENV="${KEEP_TEST_ENV:-false}"
+# set GINKGO_FOCUS to empty value if it is not set
+GINKGO_FOCUS="${GINKGO_FOCUS:-}"
 
 CI_DIR="$(dirname "$(readlink -f "${0}")")"
 IMAGE_OS="${IMAGE_OS:-ubuntu}"

--- a/jenkins/scripts/integration_delete.sh
+++ b/jenkins/scripts/integration_delete.sh
@@ -12,6 +12,11 @@ set -eu
 #  integration_delete.sh
 #
 
+# set KEEP_TEST_ENV to false if it is not set
+KEEP_TEST_ENV="${KEEP_TEST_ENV:-false}"
+# set GINKGO_FOCUS to empty value if it is not set
+GINKGO_FOCUS="${GINKGO_FOCUS:-}"
+
 CI_DIR="$(dirname "$(readlink -f "${0}")")"
 
 # shellcheck disable=SC1091


### PR DESCRIPTION
This PR fixes unbound variables issue, when running dev-tools-integration-tests.