### PR TITLE
BML: prune docker storage

### DIFF
--- a/jenkins/scripts/bare_metal_lab/tasks/cleanup-tasks.yaml
+++ b/jenkins/scripts/bare_metal_lab/tasks/cleanup-tasks.yaml
@@ -131,6 +131,7 @@
     # Note: Without --all it just removes images that are not tagged
     - docker image prune --force --all
     - docker volume prune --force
+    - docker system prune --force --all
 
 - name: Reset network
   script: reset_network.sh


### PR DESCRIPTION
We already prune containers, images and volumes, but docker was still taking up more than 60 GB. It was all cleaned up with docker system prune.