### PR TITLE
BMO e2e: Set user name and email for git

### DIFF
--- a/jenkins/jobs/bmo_e2e_tests.pipeline
+++ b/jenkins/jobs/bmo_e2e_tests.pipeline
@@ -38,6 +38,7 @@ pipeline {
                   [$class: "CleanCheckout"],
                   [$class: "CleanBeforeCheckout"],
                   [$class: "PreBuildMerge", options: [mergeTarget: pullBase, mergeRemote: "origin"]],
+                  [$class: "UserIdentity", name: "Test", email: "test@test.test"]
                   cloneOption(honorRefspec: true)],
                   submoduleCfg: [],)
               script {


### PR DESCRIPTION
Git won't merge without the user details.

```
ERROR: Branch not suitable for integration as it does not merge cleanly: Command "git merge --ff 1c35b0222619831faee2d624f9c60685479a561c" returned status code 128:
stdout: 
stderr: Committer identity unknown

*** Please tell me who you are.

Run

  git config --global user.email "you@example.com"
  git config --global user.name "Your Name"

to set your account's default identity.
Omit --global to set the identity only in this repository.

fatal: unable to auto-detect email address (got 'metal3ci@metal3-worker-591.(none)')
```

Relevant docs for scmGit: https://www.jenkins.io/doc/pipeline/steps/params/scmgit/