### PR TITLE
remove gosec from main, add make test, for IPAM

### DIFF
--- a/prow/manifests/overlays/metal3/config.yaml
+++ b/prow/manifests/overlays/metal3/config.yaml
@@ -986,6 +986,10 @@ presubmits:
             image: docker.io/golang:1.18
             imagePullPolicy: Always
     - name: gosec
+      branches:
+        - release-1.3
+        - release-1.4
+        - release-1.5
       skip_if_only_changed: '(((^|/)OWNERS)|(\.md))$'
       decorate: true
       spec:
@@ -998,6 +1002,17 @@ presubmits:
               - name: IS_CONTAINER
                 value: "TRUE"
             image: docker.io/securego/gosec:2.14.0@sha256:73858f8b1b9b7372917677151ec6deeceeaa40c5b02753080bd647dede14e213
+            imagePullPolicy: Always
+    - name: test
+      branches:
+        - main
+      run_if_changed: '^(Makefile|hack/.*)$'
+      decorate: true
+      spec:
+        containers:
+          - command:
+              - make test
+            image: docker.io/golang:1.20
             imagePullPolicy: Always
     - name: gofmt
       branches:


### PR DESCRIPTION
Gosec is part of golangci-lint, so remove Prow for it.

Instead, we're not testing "make test" or changes to hack/* files in CI, so add "make test" prow job.