### PR TITLE
BMO: Make CAPM3 e2e tests optional

### DIFF
--- a/prow/manifests/overlays/metal3/config.yaml
+++ b/prow/manifests/overlays/metal3/config.yaml
@@ -715,7 +715,7 @@ presubmits:
     - main
     agent: jenkins
     always_run: false
-    optional: false
+    optional: true
   - name: metal3-centos-e2e-integration-test-release-1-7
     branches:
     - release-0.6
@@ -727,7 +727,7 @@ presubmits:
     - release-0.5
     agent: jenkins
     always_run: false
-    optional: false
+    optional: true
   - name: metal3-centos-e2e-integration-test-release-1-5
     branches:
     - release-0.4
@@ -739,7 +739,7 @@ presubmits:
     - main
     agent: jenkins
     always_run: false
-    optional: false
+    optional: true
   - name: metal3-ubuntu-e2e-integration-test-release-1-7
     branches:
     - release-0.6


### PR DESCRIPTION
The BMO e2e tests have proven themselves over several months now. They are on par with the CAPM3 tests regarding the BMO features they test and they do it faster and more efficiently. By requiring both CAPM3 and BMO e2e tests to run on all BMO PRs we make the PR process unnessarily heavy, time consuming and resource intense.

This commit is for making the last remaining CAPM3 e2e test optional on BMO PRs. Note that CAPM3 tests can still be triggered if wanted, they will just not be required. They are also still running as daily jobs so we will quickly notice if something breaks.

I think `metal3-ubuntu-e2e-integration-test-main` was mistakenly set to required when switching to prow triggered jobs. This has not been required in BMO before.