### PR TITLE
Make BMO e2e prow job required

### DIFF
--- a/prow/manifests/overlays/metal3/config.yaml
+++ b/prow/manifests/overlays/metal3/config.yaml
@@ -138,11 +138,7 @@ branch-protection:
                   [
                     "test-centos-e2e-integration-main",
                     "test-ubuntu-integration-main",
-                    "metal3-bmo-e2e-test",
                   ]
-            release-0.5:
-              required_status_checks:
-                contexts: ["metal3-bmo-e2e-test"]
         cluster-api-provider-metal3:
           branches:
             main:
@@ -245,11 +241,6 @@ jenkins_operators:
 - max_concurrency: 150
   max_goroutines: 20
   job_url_template: 'https://jenkins.nordix.org/view/Metal3/job/{{.Spec.Job}}/{{.Status.JenkinsBuildID}}/'
-  report_templates:
-    "*": >-
-      [Full PR test history](https://prow.apps.test.metal3.io/pr-history?org={{.Spec.Refs.Org}}&repo={{.Spec.Refs.Repo}}&pr={{with index .Spec.Refs.Pulls 0}}{{.Number}}{{end}}).
-      [Your PR dashboard](https://prow.apps.test.metal3.io/pr?query=is:pr+state:open+author:{{with
-      index .Spec.Refs.Pulls 0}}{{.Author}}{{end}}).
 
 periodics:
   - name: periodic-stale
@@ -542,7 +533,15 @@ presubmits:
       agent: jenkins
       # Don't run unless triggered to avoid wasting resources
       always_run: false
-      # Until we have checked that it works, keep it optional
+      optional: false
+    - name: metal3-bmo-e2e-test-optional-pull
+      # E2e tests do not exist before release-0.5
+      branches:
+        - main
+        - release-0.5
+      agent: jenkins
+      # Don't run unless triggered to avoid wasting resources
+      always_run: false
       optional: true
 
   metal3-io/cluster-api-provider-metal3:


### PR DESCRIPTION
This removes the required status context for BMO e2e tests and instead makes the prow job required.

It also removes the report template because this is already covered by the report template set for plank. This config is currently causing double messages when a job fails (one for jenkins and one for plank).


One thing to discuss, test and decide is how to handle these required jobs.
Other required jobs that we have run automatically when needed. The e2e jobs have traditionally been manually triggered only to save some resources. I'm not sure if a required but not automatically run job will show up in the status contexts. If not, we have to decide if we

1. Add required status contexts back for them, or
2. Run the jobs automatically. If we choose this we can also use config like "skip if only" to not run it on all PRs, which would be quite nice!