### PR TITLE
Check CI VM cloud-init exit code instead of output

### DIFF
--- a/jenkins/scripts/integration_test.sh
+++ b/jenkins/scripts/integration_test.sh
@@ -127,11 +127,10 @@ fi
 echo "Waiting for the host ${TEST_EXECUTER_VM_NAME} to come up"
 # Wait for the host to come up
 wait_for_ssh "${METAL3_CI_USER}" "${METAL3_CI_USER_KEY}" "${TEST_EXECUTER_IP}"
-# FIXME (lentzi90): Temporarily disabled to get past warnings in cloud-init
-# if ! vm_healthy "${METAL3_CI_USER}" "${METAL3_CI_USER_KEY}" "${TEST_EXECUTER_IP}"; then
-#   echo "Server is unhealthy. Giving up."
-#   exit 1
-# fi
+if ! vm_healthy "${METAL3_CI_USER}" "${METAL3_CI_USER_KEY}" "${TEST_EXECUTER_IP}"; then
+  echo "Server is unhealthy. Giving up."
+  exit 1
+fi
 
 TEMP_FILE_NAME=$(mktemp vars-XXXXXX.sh)
 cat <<-EOF >>"${CI_DIR}/files/${TEMP_FILE_NAME}"

--- a/jenkins/scripts/utils.sh
+++ b/jenkins/scripts/utils.sh
@@ -60,15 +60,11 @@ vm_healthy()
     KEY="${2:?}"
     SERVER="${3:?}"
 
-    cloud_init_status=$(ssh -o ConnectTimeout=2 -o StrictHostKeyChecking=no \
+    if ssh -o ConnectTimeout=2 -o StrictHostKeyChecking=no \
         -o UserKnownHostsFile=/dev/null -i "${KEY}" \
-        "${USER}"@"${SERVER}" cloud-init status --long --wait)
-    if echo "${cloud_init_status}" | grep "error"; then
-        echo "There was a cloud-init error:"
-        echo "${cloud_init_status}"
-        return 1
-    else
-        echo "Cloud-init completed successfully!"
+        "${USER}"@"${SERVER}" cloud-init status --long --wait; then
         return 0
+    else
+        return 1
     fi
 }


### PR DESCRIPTION
The output can contain text that matches even though no fatal error occurred. Since we no longer have the issue where centos is always failing cloud-init, we can now actually check the exit code.