### PR TITLE
Run dev-env's 01 scripts in all integration tests

### DIFF
--- a/jenkins/scripts/files/run_integration_tests.sh
+++ b/jenkins/scripts/files/run_integration_tests.sh
@@ -148,10 +148,7 @@ fi
 
 if [[ "${TESTS_FOR}" == "e2e_tests" ]]; then
     make test-e2e
-elif [[ "${TESTS_FOR}" != "e2e_tests" && "${REPO_NAME}" == "metal3-dev-env" ]]; then
-    make
-    make test
 else
-    make ci_run
+    make
     make test
 fi


### PR DESCRIPTION
Skipping 01 scripts has caused quite a few issues lately. Lets run it in all ansible integration tests to avoid confusion. 