### PR TITLE
🐛Typo fix

### DIFF
--- a/prow/manifests/overlays/metal3/config.yaml
+++ b/prow/manifests/overlays/metal3/config.yaml
@@ -321,7 +321,7 @@ periodics:
         command:
         - generic-autobumper
         args:
-        - --config="prow/manifests/overlays/metal3/generic-autobumper-config.yaml"
+        - --config=prow/manifests/overlays/metal3/generic-autobumper-config.yaml
         - --signoff=true
         volumeMounts:
         - name: github-token


### PR DESCRIPTION
Fix for:
time="2024-02-11T00:00:41Z" level=fatal msg="Failed to run the bumper tool" error="read \"\\\"prow/manifests/overlays/metal3/generic-autobumper-config.yaml\\\"\": open \"prow/manifests/overlays/metal3/generic-autobumper-config.yaml\": no such file or directory"

Deleted quotation marks. Trying to see if quotation marks are causing a problem in finding the file. 