### PR TITLE
bump gosec to 2.18.2

### DIFF
--- a/prow/manifests/overlays/metal3/config.yaml
+++ b/prow/manifests/overlays/metal3/config.yaml
@@ -387,7 +387,7 @@ presubmits:
             env:
               - name: IS_CONTAINER
                 value: "TRUE"
-            image: docker.io/securego/gosec:2.14.0@sha256:73858f8b1b9b7372917677151ec6deeceeaa40c5b02753080bd647dede14e213
+            image: docker.io/securego/gosec:2.18.2@sha256:2f9daee1739765788945b79de7f46229f33fda5ed35127393d8a1e459f3a7577
             imagePullPolicy: Always
     - name: gomod
       skip_if_only_changed: '(((^|/)OWNERS)|(\.md))$'


### PR DESCRIPTION
Bump gosec to 2.18.2 for BMO.

Do not bump CAPM3/IPAM gosec as it is used in release-1.3 and 1.4, but release-1.3 is no longer maintained, and hence we'd need to fork the project-infra config between the two. 1.4 is also going to be moved out of support soon when 1.6 releases.

/hold
Needs:
https://github.com/metal3-io/baremetal-operator/pull/1476, https://github.com/metal3-io/baremetal-operator/pull/1475, https://github.com/metal3-io/baremetal-operator/pull/1474 to merge first.