### PR TITLE
BMO e2e pipeline matrix

### DIFF
--- a/jenkins/jobs/bmo_e2e_tests.pipeline
+++ b/jenkins/jobs/bmo_e2e_tests.pipeline
@@ -8,44 +8,60 @@ def branch = env.ghprbActualCommit ?: "main"
 def repoUrl = env.ghprbAuthorRepoGitUrl ?: "https://github.com/metal3-io/baremetal-operator.git"
 
 pipeline {
-  agent { label "metal3-workers" }
+  agent none
   stages {
-    stage("Checkout source code") {
-      steps {
-        checkout scmGit(
-            branches: [[name: branch]],
-            userRemoteConfigs: [[url: repoUrl, credentialsId: "metal3-jenkins-github-token"]],
-            extensions: [[$class: "WipeWorkspace"],
-            [$class: "CleanCheckout"],
-            [$class: "CleanBeforeCheckout"]],
-            submoduleCfg: [],)
-        script {
-          CURRENT_START_TIME = System.currentTimeMillis()
-        }
-      }
-    }
     stage("Run Baremetal Operator e2e tests") {
-      options {
-        timeout(time: TIMEOUT, unit: "SECONDS")
-        ansiColor("xterm")
-      }
-      steps {
-        withCredentials([string(credentialsId: "metal3-clusterctl-github-token", variable: "GITHUB_TOKEN")]) {
-          sh "./hack/ci-e2e.sh"
+      matrix {
+        agent { label "metal3-workers" }
+        axes {
+          axis {
+            name 'BMO_E2E_EMULATOR'
+            values 'vbmc', 'sushy-tools'
+          }
         }
-      }
-      post {
-        always {
-          script {
-            CURRENT_END_TIME = System.currentTimeMillis()
-            if ((((CURRENT_END_TIME - CURRENT_START_TIME)/1000) - TIMEOUT) > 0) {
-                echo "Failed due to timeout"
-                currentBuild.result = "FAILURE"
+        environment {
+          BMO_E2E_EMULATOR = "${BMO_E2E_EMULATOR}"
+        }
+        stages {
+          stage("Checkout source code") {
+            steps {
+              checkout scmGit(
+                  branches: [[name: branch]],
+                  userRemoteConfigs: [[url: repoUrl, credentialsId: "metal3-jenkins-github-token"]],
+                  extensions: [[$class: "WipeWorkspace"],
+                  [$class: "CleanCheckout"],
+                  [$class: "CleanBeforeCheckout"]],
+                  submoduleCfg: [],)
+              script {
+                CURRENT_START_TIME = System.currentTimeMillis()
+              }
             }
           }
-          archiveArtifacts "artifacts*.tar.gz"
-          /* Clean up */
-          sh "make clean-e2e"
+          stage("Run Baremetal Operator e2e tests") {
+            options {
+              timeout(time: TIMEOUT, unit: "SECONDS")
+              ansiColor("xterm")
+            }
+            steps {
+              withCredentials([string(credentialsId: "metal3-clusterctl-github-token", variable: "GITHUB_TOKEN")]) {
+                sh "./hack/ci-e2e.sh"
+              }
+            }
+            post {
+              always {
+                script {
+                  CURRENT_END_TIME = System.currentTimeMillis()
+                  if ((((CURRENT_END_TIME - CURRENT_START_TIME)/1000) - TIMEOUT) > 0) {
+                      echo "Failed due to timeout"
+                      currentBuild.result = "FAILURE"
+                  }
+                }
+                archiveArtifacts "artifacts*.tar.gz"
+                /* Clean up */
+                sh "make clean-e2e"
+              }
+            }
+          }
         }
       }
     }


### PR DESCRIPTION
This adds a matrix to the BMO e2e pipeline so that both VBMC and sushy-tools can be tested in parallel.

TODO:
- [x] Split artifacts so we can gather logs from multiple branches in the matrix
- [x] Fix [provisioning test failure](https://jenkins.nordix.org/view/Metal3%20Periodic/job/metal3-bmo-e2e-test-periodic/94/) (could be as simple as timeout?)