### PR TITLE
Fetch changes from PR id with prow feature tests triggers

### DIFF
--- a/jenkins/scripts/dynamic_worker_workflow/feature_tests.sh
+++ b/jenkins/scripts/dynamic_worker_workflow/feature_tests.sh
@@ -68,6 +68,10 @@ if [[ "${UPDATED_REPO}" != *"${REPO_ORG}/${REPO_NAME}"* ]] ||
     git config user.name "Test"
     git remote add test "${UPDATED_REPO}"
     git fetch test
+    # if triggered from prow we cannot get the ghprbAuthorRepoGitUrl then we pull the PR
+    if [[ -n "${PR_ID:-}" ]]; then
+        git fetch origin "pull/${PR_ID}/head:${UPDATED_BRANCH}-branch" || true
+    fi
     # Merging the PR with the target branch
     git merge "${UPDATED_BRANCH}" || exit
 fi

--- a/jenkins/scripts/files/run_integration_tests.sh
+++ b/jenkins/scripts/files/run_integration_tests.sh
@@ -123,7 +123,9 @@ if [[ "${UPDATED_REPO}" != *"${REPO_ORG}/${REPO_NAME}"* ]] ||
     git remote add test "${UPDATED_REPO}"
     git fetch test
     # if triggered from prow we cannot get the ghprbAuthorRepoGitUrl then we pull the PR
-    git fetch origin "pull/${PR_ID:-0}/head:${UPDATED_BRANCH}-branch" || true
+    if [[ -n "${PR_ID:-}" ]]; then
+        git fetch origin "pull/${PR_ID}/head:${UPDATED_BRANCH}-branch" || true
+    fi
     # Merging the PR with the target branch
     git merge "${UPDATED_BRANCH}" || exit
 fi


### PR DESCRIPTION
Prow jenkins operator does not propagate vars to the sources branch of the PR so we have to pull changes form the PR id 