### PR TITLE
remove capm3 gosec and add make test

### DIFF
--- a/prow/manifests/overlays/metal3/config.yaml
+++ b/prow/manifests/overlays/metal3/config.yaml
@@ -567,6 +567,10 @@ presubmits:
             image: docker.io/golang:1.17
             imagePullPolicy: Always
     - name: gosec
+      branches:
+        - release-1.3
+        - release-1.4
+        - release-1.5
       skip_if_only_changed: '(((^|/)OWNERS)|(\.md))$'
       decorate: true
       spec:
@@ -579,6 +583,19 @@ presubmits:
               - name: IS_CONTAINER
                 value: "TRUE"
             image: docker.io/securego/gosec:2.14.0@sha256:73858f8b1b9b7372917677151ec6deeceeaa40c5b02753080bd647dede14e213
+            imagePullPolicy: Always
+    - name: test
+      branches:
+        - main
+      run_if_changed: '^(Makefile|hack/.*)$'
+      decorate: true
+      spec:
+        containers:
+          - args:
+              - test
+            command:
+              - make
+            image: docker.io/golang:1.20
             imagePullPolicy: Always
     - name: golangci-lint
       branches:


### PR DESCRIPTION
Gosec is run part of golangci-lint, so it can be removed from main. Instead, we need to test Makefile and hack/.* file changes somewhere, hence we add "test" job for main, which runs "make test" which runs unit, linter etc, verifying most of our hack scripts and Makefile.