### PR TITLE
add default value to GINKGO_FOCUS variable

### DIFF
--- a/jenkins/scripts/fetch_logs.sh
+++ b/jenkins/scripts/fetch_logs.sh
@@ -11,6 +11,7 @@ set -eu
 #
 BARE_METAL_LAB="${BARE_METAL_LAB:-false}"
 KEEP_TEST_ENV="${KEEP_TEST_ENV:-false}"
+GINKGO_FOCUS="${GINKGO_FOCUS:-}"
 
 CI_DIR="$(dirname "$(readlink -f "${0}")")"
 IMAGE_OS="${IMAGE_OS:-ubuntu}"


### PR DESCRIPTION
This commit:
  - Adds missing default value to GINKGO_FOCUS variable used during log fetching. Missing default value was causing "unbound variable" error.