### PR TITLE
Remove the ghprb variable from BMO e2e pipeline

### DIFF
--- a/jenkins/jobs/bmo_e2e_tests.pipeline
+++ b/jenkins/jobs/bmo_e2e_tests.pipeline
@@ -4,7 +4,7 @@ import java.text.SimpleDateFormat
 def TIMEOUT = 3600
 
 // Set defaults for non-PR jobs
-def pullSha = (env.PULL_PULL_SHA) ?: (env.ghprbActualCommit) ?: "main"
+def pullSha = (env.PULL_PULL_SHA) ?: "main"
 def repoUrl = "https://github.com/metal3-io/baremetal-operator.git"
 // Fetch the main branch and the pullSha, nothing else
 def refspec = '+refs/heads/main:refs/remotes/origin/main ' + pullSha


### PR DESCRIPTION
We are no longer using the ghprb plugin to trigger these tests so the variable can now be removed completely.