### PR TITLE
🌱 Increasing timout for clusterctl upgrade tests

### DIFF
--- a/jenkins/jobs/capm3-e2e-tests.pipeline
+++ b/jenkins/jobs/capm3-e2e-tests.pipeline
@@ -1,8 +1,8 @@
 
 ci_git_credential_id = 'metal3-jenkins-github-token'
 
-// 3 hours
-int TIMEOUT = 10800
+// 3,5 hours
+int TIMEOUT = 12600
 
 script {
     PROJECT_REPO_ORG = (env.REPO_OWNER) ?: (env.PROJECT_REPO_ORG)


### PR DESCRIPTION
clusterctl upgrade tests are aborting because of timeout:
https://jenkins.nordix.org/view/Metal3%20Periodic/job/metal3-periodic-e2e-clusterctl-upgrade-test-main/5/

This PR is increasing the timeout. 