### PR TITLE
Fix missing default values in cleanup script

### DIFF
--- a/jenkins/scripts/integration_test_clean.sh
+++ b/jenkins/scripts/integration_test_clean.sh
@@ -16,6 +16,8 @@ CI_DIR="$(dirname "$(readlink -f "${0}")")"
 
 REPO_NAME="${REPO_NAME:-metal3-dev-env}"
 IMAGE_OS="${IMAGE_OS:-ubuntu}"
+KEEP_TEST_ENV="${KEEP_TEST_ENV:-false}"
+GINKGO_FOCUS="${GINKGO_FOCUS:-}"
 
 # shellcheck disable=SC1091
 source "${CI_DIR}/utils.sh"


### PR DESCRIPTION
This commit adds:
  - Two missing default values as some jobs are not defining these variables on Jenkins job level.