### PR TITLE
Fix refspec with prow pipeline when running on project-infra PRs

### DIFF
--- a/jenkins/jobs/capm3-e2e-tests.pipeline
+++ b/jenkins/jobs/capm3-e2e-tests.pipeline
@@ -12,6 +12,9 @@ script {
 
     if ("${PROJECT_REPO_ORG}" == 'metal3-io' && "${PROJECT_REPO_NAME}" == 'project-infra') {
         ci_git_branch = (env.PULL_PULL_SHA) ?: (env.ghprbActualCommit) ?: "main"
+        ci_git_base = (env.PULL_BASE_REF) ?: "main"
+        // Fetch the base branch and the ci_git_branch when running on project-infra PR
+        refspec = '+refs/heads/' + ci_git_base + ':refs/remotes/origin/' + ci_git_base + ' ' + ci_git_branch
         ci_git_url = (env.ghprbAuthorRepoGitUrl) ?: "https://github.com/metal3-io/project-infra.git"
     } else {
         ci_git_branch = 'main'
@@ -69,7 +72,7 @@ pipeline {
                       ],
                   submoduleCfg: [],
                   userRemoteConfigs: [
-                      [credentialsId: ci_git_credential_id,url: ci_git_url]
+                      [credentialsId: ci_git_credential_id,url: ci_git_url, refspec: refspec]
                       ]
                   ])
                 withCredentials([string(credentialsId: 'metal3-clusterctl-github-token', variable: 'GITHUB_TOKEN')]) {

--- a/jenkins/jobs/parallel_e2e_features_test.pipeline
+++ b/jenkins/jobs/parallel_e2e_features_test.pipeline
@@ -19,6 +19,9 @@ script {
 
   if ("${PROJECT_REPO_ORG}" == "metal3-io" && "${PROJECT_REPO_NAME}" == "project-infra") {
     ci_git_branch = (env.PULL_PULL_SHA) ?: (env.ghprbActualCommit) ?: "main"
+    ci_git_base = (env.PULL_BASE_REF) ?: "main"
+    // Fetch the base branch and the ci_git_branch when running on project-infra PR
+    refspec = '+refs/heads/' + ci_git_base + ':refs/remotes/origin/' + ci_git_base + ' ' + ci_git_branch
     ci_git_url = (env.ghprbAuthorRepoGitUrl) ?: "https://github.com/metal3-io/project-infra.git"
   } else {
     ci_git_branch = "main"
@@ -98,7 +101,8 @@ pipeline {
             submoduleCfg: [],
             userRemoteConfigs: [
                 [credentialsId: ci_git_credential_id,
-                url: ci_git_url
+                url: ci_git_url,
+                refspec: refspec
                 ]
             ]
             ])

--- a/jenkins/jobs/prow_integration_tests.pipeline
+++ b/jenkins/jobs/prow_integration_tests.pipeline
@@ -16,6 +16,9 @@ script {
 
   if ("${env.REPO_OWNER}" == "metal3-io" && "${env.REPO_NAME}" == "project-infra") {
     ci_git_branch = (env.PULL_PULL_SHA) ?: "main"
+    ci_git_base = (env.PULL_BASE_REF) ?: "main"
+    // Fetch the base branch and the ci_git_branch when running on project-infra PR
+    refspec = '+refs/heads/' + ci_git_base + ':refs/remotes/origin/' + ci_git_base + ' ' + ci_git_branch
   } else {
     ci_git_branch = "main"
   }
@@ -94,7 +97,7 @@ pipeline {
                  [$class: 'CleanBeforeCheckout']],
                  submoduleCfg: [],
                  userRemoteConfigs: [[credentialsId: ci_git_credential_id,
-                 url: ci_git_url]]])
+                 url: ci_git_url, refspec: refspec]]])
         script {
           CURRENT_START_TIME = System.currentTimeMillis()
         }


### PR DESCRIPTION
It seems when we trigger a test from prow on project infra branch it fails because it cannot fetch the PR branch ! e.g https://jenkins.nordix.org/view/Metal3/job/metal3-e2e-clusterctl-upgrade-test-main/5/

This PR might help with this issue 