### PR TITLE
Make BMO e2e tests required status check

### DIFF
--- a/prow/manifests/overlays/metal3/config.yaml
+++ b/prow/manifests/overlays/metal3/config.yaml
@@ -138,7 +138,11 @@ branch-protection:
                   [
                     "test-centos-e2e-integration-main",
                     "test-ubuntu-integration-main",
+                    "metal3-bmo-e2e-test",
                   ]
+            release-0.5:
+              required_status_checks:
+                contexts: ["metal3-bmo-e2e-test"]
         cluster-api-provider-metal3:
           branches:
             main:


### PR DESCRIPTION
I propose we make the e2e tests required for BMO now. They exist on main and release-0.5 so this is what I added.
We could also remove one or both CAPM3 based jobs, but perhaps better to do that separately?