### PR TITLE
Prow: Fix commenter and checkconfig command

### DIFF
--- a/prow/manifests/overlays/metal3/config.yaml
+++ b/prow/manifests/overlays/metal3/config.yaml
@@ -219,7 +219,7 @@ periodics:
       containers:
         - image: gcr.io/k8s-prow/commenter:v20231011-33fbc60185
           command:
-            - /app/robots/commenter/app.binary
+            - commenter
           args:
             - |-
               --query=org:metal3-io
@@ -252,7 +252,7 @@ periodics:
       containers:
         - image: gcr.io/k8s-prow/commenter:v20231011-33fbc60185
           command:
-            - /app/robots/commenter/app.binary
+            - commenter
           args:
             - |-
               --query=org:metal3-io
@@ -897,8 +897,9 @@ presubmits:
       spec:
         containers:
           - image: gcr.io/k8s-prow/checkconfig:v20231011-33fbc60185
+            command:
+              - checkconfig
             args:
-              - "/checkconfig"
               - "--config-path"
               - "prow/manifests/overlays/metal3/config.yaml"
               - "--plugin-config"


### PR DESCRIPTION
We have prow jobs that fail with

```
{"component":"entrypoint","error":"could not start the process: fork/exec /app/robots/commenter/app.binary: no such file or directory","file":"k8s.io/test-infra/prow/entrypoint/run.go:84","func":"k8s.io/test-infra/prow/entrypoint.Options.internalRun","level":"error","msg":"Error executing test process","severity":"error","time":"2023-10-24T17:46:51Z"}
```

There was a change in upstream that we missed when bumping the image tags.
See https://github.com/kubernetes/test-infra/pull/25384/files