### PR TITLE
Build ironic locally when running tests on ironic-image repo

### DIFF
--- a/jenkins/scripts/integration_test.sh
+++ b/jenkins/scripts/integration_test.sh
@@ -54,13 +54,10 @@ KUBERNETES_VERSION_UPGRADE_FROM="${KUBERNETES_VERSION_UPGRADE_FROM:-}"
 KUBERNETES_VERSION_UPGRADE_TO="${KUBERNETES_VERSION_UPGRADE_TO:-}"
 KUBECTL_SHA256="${KUBECTL_SHA256:-}"
 
-if [[ "${IRONIC_INSTALL_TYPE}" == "source" ]]; then
+# Build ironic locally when running tests on ironic-image repo  
+if [[ "${REPO_NAME}" == "ironic-image" ]]; then
   IRONIC_FROM_SOURCE="true"
-  if [[ "${REPO_NAME}" == "ironic-image" ]]; then
-    IRONIC_LOCAL_IMAGE="/home/${USER}/tested_repo"
-  else
-    BUILD_IRONIC_IMAGE_LOCALLY="true"
-  fi
+  IRONIC_LOCAL_IMAGE="/home/${USER}/tested_repo"
 fi
 
 # Run:


### PR DESCRIPTION
There is a behavior implimented in old ansible tests to use postfix that make the test building ironic locally even when running on a different repo but it does not seem being used