### PR TITLE
Fix UPDATED_REPO in the pipeline for e2e test trigger from prow

### DIFF
--- a/jenkins/jobs/prow_integration_tests.pipeline
+++ b/jenkins/jobs/prow_integration_tests.pipeline
@@ -31,13 +31,16 @@ pipeline {
   agent { label 'metal3-static-workers' }
   environment {
     METAL3_CI_USER="metal3ci"
-    // these defined in the job project 
+    // Defined in the job project 
     REPO_ORG = "${PROJECT_REPO_ORG}"
     REPO_NAME = "${PROJECT_REPO_NAME}"
-    // these coming from the prow env vars
-    UPDATED_REPO = "${env.REPO_NAME}"
+    // Defined in prow env vars 
+    // https://docs.prow.k8s.io/docs/jobs/#job-environment-variables
     REPO_BRANCH = "${env.PULL_BASE_REF}"
     UPDATED_BRANCH = "${env.PULL_PULL_SHA}"
+    BUILD_TAG = "${env.BUILD_TAG}"
+    PR_ID = "${env.PULL_NUMBER}"
+    UPDATED_REPO = "${UPDATED_REPO}"
     OS_USERNAME="metal3ci"
     OS_AUTH_URL="https://kna1.citycloud.com:5000"
     OS_USER_DOMAIN_NAME="CCP_Domain_37137"
@@ -48,8 +51,6 @@ pipeline {
     OS_AUTH_VERSION=3
     OS_IDENTITY_API_VERSION=3
     TEST_EXECUTER_VM_NAME = "${VM_NAME}"
-    BUILD_TAG = "${env.BUILD_TAG}"
-    PR_ID = "${env.PULL_NUMBER}"
     IMAGE_OS = "${IMAGE_OS}"
     CAPI_VERSION = "${CAPI_VERSION}"
     CAPIRELEASE = "${CAPIRELEASE}"


### PR DESCRIPTION
This supposed to be the full link but in the environment vlock it was initiated to only repo name this PR fix that and reorder the vars 