### PR TITLE
BMO e2e: Allow flexible artifact naming

### DIFF
--- a/jenkins/jobs/bmo_e2e_tests.pipeline
+++ b/jenkins/jobs/bmo_e2e_tests.pipeline
@@ -43,7 +43,7 @@ pipeline {
                 currentBuild.result = "FAILURE"
             }
           }
-          archiveArtifacts "artifacts.tar.gz"
+          archiveArtifacts "artifacts*.tar.gz"
           /* Clean up */
           sh "make clean-e2e"
         }


### PR DESCRIPTION
This is needed before we can add a matrix to the pipeline. Otherwise the parallel tests would overwrite each others artifacts...