### PR TITLE
WIP: export ironic and mariadb env vars coming from vars.sh

### DIFF
--- a/jenkins/scripts/files/run_integration_tests.sh
+++ b/jenkins/scripts/files/run_integration_tests.sh
@@ -18,6 +18,10 @@ export EPHEMERAL_TEST
 export GINKGO_FOCUS
 export GINKGO_SKIP
 export KEEP_TEST_ENV
+export IRONIC_FROM_SOURCE
+export BUILD_IRONIC_IMAGE_LOCALLY
+export IRONIC_USE_MARIADB
+export BUILD_MARIADB_IMAGE_LOCALLY
 # unsetting NUM_NODES and KUBECTL_SHA256 when it is unbound
 # in BML tests it is not passed through vars file
 export NUM_NODES="${NUM_NODES:-}"


### PR DESCRIPTION
TL;DR: Those variables get lost between integration test start and 02 script trying to use them.

I'm testing https://github.com/metal3-io/ironic-image/pull/466 Ironic source build after https://github.com/metal3-io/metal3-dev-env/pull/1330 got merged, and from the log I can see `IRONIC_FROM_SOURCE` is set to `true` in project-infra, it gets into `/tmp/vars.sh` which is sourced in `integration_test.sh` but when the test says `make ci_run` and runs `02` script, which sources `common.sh`, the `IRONIC_FROM_SOURCE` variable is empty, and gets defaulted to `false`. 

https://jenkins.nordix.org/job/metal3_ironic_image_main_integration_test_centos_ironic_from_source/10/consoleFull
