### PR TITLE
Prow: Update ingress-nginx to v1.9.4

### DIFF
--- a/prow/infra/add-args.yaml
+++ b/prow/infra/add-args.yaml
@@ -1,0 +1,4 @@
+# See https://github.com/kubernetes/ingress-nginx/issues/10572
+- op: add
+  path: /spec/template/spec/containers/0/args/-
+  value: --enable-annotation-validation=true

--- a/prow/infra/configmap-patch.yaml
+++ b/prow/infra/configmap-patch.yaml
@@ -1,0 +1,8 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: ingress-nginx-controller
+  namespace: ingress-nginx
+data:
+  # See https://kubernetes.github.io/ingress-nginx/user-guide/nginx-configuration/configmap/#strict-validate-path-type
+  strict-validate-path-type: "true"

--- a/prow/infra/kustomization.yaml
+++ b/prow/infra/kustomization.yaml
@@ -1,7 +1,7 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
-- https://github.com/kubernetes/ingress-nginx/deploy/static/provider/cloud?ref=controller-v1.8.1
+- https://github.com/kubernetes/ingress-nginx/deploy/static/provider/cloud?ref=controller-v1.9.4
 - cluster-issuer-http.yaml
 - storageclass.yaml
 - ingress-controller-pdb.yaml
@@ -15,3 +15,9 @@ patches:
     kind: Job
     namespace: ingress-nginx
 - path: ingress-controller-deployment-patch.yaml
+- path: configmap-patch.yaml
+- path: add-args.yaml
+  target:
+    kind: Deployment
+    namespace: ingress-nginx
+    name: ingress-nginx-controller


### PR DESCRIPTION
This bumps the ingress-nginx version and enables mitigations for 3 CVEs.

- https://github.com/advisories/GHSA-5wj4-wffq-3378
- https://github.com/advisories/GHSA-gvrm-w2f9-f77q
- https://github.com/advisories/GHSA-fp9f-44c2-cw27

The CVEs are all rated High, but require that the attacker has access to the Kubernetes cluster and is able to create or modify annotations on the ingress resources.

Note: Future versions of ingress-nginx may enable these mitigations by default, at which point we can remove these extra patches.

The changes has been applied in the cluster. :heavy_check_mark: 