### PR TITLE
Update required contexts for BMO

### DIFF
--- a/prow/manifests/overlays/metal3/config.yaml
+++ b/prow/manifests/overlays/metal3/config.yaml
@@ -135,7 +135,6 @@ branch-protection:
                 contexts:
                   [
                     "test-centos-e2e-integration-main",
-                    "test-ubuntu-integration-main",
                   ]
         cluster-api-provider-metal3:
           branches:


### PR DESCRIPTION
The BMO e2e tests have now been required for PRs in BMO for a couple of weeks already. They test more extensively and efficiently than the old integration test so I suggest we make it optional.