### PR TITLE
Add jenkins-operator for prow

### DIFF
--- a/prow/.gitignore
+++ b/prow/.gitignore
@@ -7,3 +7,4 @@ service-account.json
 github-token
 cherrypick-bot-github-token
 hmac-token
+jenkins-token

--- a/prow/README.md
+++ b/prow/README.md
@@ -31,6 +31,8 @@ instance:
 1. A HMAC token for webhook validation.
 1. A GitHub token for accessing GitHub.
 1. A separate GitHub token for the cherry-pick bot.
+1. A token and username for accessing Jenkins, when triggering Jenkins jobs from
+   Prow.
 
 In addition to this, we rely on a GitHub bot account
 ([metal3-io-bot](https://github.com/metal3-io-bot), owner of the GitHub token)
@@ -153,6 +155,10 @@ PACKER_VAR_FILES=var_file.json make build-openstack-ubuntu-2204
 
    It will be referred to as `${HMAC_TOKEN}`.
 
+1. Create a Jenkins token by logging in to Jenkins using the
+   metal3.bot@gmail.com account and adding an API token in the "Configure" tab
+   for the user. It will be referred to as `${JENKINS_TOKEN}`.
+
 ## GitHub configuration
 
 1. Create bot accounts. The bot accounts are normal accounts on GitHub. Both of
@@ -213,6 +219,7 @@ Then you will be able to just copy and paste the snippets below.
 - `HMAC_TOKEN`
 - `GITHUB_TOKEN`
 - `CHERRYPICK_TOKEN`
+- `JENKINS_TOKEN`
 
 Now you are ready to create the files.
 
@@ -295,6 +302,12 @@ Now you are ready to create the files.
 
    ```bash
    echo "${CHERRYPICK_TOKEN}" > manifests/overlays/metal3/cherrypick-bot-github-token
+   ```
+
+1. Save the Jenkins token as `manifests/overlays/metal3/jenkins-token`.
+
+   ```bash
+   echo "${JENKINS_TOKEN}" > manifests/overlays/metal3/jenkins-token
    ```
 
 ## Access existing instance

--- a/prow/manifests/overlays/metal3/config.yaml
+++ b/prow/manifests/overlays/metal3/config.yaml
@@ -232,6 +232,20 @@ deck:
           name: podinfo
         required_files:
           - podinfo.json
+  external_agent_logs:
+  - agent: jenkins
+    url_template: 'http://jenkins-operator/job/{{.Spec.Job}}/{{.Status.BuildID}}/consoleText'
+
+
+jenkins_operators:
+- max_concurrency: 150
+  max_goroutines: 20
+  job_url_template: https://jenkins.nordix.org/view/Metal3/job/{{.Spec.Job}}/{{.Status.JenkinsBuildId}}/
+  report_templates:
+    "*": >-
+      [Full PR test history](https://prow.apps.test.metal3.io/pr-history?org={{.Spec.Refs.Org}}&repo={{.Spec.Refs.Repo}}&pr={{with index .Spec.Refs.Pulls 0}}{{.Number}}{{end}}).
+      [Your PR dashboard](https://prow.apps.test.metal3.io/pr?query=is:pr+state:open+author:{{with
+      index .Spec.Refs.Pulls 0}}{{.Author}}{{end}}).
 
 periodics:
   - name: periodic-stale

--- a/prow/manifests/overlays/metal3/external-plugins/jenkins-operator.yaml
+++ b/prow/manifests/overlays/metal3/external-plugins/jenkins-operator.yaml
@@ -1,0 +1,139 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: jenkins-operator
+  namespace: prow
+spec:
+  selector:
+    app: jenkins-operator
+  ports:
+  - port: 80
+    targetPort: 8080
+  type: ClusterIP
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  namespace: prow
+  name: jenkins-operator
+  labels:
+    app: jenkins-operator
+spec:
+  replicas: 1
+  strategy:
+    type: RollingUpdate
+    rollingUpdate:
+      maxSurge: 1
+      maxUnavailable: 1
+  selector:
+    matchLabels:
+      app: jenkins-operator
+  template:
+    metadata:
+      labels:
+        app: jenkins-operator
+    spec:
+      serviceAccountName: jenkins-operator
+      containers:
+      - name: jenkins-operator
+        image: gcr.io/k8s-prow/jenkins-operator:v20231011-33fbc60185
+        args:
+        - --config-path=/etc/config/config.yaml
+        - --jenkins-url=https://jenkins.nordix.org
+        - --jenkins-user=metal3.bot@gmail.com
+        - --jenkins-token-file=/etc/jenkins/token
+        - --github-token-path=/etc/github/token
+        - --github-endpoint=http://ghproxy
+        - --github-endpoint=https://api.github.com
+        - --dry-run=false
+        ports:
+        # Used for serving logs so that they can be displayed by deck
+        - name: http
+          containerPort: 8080
+        volumeMounts:
+        - name: github-token
+          mountPath: /etc/github
+          readOnly: true
+        - name: jenkins-token
+          mountPath: /etc/jenkins
+          readOnly: true
+        - name: config
+          mountPath: /etc/config
+          readOnly: true
+      volumes:
+      - name: github-token
+        secret:
+          secretName: github-token
+      - name: jenkins-token
+        secret:
+          secretName: jenkins-token
+      - name: config
+        configMap:
+          name: config
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  namespace: prow
+  name: jenkins-operator
+---
+kind: Role
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  namespace: prow
+  name: jenkins-operator
+rules:
+- apiGroups:
+  - "prow.k8s.io"
+  resources:
+  - prowjobs
+  verbs:
+  - get
+  - list
+  - watch
+  - update
+  - patch
+- apiGroups:
+  - coordination.k8s.io
+  resources:
+  - leases
+  resourceNames:
+  - jenkins-operator-leader-lock
+  verbs:
+  - get
+  - update
+- apiGroups:
+  - coordination.k8s.io
+  resources:
+  - leases
+  verbs:
+  - create
+- apiGroups:
+  - ""
+  resources:
+  - configmaps
+  resourceNames:
+  - jenkins-operator-leader-lock
+  verbs:
+  - get
+  - update
+- apiGroups:
+  - ""
+  resources:
+  - configmaps
+  - events
+  verbs:
+  - create
+---
+kind: RoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  namespace: prow
+  name: jenkins-operator
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: jenkins-operator
+subjects:
+- kind: ServiceAccount
+  name: jenkins-operator

--- a/prow/manifests/overlays/metal3/kustomization.yaml
+++ b/prow/manifests/overlays/metal3/kustomization.yaml
@@ -10,6 +10,7 @@ resources:
 - external-plugins/needs-rebase_deployment.yaml
 - external-plugins/needs-rebase_service.yaml
 - external-plugins/labels_cronjob.yaml
+- external-plugins/jenkins-operator.yaml
 - pdb.yaml
 - limitrange.yaml
 
@@ -68,6 +69,11 @@ secretGenerator:
   name: cherrypick-bot-github-token
   namespace: prow
   type: Opaque
+- files:
+  - token=jenkins-token
+  name: jenkins-token
+  namespace: prow
+  type: Opaque
 
 images:
 - name: gcr.io/k8s-prow/crier
@@ -95,6 +101,8 @@ images:
   newTag: v20231011-33fbc60185
 - name: gcr.io/k8s-prow/needs-rebase
   newTag: v20231011-33fbc60185
+- name: gcr.io/k8s-prow/jenkins-operator
+  newTag: v20231011-33fbc60185
 
 patches:
 - path: patches/crier.yaml
@@ -109,3 +117,4 @@ patches:
 # External plugins
 - path: patches/cherrypicker.yaml
 - path: patches/needs-rebase.yaml
+- path: patches/jenkins-operator.yaml

--- a/prow/manifests/overlays/metal3/patches/jenkins-operator.yaml
+++ b/prow/manifests/overlays/metal3/patches/jenkins-operator.yaml
@@ -1,0 +1,14 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  namespace: prow
+  name: jenkins-operator
+spec:
+  template:
+    spec:
+      containers:
+      - name: jenkins-operator
+        resources:
+          requests:
+            cpu: 50m
+            memory: 50Mi


### PR DESCRIPTION
The name is a bit misleading unfortunately. This prow component is used to trigger jenkins jobs. It will allow us to have one common way to trigger all tests (except github workflows) and we can stop using the ghprb jenkins plugin that is no longer maintained.