### PR TITLE
Add BMO upgrade tests pipeline

### DIFF
--- a/jenkins/jobs/bmo_e2e_tests.pipeline
+++ b/jenkins/jobs/bmo_e2e_tests.pipeline
@@ -8,6 +8,9 @@ def branch = env.ghprbActualCommit ?: "main"
 def repoUrl = env.ghprbAuthorRepoGitUrl ?: "https://github.com/metal3-io/baremetal-operator.git"
 
 pipeline {
+  environment {
+    GINKGO_FOCUS="${GINKGO_FOCUS}"
+  }
   agent none
   stages {
     stage("Run Baremetal Operator e2e tests") {


### PR DESCRIPTION
This change is needed for the new jenkins job, which runs BMO E2E upgrade tests.
Related jjb changes: https://gerrit.nordix.org/c/infra/cicd/+/20387