### PR TITLE
Prow: Bump ingress-nginx to v1.9.6

### DIFF
--- a/prow/infra/kustomization.yaml
+++ b/prow/infra/kustomization.yaml
@@ -1,7 +1,7 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
-- https://github.com/kubernetes/ingress-nginx/deploy/static/provider/cloud?ref=controller-v1.9.4
+- https://github.com/kubernetes/ingress-nginx/deploy/static/provider/cloud?ref=controller-v1.9.6
 - cluster-issuer-http.yaml
 - storageclass.yaml
 - ingress-controller-pdb.yaml


### PR DESCRIPTION
Just keeping up with the upstream. Nothing newsworthy in the changelog.