### PR TITLE
enable build timestamps

### DIFF
--- a/jenkins/jobs/bml_integration_tests.pipeline
+++ b/jenkins/jobs/bml_integration_tests.pipeline
@@ -87,7 +87,9 @@ pipeline {
         withCredentials([sshUserPrivateKey(credentialsId: 'metal3ci_city_cloud_ssh_keypair', keyFileVariable: 'METAL3_CI_USER_KEY')]) {
           withCredentials([usernamePassword(credentialsId: 'metal3-bml-ilo-credentials', usernameVariable: 'BML_ILO_USERNAME', passwordVariable: 'BML_ILO_PASSWORD')]) {
             withCredentials([string(credentialsId: 'metal3-clusterctl-github-token', variable: 'GITHUB_TOKEN')]){
-              sh "./jenkins/scripts/bml_integration_test.sh"
+              timestamps {
+                sh "./jenkins/scripts/bml_integration_test.sh"
+              }
             }
           }
         }
@@ -105,7 +107,9 @@ pipeline {
       }
       withCredentials([sshUserPrivateKey(credentialsId: 'metal3ci_city_cloud_ssh_keypair', keyFileVariable: 'METAL3_CI_USER_KEY')]){
         withCredentials([usernamePassword(credentialsId: 'metal3-bml-ilo-credentials', usernameVariable: 'BML_ILO_USERNAME', passwordVariable: 'BML_ILO_PASSWORD')]) {
-          sh "./jenkins/scripts/fetch_logs.sh"
+          timestamps {
+            sh "./jenkins/scripts/fetch_logs.sh"
+          }
         }
       }
         archiveArtifacts "logs-${env.BUILD_TAG}.tgz"
@@ -114,7 +118,9 @@ pipeline {
       withCredentials([sshUserPrivateKey(credentialsId: 'metal3ci_city_cloud_ssh_keypair', keyFileVariable: 'METAL3_CI_USER_KEY')]){
         withCredentials([usernamePassword(credentialsId: 'metal3-bml-ilo-credentials', usernameVariable: 'BML_ILO_USERNAME', passwordVariable: 'BML_ILO_PASSWORD')]) {
           withCredentials([string(credentialsId: 'metal3-clusterctl-github-token', variable: 'GITHUB_TOKEN')]){
-            sh "./jenkins/scripts/bml_cleanup.sh"
+            timestamps {
+              sh "./jenkins/scripts/bml_cleanup.sh"
+            }
           }
         }
       }

--- a/jenkins/jobs/bmo_e2e_tests.pipeline
+++ b/jenkins/jobs/bmo_e2e_tests.pipeline
@@ -44,7 +44,9 @@ pipeline {
             }
             steps {
               withCredentials([string(credentialsId: "metal3-clusterctl-github-token", variable: "GITHUB_TOKEN")]) {
-                sh "./hack/ci-e2e.sh"
+                timestamps {
+                  sh "./hack/ci-e2e.sh"
+                }
               }
             }
             post {
@@ -57,8 +59,10 @@ pipeline {
                   }
                 }
                 archiveArtifacts "artifacts*.tar.gz"
-                /* Clean up */
-                sh "make clean-e2e"
+                timestamps {
+                  /* Clean up */
+                  sh "make clean-e2e"
+                }
               }
             }
           }

--- a/jenkins/jobs/integration_tests.pipeline
+++ b/jenkins/jobs/integration_tests.pipeline
@@ -38,7 +38,6 @@ script {
     VM_NAME = "ci-test-vm-" + dateFormat.format(date) + "-" + VM_KEY
   }
 }
-
 pipeline {
   agent { label 'metal3-static-workers' }
   environment {
@@ -112,7 +111,9 @@ pipeline {
           withCredentials([sshUserPrivateKey(credentialsId: 'metal3ci_city_cloud_ssh_keypair', keyFileVariable: 'METAL3_CI_USER_KEY')]) {
             withCredentials([string(credentialsId: 'metal3-clusterctl-github-token', variable: 'GITHUB_TOKEN')]) {
               ansiColor('xterm') {
-                sh "./jenkins/scripts/integration_test.sh"
+                timestamps {
+                  sh "./jenkins/scripts/integration_test.sh"
+                }
               }
             }
           }
@@ -129,7 +130,9 @@ pipeline {
           }
           withCredentials([usernamePassword(credentialsId: 'metal3ci_city_cloud_openstack_credentials', usernameVariable: 'OS_USERNAME', passwordVariable: 'OS_PASSWORD')]) {
             withCredentials([sshUserPrivateKey(credentialsId: 'metal3ci_city_cloud_ssh_keypair', keyFileVariable: 'METAL3_CI_USER_KEY')]){
-              sh "./jenkins/scripts/fetch_logs.sh"
+              timestamps {
+                sh "./jenkins/scripts/fetch_logs.sh"
+              }
             }
           }
           archiveArtifacts "logs-${env.BUILD_TAG}.tgz"
@@ -145,7 +148,9 @@ pipeline {
             if ("${KEEP_TEST_ENV}" == "true") {
               echo "Skipping environment clean up"
             } else {
-              sh "./jenkins/scripts/integration_test_clean.sh"
+              timestamps {
+                sh "./jenkins/scripts/integration_test_clean.sh"
+              }
             }
           }
         }
@@ -158,7 +163,9 @@ pipeline {
             if ("${KEEP_TEST_ENV}" == "true") {
               echo "Skipping VM deletion"
             } else {
-              sh "./jenkins/scripts/integration_delete.sh"
+              timestamps {
+                sh "./jenkins/scripts/integration_delete.sh"
+              }
             }
           }
         }

--- a/jenkins/jobs/integration_tests_clean.pipeline
+++ b/jenkins/jobs/integration_tests_clean.pipeline
@@ -55,7 +55,9 @@ pipeline {
       steps {
         script {
           withCredentials([usernamePassword(credentialsId: 'metal3ci_city_cloud_openstack_credentials', usernameVariable: 'OS_USERNAME', passwordVariable: 'OS_PASSWORD')]) {
-            sh "./jenkins/scripts/integration_clean.sh"
+            timestamps {
+              sh "./jenkins/scripts/integration_clean.sh"
+            }
           }
         }
       }

--- a/jenkins/jobs/ironic_image_build_test.pipeline
+++ b/jenkins/jobs/ironic_image_build_test.pipeline
@@ -56,7 +56,9 @@ pipeline {
             script {
               CURRENT_START_TIME = System.currentTimeMillis()
             }
-            sh "./jenkins/scripts/start_ironic_image_build_test.sh"
+            timestamps {
+              sh "./jenkins/scripts/start_ironic_image_build_test.sh"
+            }
          }
        }
     }
@@ -75,7 +77,9 @@ pipeline {
       withCredentials([usernamePassword(credentialsId: 'metal3ci_city_cloud_openstack_credentials', usernameVariable: 'OS_USERNAME', passwordVariable: 'OS_PASSWORD'),
         sshUserPrivateKey(credentialsId: 'metal3ci_city_cloud_ssh_keypair', keyFileVariable: 'METAL3_CI_USER_KEY')]){
           script {
-              sh "./jenkins/scripts/ironic_image_build_test_delete.sh"
+              timestamps {
+                sh "./jenkins/scripts/ironic_image_build_test_delete.sh"
+              }
           }
         }
     }

--- a/jenkins/jobs/parallel_e2e_features_test.pipeline
+++ b/jenkins/jobs/parallel_e2e_features_test.pipeline
@@ -125,7 +125,9 @@ pipeline {
               string(credentialsId: 'metal3-clusterctl-github-token', variable: 'GITHUB_TOKEN')
             ]) {
               ansiColor('xterm') {
-                sh "./jenkins/scripts/integration_test.sh"
+                timestamps {
+                  sh "./jenkins/scripts/integration_test.sh"
+                }
               }
             }
           }
@@ -141,8 +143,9 @@ pipeline {
               withCredentials([usernamePassword(credentialsId: 'metal3ci_city_cloud_openstack_credentials', usernameVariable: 'OS_USERNAME', passwordVariable: 'OS_PASSWORD'),
                 sshUserPrivateKey(credentialsId: 'metal3ci_city_cloud_ssh_keypair', keyFileVariable: 'METAL3_CI_USER_KEY')
               ]) {
-                sh "./jenkins/scripts/fetch_logs.sh"
-
+                timestamps {
+                  sh "./jenkins/scripts/fetch_logs.sh"
+                }
               }
               archiveArtifacts "logs-${env.BUILD_TAG}.tgz"
             }
@@ -154,7 +157,9 @@ pipeline {
                   if ("${KEEP_TEST_ENV}" == "true") {
                     echo "Skipping environment clean up"
                   } else {
-                    sh "./jenkins/scripts/integration_test_clean.sh"
+                    timestamps {
+                      sh "./jenkins/scripts/integration_test_clean.sh"
+                    }
                   }
                 }
               }
@@ -167,7 +172,9 @@ pipeline {
                   if ("${KEEP_TEST_ENV}" == "true") {
                     echo "Skipping VM deletion"
                   } else {
-                    sh "./jenkins/scripts/integration_delete.sh"
+                    timestamps {
+                      sh "./jenkins/scripts/integration_delete.sh"
+                    }
                   }
                 }
               }
@@ -192,7 +199,9 @@ pipeline {
               string(credentialsId: 'metal3-clusterctl-github-token', variable: 'GITHUB_TOKEN')
             ]) {
               ansiColor('xterm') {
-                sh "./jenkins/scripts/integration_test.sh"
+                timestamps {
+                  sh "./jenkins/scripts/integration_test.sh"
+                }
               }
             }
           }
@@ -208,7 +217,9 @@ pipeline {
               withCredentials([usernamePassword(credentialsId: 'metal3ci_city_cloud_openstack_credentials', usernameVariable: 'OS_USERNAME', passwordVariable: 'OS_PASSWORD'),
                 sshUserPrivateKey(credentialsId: 'metal3ci_city_cloud_ssh_keypair', keyFileVariable: 'METAL3_CI_USER_KEY')
               ]) {
-                sh "./jenkins/scripts/fetch_logs.sh"
+                timestamps {
+                  sh "./jenkins/scripts/fetch_logs.sh"
+                }
               }
               archiveArtifacts "logs-${env.BUILD_TAG}.tgz"
             }
@@ -220,7 +231,9 @@ pipeline {
                   if ("${KEEP_TEST_ENV}" == "true") {
                     echo "Skipping environment clean up"
                   } else {
-                    sh "./jenkins/scripts/integration_test_clean.sh"
+                    timestamps {
+                      sh "./jenkins/scripts/integration_test_clean.sh"
+                    }
                   }
                 }
               }
@@ -233,7 +246,9 @@ pipeline {
                   if ("${KEEP_TEST_ENV}" == "true") {
                     echo "Skipping VM deletion"
                   } else {
-                    sh "./jenkins/scripts/integration_delete.sh"
+                    timestamps {
+                      sh "./jenkins/scripts/integration_delete.sh"
+                    }
                   }
                 }
               }
@@ -259,7 +274,9 @@ pipeline {
               string(credentialsId: 'metal3-clusterctl-github-token', variable: 'GITHUB_TOKEN')
             ]) {
               ansiColor('xterm') {
-                sh "./jenkins/scripts/integration_test.sh"
+                timestamps {
+                  sh "./jenkins/scripts/integration_test.sh"
+                }
               }
             }
           }
@@ -275,7 +292,9 @@ pipeline {
               withCredentials([usernamePassword(credentialsId: 'metal3ci_city_cloud_openstack_credentials', usernameVariable: 'OS_USERNAME', passwordVariable: 'OS_PASSWORD'),
                 sshUserPrivateKey(credentialsId: 'metal3ci_city_cloud_ssh_keypair', keyFileVariable: 'METAL3_CI_USER_KEY')
               ]) {
-                sh "./jenkins/scripts/fetch_logs.sh"
+                timestamps {
+                  sh "./jenkins/scripts/fetch_logs.sh"
+                }
               }
               archiveArtifacts "logs-${env.BUILD_TAG}.tgz"
             }
@@ -287,7 +306,9 @@ pipeline {
                   if ("${KEEP_TEST_ENV}" == "true") {
                     echo "Skipping environment clean up"
                   } else {
-                    sh "./jenkins/scripts/integration_test_clean.sh"
+                    timestamps {
+                      sh "./jenkins/scripts/integration_test_clean.sh"
+                    }
                   }
                 }
               }
@@ -300,7 +321,9 @@ pipeline {
                   if ("${KEEP_TEST_ENV}" == "true") {
                     echo "Skipping VM deletion"
                   } else {
-                    sh "./jenkins/scripts/integration_delete.sh"
+                    timestamps {
+                      sh "./jenkins/scripts/integration_delete.sh"
+                    }
                   }
                 }
               }


### PR DESCRIPTION
This commit enables build log timestamps in all pipeline scripts with a 1 second resolution.