### PR TITLE
Set jenkins worker for BML job

### DIFF
--- a/jenkins/jobs/bml_integration_tests.pipeline
+++ b/jenkins/jobs/bml_integration_tests.pipeline
@@ -29,7 +29,7 @@ pipeline {
   options {
     disableConcurrentBuilds()
   }
-  agent { label 'metal3-static-workers' }
+  agent { label 'metal3ci-bml-jenkins-worker' }
   environment {
     METAL3_CI_USER="metal3ci"
     REPO_ORG = "${PROJECT_REPO_ORG}"

--- a/jenkins/scripts/bml_cleanup.sh
+++ b/jenkins/scripts/bml_cleanup.sh
@@ -12,7 +12,6 @@ echo "Cleaning up the lab"
 # Execute remote script
 # shellcheck disable=SC2029
 
-JUMPHOST_IP="129.192.80.20"
 TEST_EXECUTER_IP="192.168.1.3"
 
 ssh \
@@ -27,6 +26,5 @@ ssh \
     -o SendEnv="BML_METAL3_DEV_ENV_REPO" \
     -o SendEnv="BML_METAL3_DEV_ENV_BRANCH" \
     -i "${METAL3_CI_USER_KEY}" \
-    -o ProxyCommand="ssh -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -i ${METAL3_CI_USER_KEY} -W %h:%p ${METAL3_CI_USER}@${JUMPHOST_IP}" \
     "${METAL3_CI_USER}"@"${TEST_EXECUTER_IP}" \
     ANSIBLE_FORCE_COLOR=true ansible-playbook -v /tmp/bare_metal_lab/cleanup-lab.yaml --skip-tags "clone"

--- a/jenkins/scripts/bml_integration_test.sh
+++ b/jenkins/scripts/bml_integration_test.sh
@@ -47,7 +47,6 @@ UPGRADE_FROM_RELEASE="${UPGRADE_FROM_RELEASE:-}"
 KUBERNETES_VERSION_UPGRADE_FROM="${KUBERNETES_VERSION_UPGRADE_FROM:-}"
 KUBERNETES_VERSION_UPGRADE_TO="${KUBERNETES_VERSION_UPGRADE_TO:-}"
 
-JUMPHOST_IP="129.192.80.20"
 TEST_EXECUTER_IP="192.168.1.3"
 
 cat <<-EOF >"${CI_DIR}/files/vars.sh"
@@ -81,13 +80,10 @@ declare -a SSH_OPTIONS=(
     -o ServerAliveInterval=15
     -o ServerAliveCountMax=10
     -i "${METAL3_CI_USER_KEY}"
-    -o ProxyCommand="ssh -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -i ${METAL3_CI_USER_KEY} -W %h:%p ${METAL3_CI_USER}@${JUMPHOST_IP}"
 )
 
 # Send Remote script to Executer
-scp \
-    "${SSH_OPTIONS[@]}" \
-    -r \
+scp -r \
     "${CI_DIR}/files/run_integration_tests.sh" \
     "${CI_DIR}/files/vars.sh" \
     "${CI_DIR}/bare_metal_lab/" \

--- a/jenkins/scripts/fetch_logs.sh
+++ b/jenkins/scripts/fetch_logs.sh
@@ -42,7 +42,6 @@ fi
 
 # Get the IP
 if [[ "${BARE_METAL_LAB}" == true ]]; then
-    JUMPHOST_IP="129.192.80.20"
     TEST_EXECUTER_IP="192.168.1.3"
 else
     TEST_EXECUTER_IP="$(openstack port show -f json "${TEST_EXECUTER_PORT_NAME}" |
@@ -54,24 +53,13 @@ else
     fi
 fi
 
-if [[ "${BARE_METAL_LAB}" == true ]]; then
-    declare -a SSH_OPTIONS=(
-        -o StrictHostKeyChecking=no
-        -o UserKnownHostsFile=/dev/null
-        -o ServerAliveInterval=15
-        -o ServerAliveCountMax=10
-        -i "${METAL3_CI_USER_KEY}"
-        -o ProxyCommand="ssh -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -i ${METAL3_CI_USER_KEY} -W %h:%p ${METAL3_CI_USER}@${JUMPHOST_IP}"
+declare -a SSH_OPTIONS=(
+    -o StrictHostKeyChecking=no
+    -o UserKnownHostsFile=/dev/null
+    -o ServerAliveInterval=15
+    -o ServerAliveCountMax=10
+    -i "${METAL3_CI_USER_KEY}"
     )
-else
-    declare -a SSH_OPTIONS=(
-        -o StrictHostKeyChecking=no
-        -o UserKnownHostsFile=/dev/null
-        -o ServerAliveInterval=15
-        -o ServerAliveCountMax=10
-        -i "${METAL3_CI_USER_KEY}"
-    )
-fi
 
 # Send Remote script to Executer
 scp \


### PR DESCRIPTION
This PR:
- sets new jenkins worker (vm inside a Jumphost) to be used for bml jobs 
- removes Jumphost related logic from bml scripts
- changes jenkins agent label for bml jobs