### PR TITLE
Add cluster-autoscaler for prow cluster

### DIFF
--- a/prow/capo-cluster/machinedeployment.yaml
+++ b/prow/capo-cluster/machinedeployment.yaml
@@ -2,9 +2,13 @@ apiVersion: cluster.x-k8s.io/v1beta1
 kind: MachineDeployment
 metadata:
   name: prow-md-0
+  annotations:
+    cluster.x-k8s.io/cluster-api-autoscaler-node-group-min-size: "1"
+    cluster.x-k8s.io/cluster-api-autoscaler-node-group-max-size: "5"
 spec:
   clusterName: prow
-  replicas: 3
+  # Replicas are handled by the autoscaler, don't touch this!
+  # replicas: 3
   selector:
     matchLabels: null
   template:

--- a/prow/cluster-resources/autoscaler.yaml
+++ b/prow/cluster-resources/autoscaler.yaml
@@ -1,0 +1,177 @@
+# This manifest is based on the example here:
+# https://github.com/kubernetes/autoscaler/blob/74446d4164a42fc4c15c919bc0b6cb97ea116018/cluster-autoscaler/cloudprovider/clusterapi/examples/deployment.yaml
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: cluster-autoscaler
+  namespace: kube-system
+  labels:
+    app: cluster-autoscaler
+spec:
+  selector:
+    matchLabels:
+      app: cluster-autoscaler
+  replicas: 1
+  template:
+    metadata:
+      labels:
+        app: cluster-autoscaler
+    spec:
+      containers:
+      - image: registry.k8s.io/autoscaling/cluster-autoscaler:v1.29.0
+        name: cluster-autoscaler
+        command:
+        - /cluster-autoscaler
+        args:
+        - --cloud-provider=clusterapi
+        - --skip-nodes-with-local-storage=false
+      serviceAccountName: cluster-autoscaler
+      terminationGracePeriodSeconds: 10
+      tolerations:
+      - effect: NoSchedule
+        key: node-role.kubernetes.io/control-plane
+      nodeSelector:
+        node-role.kubernetes.io/control-plane: ""
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: cluster-autoscaler-workload
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: cluster-autoscaler-workload
+subjects:
+- kind: ServiceAccount
+  name: cluster-autoscaler
+  namespace: kube-system
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: cluster-autoscaler-management
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: cluster-autoscaler-management
+subjects:
+- kind: ServiceAccount
+  name: cluster-autoscaler
+  namespace: kube-system
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: cluster-autoscaler
+  namespace: kube-system
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: cluster-autoscaler-workload
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - namespaces
+  - persistentvolumeclaims
+  - persistentvolumes
+  - pods
+  - replicationcontrollers
+  - services
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - nodes
+  verbs:
+  - get
+  - list
+  - update
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - pods/eviction
+  verbs:
+  - create
+- apiGroups:
+  - policy
+  resources:
+  - poddisruptionbudgets
+  verbs:
+  - list
+  - watch
+- apiGroups:
+  - storage.k8s.io
+  resources:
+  - csinodes
+  - storageclasses
+  - csidrivers
+  - csistoragecapacities
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - batch
+  resources:
+  - jobs
+  verbs:
+  - list
+  - watch
+- apiGroups:
+  - apps
+  resources:
+  - daemonsets
+  - replicasets
+  - statefulsets
+  verbs:
+  - list
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - events
+  verbs:
+  - create
+  - patch
+- apiGroups:
+  - ""
+  resources:
+  - configmaps
+  verbs:
+  - create
+  - delete
+  - get
+  - update
+- apiGroups:
+  - coordination.k8s.io
+  resources:
+  - leases
+  verbs:
+  - create
+  - get
+  - update
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: cluster-autoscaler-management
+rules:
+- apiGroups:
+  - cluster.x-k8s.io
+  resources:
+  - machinedeployments
+  - machinedeployments/scale
+  - machines
+  - machinesets
+  - machinepools
+  verbs:
+  - get
+  - list
+  - update
+  - watch

--- a/prow/cluster-resources/coredns-pdb.yaml
+++ b/prow/cluster-resources/coredns-pdb.yaml
@@ -1,0 +1,13 @@
+# The cluster autoscaler will not remove nodes with pods
+# in the kube-system namespace, unless they have a PDB that
+# allows it.
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  name: coredns
+  namespace: kube-system
+spec:
+  minAvailable: 1
+  selector:
+    matchLabels:
+      k8s-app: kube-dns

--- a/prow/cluster-resources/kustomization.yaml
+++ b/prow/cluster-resources/kustomization.yaml
@@ -10,6 +10,8 @@ resources:
 - https://raw.githubusercontent.com/kubernetes/cloud-provider-openstack/v1.28.0/manifests/cinder-csi-plugin/cinder-csi-nodeplugin-rbac.yaml
 - https://raw.githubusercontent.com/kubernetes/cloud-provider-openstack/v1.28.0/manifests/cinder-csi-plugin/cinder-csi-nodeplugin.yaml
 - https://raw.githubusercontent.com/kubernetes/cloud-provider-openstack/v1.28.0/manifests/cinder-csi-plugin/csi-cinder-driver.yaml
+- autoscaler.yaml
+- coredns-pdb.yaml
 
 generatorOptions:
   disableNameSuffixHash: true


### PR DESCRIPTION
This adds the cluster-autoscaler to the prow cluster and configures the MachineDeployment to be managed by it. It is configured to scale between 1 and 5 replicas.
The deployment manifest is based on the upstream example. The autoscaler is configured to run on control-plane nodes only, as recommended by upstream. It has the necessary RBAC to manage resources in the prow cluster itself but nothing else.