### PR TITLE
add prow support for utility-images

### DIFF
--- a/prow/manifests/overlays/metal3/config.yaml
+++ b/prow/manifests/overlays/metal3/config.yaml
@@ -67,6 +67,7 @@ tide:
         - metal3-io/metal3-io.github.io
         - metal3-io/project-infra
         - metal3-io/ip-address-manager
+        - metal3-io/utility-images
         - Nordix/metal3-dev-tools
         - Nordix/metal3-clusterapi-docs
       labels:
@@ -1400,6 +1401,36 @@ presubmits:
             imagePullPolicy: Always
 
   metal3-io/ironic-hardware-inventory-recorder-image:
+    - name: shellcheck
+      run_if_changed: '((\.sh)|^Makefile)$'
+      decorate: true
+      spec:
+        containers:
+          - args:
+              - ./hack/shellcheck.sh
+            command:
+              - sh
+            env:
+              - name: IS_CONTAINER
+                value: "TRUE"
+            image: docker.io/koalaman/shellcheck-alpine:v0.9.0@sha256:e19ed93c22423970d56568e171b4512c9244fc75dd9114045016b4a0073ac4b7
+            imagePullPolicy: Always
+    - name: markdownlint
+      run_if_changed: '\.md$'
+      decorate: true
+      spec:
+        containers:
+          - args:
+              - ./hack/markdownlint.sh
+            command:
+              - sh
+            env:
+              - name: IS_CONTAINER
+                value: "TRUE"
+            image: docker.io/pipelinecomponents/markdownlint:0.12.0@sha256:0b8f9fcf0410257b2f3548f67ffe25934cfc9877a618b9f85afcf345a25804a2
+            imagePullPolicy: Always
+
+  metal3-io/utility-images:
     - name: shellcheck
       run_if_changed: '((\.sh)|^Makefile)$'
       decorate: true


### PR DESCRIPTION
This commit:
  - Adds tide support for the metal3-io/utility-images repo
  - Adds shellcheck and markdownlint support for the metal3-io/utility-images repo