### PR TITLE
Use dhcp provided dns address for metal3ci ubuntu images

### DIFF
--- a/jenkins/image_building/dib_elements/ubuntu-ci/post-install.d/configure
+++ b/jenkins/image_building/dib_elements/ubuntu-ci/post-install.d/configure
@@ -6,12 +6,13 @@ set -eux
 cat <<EOF | sudo tee /etc/netplan/90-nameservers.yaml
 network:
   version: 2
+  renderer: networkd
   ethernets:
     ens3:
       dhcp4-overrides:
-        use-dns: no
+        use-dns: yes
       nameservers:
-        addresses: [1.1.1.1, 1.0.0.1]
+        addresses: [1.1.1.1, 8.8.8.8]
 
 EOF
 # Apply the changes


### PR DESCRIPTION
in centos images we use dns servers that are provided by openstack network, This PR makes ubuntu ci images to use dns provided dns names