### PR TITLE
Fix typos in prow config for jenkins-operator

### DIFF
--- a/prow/manifests/overlays/metal3/config.yaml
+++ b/prow/manifests/overlays/metal3/config.yaml
@@ -238,13 +238,13 @@ deck:
           - podinfo.json
   external_agent_logs:
   - agent: jenkins
-    url_template: 'http://jenkins-operator/job/{{.Spec.Job}}/{{.Status.BuildID}}/consoleText'
+    url_template: 'http://jenkins-operator/job/{{.Spec.Job}}/{{.Status.JenkinsBuildID}}/consoleText'
 
 
 jenkins_operators:
 - max_concurrency: 150
   max_goroutines: 20
-  job_url_template: https://jenkins.nordix.org/view/Metal3/job/{{.Spec.Job}}/{{.Status.JenkinsBuildId}}/
+  job_url_template: 'https://jenkins.nordix.org/view/Metal3/job/{{.Spec.Job}}/{{.Status.JenkinsBuildID}}/'
   report_templates:
     "*": >-
       [Full PR test history](https://prow.apps.test.metal3.io/pr-history?org={{.Spec.Refs.Org}}&repo={{.Spec.Refs.Repo}}&pr={{with index .Spec.Refs.Pulls 0}}{{.Number}}{{end}}).


### PR DESCRIPTION
I think this is the reason we do not get links to the jenkins build and logs.

API ref: https://github.com/kubernetes/test-infra/blob/8a9df5c914af259a641c9362aca124d9238960e6/prow/apis/prowjobs/v1/types.go#L1069

Error seen in the logs:

```
{"component":"jenkins-operator","event-GUID":"f78845c0-b5e7-11ee-9678-d4a6c200b850","file":"k8s.io/test-infra/prow/jenkins/controller.go:395","func":"k8s.io/test-infra/prow/jenkins.(*Controller).syncPendingJob","job":"metal3-bmo-e2e-test-pull","level":"error","msg":"error executing URL template: template: JobURL:1:66: executing \"JobURL\" at \u003c.Status.JenkinsBuildId\u003e: can't evaluate field JenkinsBuildId in type v1.ProwJobStatus","name":"6ce9f938-39b2-44ab-98eb-ec6c591b8044","org":"metal3-io","pr":1520,"repo":"baremetal-operator","severity":"error","state":"failure","time":"2024-01-18T10:27:48Z","type":"presubmit"}
```