### PR TITLE
increase ssh inactivity tolerance in test jobs 

### DIFF
--- a/jenkins/scripts/integration_test.sh
+++ b/jenkins/scripts/integration_test.sh
@@ -201,8 +201,8 @@ echo "Running the tests"
 ssh \
   -o StrictHostKeyChecking=no \
   -o UserKnownHostsFile=/dev/null \
-  -o ServerAliveInterval=15 \
-  -o ServerAliveCountMax=10 \
+  -o ServerAliveInterval=60 \
+  -o ServerAliveCountMax=20 \
   -i "${METAL3_CI_USER_KEY}" \
   "${METAL3_CI_USER}"@"${TEST_EXECUTER_IP}" \
   PATH=/usr/local/bin:/usr/bin:/usr/local/sbin:/usr/sbin:/sbin:/bin \


### PR DESCRIPTION
This PR:
  - Increases the ServerAliveInterval  of any job that uses the integration_test.sh
    script from 2.5 min to 20 min. This change aims to make the ssh connection more
    patient at times when the test workloads are not generating any ssh traffic.