### PR TITLE
Make basic e2e test triggerable from different repos and os

### DIFF
--- a/prow/manifests/overlays/metal3/config.yaml
+++ b/prow/manifests/overlays/metal3/config.yaml
@@ -720,6 +720,23 @@ presubmits:
       # Don't run unless triggered to avoid wasting resources
       always_run: false
       optional: true
+    # name: {job_prefix}-{image_os}-e2e-basic-test-{capm3_target_branch}
+    - name: metal3-centos-e2e-basic-test-main
+      agent: jenkins
+      always_run: false
+      optional: true
+    - name: metal3-centos-e2e-basic-test-release-1.6
+      agent: jenkins
+      always_run: false
+      optional: true
+    - name: metal3-ubuntu-e2e-basic-test-main
+      agent: jenkins
+      always_run: false
+      optional: true
+    - name: metal3-ubuntu-e2e-basic-test-release-1.6
+      agent: jenkins
+      always_run: false
+      optional: true
 
   metal3-io/cluster-api-provider-metal3:
     - name: gomod
@@ -1139,27 +1156,31 @@ presubmits:
                 value: "TRUE"
             image: docker.io/golang:1.19
             imagePullPolicy: Always
-    # name: {job_prefix}-{proj}-{capm3_target_branch}-e2e-basic-test-{image_os}
-    - name: metal3-capm3-main-e2e-basic-test-centos
+    # name: {job_prefix}-{image_os}-e2e-basic-test-{capm3_target_branch}
+    - name: metal3-centos-e2e-basic-test-main
       branches:
         - main
+      agent: jenkins
+      always_run: false
+      optional: true
+    - name: metal3-centos-e2e-basic-test-release-1.6
+      branches:
         - release-1.6
       agent: jenkins
-      # Don't run unless triggered to avoid wasting resources
       always_run: false
-      # Until we have checked that it works, keep it optional
       optional: true
-    # name: {job_prefix}-{proj}-{capm3_target_branch}-e2e-basic-test-{image_os}
-    - name: metal3-project_infra-main-e2e-basic-test-centos
+    - name: metal3-ubuntu-e2e-basic-test-main
       branches:
         - main
+      agent: jenkins
+      always_run: false
+      optional: true
+    - name: metal3-ubuntu-e2e-basic-test-release-1.6
+      branches:
         - release-1.6
       agent: jenkins
-      # Don't run unless triggered to avoid wasting resources
       always_run: false
-      # Until we have checked that it works, keep it optional
       optional: true
-
   metal3-io/community:
     - name: markdownlint
       run_if_changed: '(\.md|markdownlint\.sh)$'
@@ -1219,6 +1240,23 @@ presubmits:
                 value: "TRUE"
             image: docker.io/pipelinecomponents/markdownlint-cli2:0.9.0@sha256:71370df6c967bae548b0bfd0ae313ddf44bfad87da76f88180eff55c6264098c
             imagePullPolicy: Always
+    # name: {job_prefix}-{image_os}-e2e-basic-test-{capm3_target_branch}
+    - name: metal3-centos-e2e-basic-test-main
+      agent: jenkins
+      always_run: false
+      optional: true
+    - name: metal3-centos-e2e-basic-test-release-1.6
+      agent: jenkins
+      always_run: false
+      optional: true
+    - name: metal3-ubuntu-e2e-basic-test-main
+      agent: jenkins
+      always_run: false
+      optional: true
+    - name: metal3-ubuntu-e2e-basic-test-release-1.6
+      agent: jenkins
+      always_run: false
+      optional: true
 
   metal3-io/project-infra:
     - name: check-prow-config
@@ -1266,7 +1304,23 @@ presubmits:
                 value: "TRUE"
             image: docker.io/koalaman/shellcheck-alpine:v0.9.0@sha256:e19ed93c22423970d56568e171b4512c9244fc75dd9114045016b4a0073ac4b7
             imagePullPolicy: Always
-
+    # name: {job_prefix}-{image_os}-e2e-basic-test-{capm3_target_branch}
+    - name: metal3-centos-e2e-basic-test-main
+      agent: jenkins
+      always_run: false
+      optional: true
+    - name: metal3-centos-e2e-basic-test-release-1.6
+      agent: jenkins
+      always_run: false
+      optional: true
+    - name: metal3-ubuntu-e2e-basic-test-main
+      agent: jenkins
+      always_run: false
+      optional: true
+    - name: metal3-ubuntu-e2e-basic-test-release-1.6
+      agent: jenkins
+      always_run: false
+      optional: true
   metal3-io/metal3-docs:
     - name: markdownlint
       run_if_changed: '(\.md|markdownlint\.sh)$'
@@ -1677,6 +1731,23 @@ presubmits:
                 value: "/"
             image: ghcr.io/yannh/kubeconform:v0.6.2-alpine@sha256:49b5f6b320d30c1b8b72a7abdf02740ac9dc36a3ba23b934d1c02f7b37e6e740
             imagePullPolicy: Always
+    # name: {job_prefix}-{image_os}-e2e-basic-test-{capm3_target_branch}
+    - name: metal3-centos-e2e-basic-test-main
+      agent: jenkins
+      always_run: false
+      optional: true
+    - name: metal3-centos-e2e-basic-test-release-1.6
+      agent: jenkins
+      always_run: false
+      optional: true
+    - name: metal3-ubuntu-e2e-basic-test-main
+      agent: jenkins
+      always_run: false
+      optional: true
+    - name: metal3-ubuntu-e2e-basic-test-release-1.6
+      agent: jenkins
+      always_run: false
+      optional: true
 
   metal3-io/ironic-ipa-downloader:
     - name: shellcheck


### PR DESCRIPTION
Add prow trigger for basic e2e test from project-infra, dev-env, bmo and ipam for ubuntu and centos following the jjb name format here https://gerrit.nordix.org/c/infra/cicd/+/20718