### PR TITLE
:sparkles:  Switch integration tests from static workers to dynamic workers

### DIFF
--- a/jenkins/jobs/dev_env_integration_tests.pipeline
+++ b/jenkins/jobs/dev_env_integration_tests.pipeline
@@ -1,0 +1,109 @@
+import java.text.SimpleDateFormat
+
+ci_git_credential_id = "metal3-jenkins-github-token"
+
+// 10 minutes
+def CLEAN_TIMEOUT = 600
+// 2 hours
+def TIMEOUT = 7200
+
+script {
+  if ("${PROJECT_REPO_ORG}" == "metal3-io" && "${PROJECT_REPO_NAME}" == "project-infra") {
+    echo "Checkout ${ghprbAuthorRepoGitUrl} branch ${ghprbActualCommit}"
+    ci_git_branch="${ghprbActualCommit}"
+    ci_git_url = "${ghprbAuthorRepoGitUrl}"
+  } else {
+    echo "Checkout ${ghprbAuthorRepoGitUrl} main"
+    ci_git_branch = "main"
+    ci_git_url = "https://github.com/metal3-io/project-infra.git"
+  }
+  agent_label="metal3ci-medium-${IMAGE_OS}"
+}
+
+pipeline {
+  agent { label agent_label }
+  environment {
+    METAL3_CI_USER="metal3ci"
+    REPO_ORG = "${PROJECT_REPO_ORG}"
+    REPO_NAME = "${PROJECT_REPO_NAME}"
+    UPDATED_REPO = "${ghprbAuthorRepoGitUrl}"
+    REPO_BRANCH = "${ghprbTargetBranch}"
+    UPDATED_BRANCH = "${ghprbActualCommit}"
+    BUILD_TAG = "${env.BUILD_TAG}"
+    PR_ID = "${ghprbPullId}"
+    IMAGE_OS = "${IMAGE_OS}"
+    CAPI_VERSION = "${CAPI_VERSION}"
+    CAPM3_VERSION = "${CAPM3_VERSION}"
+    CAPM3RELEASEBRANCH = "${capm3_release_branch}"
+    BMORELEASEBRANCH = "${bmo_release_branch}"
+    TARGET_NODE_MEMORY = "${TARGET_NODE_MEMORY}"
+    NUM_NODES=2
+    IRONIC_INSTALL_TYPE="${params.IRONIC_INSTALL_TYPE}"
+    IRONIC_USE_MARIADB="${params.IRONIC_USE_MARIADB}"
+    BUILD_MARIADB_IMAGE_LOCALLY="${params.BUILD_MARIADB_IMAGE_LOCALLY}"
+  }
+
+  stages {
+    stage('Run integration test') {
+      options {
+        timeout(time: TIMEOUT, unit: 'SECONDS')
+      }
+      environment {
+        BUILD_TAG = "${env.BUILD_TAG}-integration"
+      }
+      steps {
+        script {
+            CURRENT_START_TIME = System.currentTimeMillis()
+        }
+        /* Checkout CI Repo */
+        checkout([$class: 'GitSCM',
+        branches: [
+            [name: ci_git_branch]
+        ],
+        doGenerateSubmoduleConfigurations: false,
+        extensions: [
+            [$class: 'WipeWorkspace'],
+            [$class: 'CleanCheckout'],
+            [$class: 'CleanBeforeCheckout']
+        ],
+        submoduleCfg: [],
+        userRemoteConfigs: [
+            [credentialsId: ci_git_credential_id,
+            url: ci_git_url
+            ]
+        ]
+        ])
+
+       withCredentials([string(credentialsId: 'metal3-clusterctl-github-token', variable: 'GITHUB_TOKEN')]) {
+          ansiColor('xterm') {
+            timestamps {
+              sh "./jenkins/scripts/dynamic_worker_workflow/dev_env_integration_tests.sh"
+            }
+          }
+        }
+      }
+      post {
+        always {
+          script {
+            CURRENT_END_TIME = System.currentTimeMillis()
+            if ((((CURRENT_END_TIME - CURRENT_START_TIME)/1000) - TIMEOUT) > 0) {
+              echo "Failed due to timeout"
+              currentBuild.result = 'FAILURE'
+            }
+            timestamps {
+              sh "./jenkins/scripts/dynamic_worker_workflow/fetch_logs.sh"
+              archiveArtifacts "logs-${env.BUILD_TAG}.tgz"
+            }
+          }
+        }
+        cleanup {
+          script {
+            timestamps {
+              sh "./jenkins/scripts/dynamic_worker_workflow/run_clean.sh"
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/jenkins/scripts/dynamic_worker_workflow/dev_env_integration_tests.sh
+++ b/jenkins/scripts/dynamic_worker_workflow/dev_env_integration_tests.sh
@@ -1,0 +1,67 @@
+#!/usr/bin/env bash
+
+set -eu
+
+# Description:
+#   Runs the feature tests in dynamic jenkins worker
+# Usage:
+#  ./dev_env_integration_tests.sh
+
+CI_DIR="$(dirname "$(readlink -f "${0}")")"
+
+export IMAGE_OS="${IMAGE_OS:-ubuntu}"
+export REPO_ORG="${REPO_ORG:-metal3-io}"
+export REPO_NAME="${REPO_NAME:-metal3-dev-env}"
+export METAL3REPO="${METAL3REPO:-https://github.com/metal3-io/metal3-dev-env.git}"
+export METAL3BRANCH="${METAL3BRANCH:-main}"
+export CAPM3RELEASEBRANCH="${CAPM3RELEASEBRANCH:-main}"
+export BMORELEASEBRANCH="${BMORELEASEBRANCH:-main}"
+export NUM_NODES="${NUM_NODES:-1}"
+export TARGET_NODE_MEMORY="${TARGET_NODE_MEMORY:-4096}"
+export IRONIC_INSTALL_TYPE="${IRONIC_INSTALL_TYPE:-rpm}"
+export IRONIC_FROM_SOURCE="${IRONIC_FROM_SOURCE:-false}"
+export BUILD_IRONIC_IMAGE_LOCALLY=""
+
+if [[ "${IRONIC_INSTALL_TYPE}" == "source" ]]; then
+    IRONIC_FROM_SOURCE="true"
+    if [[ "${REPO_NAME}" == "ironic-image" ]]; then
+        export IRONIC_LOCAL_IMAGE="/home/${USER}/tested_repo"
+    else
+        BUILD_IRONIC_IMAGE_LOCALLY="true"
+    fi
+fi
+
+# shellcheck disable=SC1091
+. "${CI_DIR}/integration_test_env.sh"
+
+# Run:
+#   - ansible, basic integration
+export FORCE_REPO_UPDATE=false
+
+if [[ "${IMAGE_OS}" == "ubuntu" ]]; then
+    #Must match with run_fetch_logs.sh
+    export CONTAINER_RUNTIME="docker"
+    export EPHEMERAL_CLUSTER="kind"
+else
+    export EPHEMERAL_CLUSTER="minikube"
+fi
+
+git clone "https://github.com/${REPO_ORG}/${REPO_NAME}.git" tested_repo
+cd tested_repo
+git checkout "${REPO_BRANCH}"
+cd ../
+
+if [[ "${REPO_NAME}" == "metal3-dev-env" ]]; then
+    # it will already be cloned to tested_repo
+    pushd tested_repo
+else
+    # clone metal3-dev-env and run the test from there
+    git clone "${METAL3REPO}" metal3
+    pushd metal3
+    git checkout "${METAL3BRANCH}"
+fi
+
+echo "Running the tests"
+
+make
+make test


### PR DESCRIPTION
Switching static workers to dynamic workers for integration tests. Also separating metal3 dev env and upgrade integration tests to keep code more maintainable. 