### PR TITLE
Prow: Add infra node pool

### DIFF
--- a/prow/capo-cluster/infra-kct.yaml
+++ b/prow/capo-cluster/infra-kct.yaml
@@ -1,0 +1,18 @@
+apiVersion: bootstrap.cluster.x-k8s.io/v1beta1
+kind: KubeadmConfigTemplate
+metadata:
+  name: infra-0
+spec:
+  template:
+    spec:
+      joinConfiguration:
+        nodeRegistration:
+          kubeletExtraArgs:
+            cloud-provider: external
+            provider-id: "openstack:///'{{ instance_id }}'"
+            kube-reserved: cpu=200m,memory=100Mi
+            system-reserved: cpu=100m,memory=100Mi
+          name: '{{ local_hostname }}'
+          taints:
+          - key: node-role.kubernetes.io/infra
+            effect: NoSchedule

--- a/prow/capo-cluster/infra-md.yaml
+++ b/prow/capo-cluster/infra-md.yaml
@@ -1,0 +1,27 @@
+apiVersion: cluster.x-k8s.io/v1beta1
+kind: MachineDeployment
+metadata:
+  name: infra-0
+spec:
+  clusterName: prow
+  replicas: 1
+  selector:
+    matchLabels: null
+  template:
+    metadata:
+      labels:
+        # This is propagated to the Machine and Node
+        node-role.kubernetes.io/infra: ""
+    spec:
+      bootstrap:
+        configRef:
+          apiVersion: bootstrap.cluster.x-k8s.io/v1beta1
+          kind: KubeadmConfigTemplate
+          name: infra-0
+      clusterName: prow
+      failureDomain: nova
+      infrastructureRef:
+        apiVersion: infrastructure.cluster.x-k8s.io/v1alpha6
+        kind: OpenStackMachineTemplate
+        name: prow-md-0-v1-28-7
+      version: v1.28.7

--- a/prow/capo-cluster/kustomization.yaml
+++ b/prow/capo-cluster/kustomization.yaml
@@ -7,6 +7,8 @@ resources:
 - machinedeployment.yaml
 - openstackcluster.yaml
 - openstackmachinetemplates.yaml
+- infra-kct.yaml
+- infra-md.yaml
 
 generatorOptions:
   disableNameSuffixHash: true

--- a/prow/cluster-resources/kustomization.yaml
+++ b/prow/cluster-resources/kustomization.yaml
@@ -22,3 +22,22 @@ secretGenerator:
   name: cloud-config
   namespace: kube-system
   type: Opaque
+
+patches:
+# CSI Cinder does not set any toleration or nodeSelector so we have to first create
+# the array/map before we can add values to them...
+- patch: |-
+    - op: add
+      path: /spec/template/spec/tolerations
+      value: []
+    - op: add
+      path: /spec/template/spec/nodeSelector
+      value: {}
+  target:
+    kind: Deployment
+    name: csi-cinder-controllerplugin
+# Add toleration and node selector to run on infra nodes
+- path: toleration-node-selector-patch.yaml
+  target:
+    kind: Deployment
+    name: csi-cinder-controllerplugin|calico-kube-controllers

--- a/prow/cluster-resources/toleration-node-selector-patch.yaml
+++ b/prow/cluster-resources/toleration-node-selector-patch.yaml
@@ -1,0 +1,13 @@
+- op: add
+  path: /spec/template/spec/tolerations/-
+  value:
+    key: node-role.kubernetes.io/infra
+    operator: Exists
+    effect: NoSchedule
+# We add the node selector for node-role.kubernetes.io/infra=""
+# The key has to be included in the path or it would overwrite any existing nodeSelectors.
+# We have to write the "/" as "~1" since it is the separator in the path field.
+# See https://datatracker.ietf.org/doc/html/rfc6901#section-3
+- op: add
+  path: /spec/template/spec/nodeSelector/node-role.kubernetes.io~1infra
+  value: ""

--- a/prow/infra/kustomization.yaml
+++ b/prow/infra/kustomization.yaml
@@ -21,3 +21,7 @@ patches:
     kind: Deployment
     namespace: ingress-nginx
     name: ingress-nginx-controller
+# Run on infra nodes
+- path: toleration-node-selector-patch.yaml
+  target:
+    kind: Deployment|Job

--- a/prow/infra/toleration-node-selector-patch.yaml
+++ b/prow/infra/toleration-node-selector-patch.yaml
@@ -1,0 +1,16 @@
+- op: add
+  path: /spec/template/spec/tolerations
+  value: []
+- op: add
+  path: /spec/template/spec/tolerations/-
+  value:
+    key: node-role.kubernetes.io/infra
+    operator: Exists
+    effect: NoSchedule
+# We add the node selector for node-role.kubernetes.io/infra=""
+# The key has to be included in the path or it would overwrite any existing nodeSelectors.
+# We have to write the "/" as "~1" since it is the separator in the path field.
+# See https://datatracker.ietf.org/doc/html/rfc6901#section-3
+- op: add
+  path: /spec/template/spec/nodeSelector/node-role.kubernetes.io~1infra
+  value: ""

--- a/prow/manifests/overlays/metal3/kustomization.yaml
+++ b/prow/manifests/overlays/metal3/kustomization.yaml
@@ -89,3 +89,7 @@ patches:
 - path: patches/cherrypicker.yaml
 - path: patches/needs-rebase.yaml
 - path: patches/jenkins-operator.yaml
+# Run on infra nodes
+- path: toleration-node-selector-patch.yaml
+  target:
+    kind: Deployment

--- a/prow/manifests/overlays/metal3/toleration-node-selector-patch.yaml
+++ b/prow/manifests/overlays/metal3/toleration-node-selector-patch.yaml
@@ -1,0 +1,19 @@
+- op: add
+  path: /spec/template/spec/tolerations
+  value: []
+- op: add
+  path: /spec/template/spec/tolerations/-
+  value:
+    key: node-role.kubernetes.io/infra
+    operator: Exists
+    effect: NoSchedule
+- op: add
+  path: /spec/template/spec/nodeSelector
+  value: {}
+# We add the node selector for node-role.kubernetes.io/infra=""
+# The key has to be included in the path or it would overwrite any existing nodeSelectors.
+# We have to write the "/" as "~1" since it is the separator in the path field.
+# See https://datatracker.ietf.org/doc/html/rfc6901#section-3
+- op: add
+  path: /spec/template/spec/nodeSelector/node-role.kubernetes.io~1infra
+  value: ""


### PR DESCRIPTION
This adds a separate node pool for everything that isn't a prow job or
running on the control-plane. The node pool has a taint to prevent
workload running there by accident. All relevant workload now has
toleration for this taint and a node selector to always run in this node
pool.

