### PR TITLE
add prow test config dumper

### DIFF
--- a/hack/prow_test_dumper.py
+++ b/hack/prow_test_dumper.py
@@ -1,0 +1,82 @@
+#!/usr/bin/env python3
+"""
+Dump required tests out of prow config in human (and machine) readable format
+"""
+
+from argparse import Namespace, ArgumentParser
+from collections import defaultdict
+from typing import DefaultDict, List
+
+# pip3 install PyYAML
+import yaml
+
+
+def get_external_branchprotection(data: dict) -> DefaultDict[str, List[str]]:
+    """print external branch protection jobs"""
+    protected_repos: DefaultDict[str, List[str]] = defaultdict(list)
+
+    for org, org_data in data.get("orgs", {}).items():
+        for repo, repo_data in org_data.get("repos", {}).items():
+            for branch, branch_data in repo_data.get("branches", {}).items():
+                required_checks = branch_data.get("required_status_checks", {}).get("contexts", [])
+                key = f"{org}/{repo}/{branch}"
+                protected_repos.setdefault(key, []).extend(required_checks)
+
+    return protected_repos
+
+
+def get_prow_branchprotection(data: dict) -> DefaultDict[str, List[str]]:
+    """get prow required tests"""
+    protected_repos: DefaultDict[str, List[str]] = defaultdict(list)
+
+    for orgrepo, orgrepo_data in data.items():
+        for test_data in orgrepo_data:
+            if test_data.get("optional") is not True:
+                required_check = test_data.get("name")
+                # skip all tests that are always_run
+                if test_data.get("always_run") is not False:
+                    continue
+                for branch in test_data.get("branches", ["ALL BRANCHES"]):
+                    key = f"{orgrepo}/{branch}"
+                    protected_repos.setdefault(key, []).append(required_check)
+
+    return protected_repos
+
+
+def parse_args() -> Namespace:
+    """parse arguments"""
+    parser = ArgumentParser(description="Dump required tests out of Prow config.yaml")
+    parser.add_argument(
+        "file",
+        type=str,
+        help="""
+        Prow's config.yaml (script cannot handle split off config, yet)
+        """,
+    )
+    args = parser.parse_args()
+    return args
+
+
+def main():
+    """print out required jobs"""
+    args = parse_args()
+
+    with open(args.file, "r", encoding="utf-8") as fh:
+        parsed_data = yaml.safe_load(fh)
+
+    # protection can come from two places: branch-protection and presubmits
+    branchprotection = parsed_data.get("branch-protection", {})
+    required = get_external_branchprotection(branchprotection)
+    presubmits = parsed_data.get("presubmits", {})
+    pre_submit = get_prow_branchprotection(presubmits)
+    required.update(pre_submit)
+
+    for repo, checks in required.items():
+        print(f"{repo}:")
+        for check in checks:
+            print(f"- {check}")
+        print()
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
Add prow_test_dumper.py to hack/. It will read the prow config.yaml and spit out branch protection settings it finds. Supports "branch-protection" and "presubmits" sections. Does not support split prow config, so reads only one file at a time.

Requires python3 and pyyaml (`pip3 install pyyaml`). Use virtualenv's responsibly.

Example output: https://github.com/metal3-io/project-infra/pull/714#issuecomment-2078910887 

Script location and naming suggestion welcome.