### PR TITLE
remove release-1.3 from prow

### DIFF
--- a/jenkins/README.md
+++ b/jenkins/README.md
@@ -39,10 +39,6 @@ the commands below. The job result will be posted as a comment.
   version v1beta1 and branch release-1.4 on Ubuntu
 * **/test-centos-integration-release-1-4** run integration tests with CAPM3 API
   version v1beta1 and branch release-1.4 on CentOS
-* **/test-ubuntu-integration-release-1-3** run integration tests with CAPM3 API
-  version v1beta1 and branch release-1.3 on Ubuntu
-* **/test-centos-integration-release-1-3** run integration tests with CAPM3 API
-  version v1beta1 and branch release-1.3 on CentOS
 
 Usually, after the integration test part is completed, Jenkins executes another
 script to clean up the environment first and then deletes the VM. However,
@@ -65,10 +61,6 @@ clean up and deletion operations, there are separate triggers phrases as below:
   CAPM3 API version v1beta1 and branch release-1.4 on Ubuntu
 * **/keep-test-centos-integration-release-1-4** run keep integration tests with
   CAPM3 API version v1beta1 and branch release-1.4 on CentOS
-* **/keep-test-ubuntu-integration-release-1-3** run keep integration tests with
-  CAPM3 API version v1beta1 and branch release-1.3 on Ubuntu
-* **/keep-test-centos-integration-release-1-3** run keep integration tests with
-  CAPM3 API version v1beta1 and branch release-1.3 on CentOS
 
 Keep in mind that test VM created with these phrases will not be kept forever
 but deleted after 24 hours, to avoid garbage collection of VMs.

--- a/prow/manifests/overlays/metal3/config.yaml
+++ b/prow/manifests/overlays/metal3/config.yaml
@@ -152,9 +152,6 @@ branch-protection:
                     "test-centos-e2e-integration-main",
                     "test-ubuntu-integration-main",
                   ]
-            release-1.3:
-              required_status_checks:
-                contexts: ["test-ubuntu-integration-release-1-3"]
             release-1.4:
               required_status_checks:
                 contexts: ["test-ubuntu-e2e-integration-release-1-4"]
@@ -194,9 +191,6 @@ branch-protection:
                     "test-centos-e2e-integration-main",
                     "test-ubuntu-integration-main",
                   ]
-            release-1.3:
-              required_status_checks:
-                contexts: ["test-ubuntu-integration-release-1-3"]
             release-1.4:
               required_status_checks:
                 contexts: ["test-ubuntu-e2e-integration-release-1-4"]
@@ -562,7 +556,6 @@ presubmits:
             imagePullPolicy: Always
     - name: gomod
       branches:
-        - release-1.3
         - release-1.4
       skip_if_only_changed: '(((^|/)OWNERS)|(\.md))$'
       decorate: true
@@ -597,7 +590,6 @@ presubmits:
             imagePullPolicy: Always
     - name: gofmt
       branches:
-        - release-1.3
         - release-1.4
       skip_if_only_changed: '(((^|/)OWNERS)|(\.md))$'
       decorate: true
@@ -614,7 +606,6 @@ presubmits:
             imagePullPolicy: Always
     - name: gosec
       branches:
-        - release-1.3
         - release-1.4
       skip_if_only_changed: '(((^|/)OWNERS)|(\.md))$'
       decorate: true
@@ -646,7 +637,6 @@ presubmits:
             imagePullPolicy: Always
     - name: golangci-lint
       branches:
-        - release-1.3
         - release-1.4
       skip_if_only_changed: '(((^|/)OWNERS)|(\.md))$'
       decorate: true
@@ -681,7 +671,6 @@ presubmits:
             imagePullPolicy: Always
     - name: govet
       branches:
-        - release-1.3
         - release-1.4
       skip_if_only_changed: '(((^|/)OWNERS)|(\.md))$'
       decorate: true
@@ -744,7 +733,6 @@ presubmits:
             imagePullPolicy: Always
     - name: generate
       branches:
-        - release-1.3
         - release-1.4
       skip_if_only_changed: '(((^|/)OWNERS)|(\.md))$'
       decorate: true
@@ -779,7 +767,6 @@ presubmits:
             imagePullPolicy: Always
     - name: unit
       branches:
-        - release-1.3
         - release-1.4
       skip_if_only_changed: '(((^|/)OWNERS)|(\.md))$'
       decorate: true
@@ -830,7 +817,6 @@ presubmits:
             imagePullPolicy: Always
     - name: build
       branches:
-        - release-1.3
         - release-1.4
       skip_if_only_changed: '(((^|/)OWNERS)|(\.md))$'
       decorate: true
@@ -990,7 +976,6 @@ presubmits:
             imagePullPolicy: Always
     - name: gomod
       branches:
-        - release-1.3
         - release-1.4
       skip_if_only_changed: '(((^|/)OWNERS)|(\.md))$'
       decorate: true
@@ -1007,7 +992,6 @@ presubmits:
             imagePullPolicy: Always
     - name: gosec
       branches:
-        - release-1.3
         - release-1.4
       skip_if_only_changed: '(((^|/)OWNERS)|(\.md))$'
       decorate: true
@@ -1057,7 +1041,6 @@ presubmits:
             imagePullPolicy: Always
     - name: gofmt
       branches:
-        - release-1.3
         - release-1.4
       skip_if_only_changed: '(((^|/)OWNERS)|(\.md))$'
       decorate: true
@@ -1074,7 +1057,6 @@ presubmits:
             imagePullPolicy: Always
     - name: golangci-lint
       branches:
-        - release-1.3
         - release-1.4
       skip_if_only_changed: '(((^|/)OWNERS)|(\.md))$'
       decorate: true
@@ -1109,7 +1091,6 @@ presubmits:
             imagePullPolicy: Always
     - name: govet
       branches:
-        - release-1.3
         - release-1.4
       skip_if_only_changed: '(((^|/)OWNERS)|(\.md))$'
       decorate: true
@@ -1171,7 +1152,6 @@ presubmits:
             image: docker.io/golang:1.20
     - name: unit
       branches:
-        - release-1.3
         - release-1.4
       skip_if_only_changed: '(((^|/)OWNERS)|(\.md))$'
       decorate: true
@@ -1205,7 +1185,6 @@ presubmits:
             imagePullPolicy: Always
     - name: generate
       branches:
-        - release-1.3
         - release-1.4
       skip_if_only_changed: '(((^|/)OWNERS)|(\.md))$'
       decorate: true


### PR DESCRIPTION
We no longer run release-1.3 tests in Prow. We run tests for 1.4, and support 1.5, 1.6 and main.