### PR TITLE
Prow: Restore patches that were mistakenly removed

### DIFF
--- a/prow/manifests/overlays/metal3/kustomization.yaml
+++ b/prow/manifests/overlays/metal3/kustomization.yaml
@@ -74,3 +74,18 @@ secretGenerator:
   name: jenkins-token
   namespace: prow
   type: Opaque
+
+patches:
+- path: patches/crier.yaml
+- path: patches/deck.yaml
+- path: patches/ghproxy.yaml
+- path: patches/hook.yaml
+- path: patches/horologium.yaml
+- path: patches/prow-controller-manager.yaml
+- path: patches/sinker.yaml
+- path: patches/statusreconciler.yaml
+- path: patches/tide.yaml
+# External plugins
+- path: patches/cherrypicker.yaml
+- path: patches/needs-rebase.yaml
+- path: patches/jenkins-operator.yaml


### PR DESCRIPTION
The patches used to add resource requests for all prow containers were mistakenly removed when adding the autobumper. This commits restores them.

(The files that they refer to are still there.)