### PR TITLE
remove gosec, add test to capm3/ipam release-1.5

### DIFF
--- a/prow/manifests/overlays/metal3/config.yaml
+++ b/prow/manifests/overlays/metal3/config.yaml
@@ -570,7 +570,6 @@ presubmits:
       branches:
         - release-1.3
         - release-1.4
-        - release-1.5
       skip_if_only_changed: '(((^|/)OWNERS)|(\.md))$'
       decorate: true
       spec:
@@ -587,6 +586,7 @@ presubmits:
     - name: test
       branches:
         - main
+        - release-1.5
       run_if_changed: '^(Makefile|hack/.*)$'
       decorate: true
       spec:
@@ -1006,7 +1006,6 @@ presubmits:
       branches:
         - release-1.3
         - release-1.4
-        - release-1.5
       skip_if_only_changed: '(((^|/)OWNERS)|(\.md))$'
       decorate: true
       spec:
@@ -1023,6 +1022,7 @@ presubmits:
     - name: test
       branches:
         - main
+        - release-1.5
       run_if_changed: '^(Makefile|hack/.*)$'
       decorate: true
       spec:


### PR DESCRIPTION
Remove gosec from IPAM/CAPM3 release-1.5 branches, but add "make test" instead to match main.

Requires: https://github.com/metal3-io/cluster-api-provider-metal3/pull/1218 and https://github.com/metal3-io/ip-address-manager/pull/329 to be merged first.

/hold