### PR TITLE
Prow: Upgrade Kubernetes to v1.29.4

### DIFF
--- a/prow/capo-cluster/infra-md.yaml
+++ b/prow/capo-cluster/infra-md.yaml
@@ -23,5 +23,5 @@ spec:
       infrastructureRef:
         apiVersion: infrastructure.cluster.x-k8s.io/v1alpha6
         kind: OpenStackMachineTemplate
-        name: prow-md-0-v1-28-7
-      version: v1.28.7
+        name: prow-worker-v1-29-4
+      version: v1.29.4

--- a/prow/capo-cluster/kubeadmcontrolplane.yaml
+++ b/prow/capo-cluster/kubeadmcontrolplane.yaml
@@ -31,6 +31,6 @@ spec:
     infrastructureRef:
       apiVersion: infrastructure.cluster.x-k8s.io/v1alpha6
       kind: OpenStackMachineTemplate
-      name: prow-control-plane-v1-28-7
+      name: prow-control-plane-v1-29-4
   replicas: 1
-  version: v1.28.7
+  version: v1.29.4

--- a/prow/capo-cluster/machinedeployment.yaml
+++ b/prow/capo-cluster/machinedeployment.yaml
@@ -23,5 +23,5 @@ spec:
       infrastructureRef:
         apiVersion: infrastructure.cluster.x-k8s.io/v1alpha6
         kind: OpenStackMachineTemplate
-        name: prow-md-0-v1-28-7
-      version: v1.28.7
+        name: prow-worker-v1-29-4
+      version: v1.29.4

--- a/prow/capo-cluster/openstackmachinetemplates.yaml
+++ b/prow/capo-cluster/openstackmachinetemplates.yaml
@@ -31,7 +31,7 @@ spec:
 apiVersion: infrastructure.cluster.x-k8s.io/v1alpha6
 kind: OpenStackMachineTemplate
 metadata:
-  name: prow-control-plane-v1-27-7
+  name: prow-control-plane-v1-29-4
 spec:
   template:
     spec:
@@ -40,13 +40,13 @@ spec:
       identityRef:
         kind: Secret
         name: prow-cloud-config
-      image: ubuntu-2204-kube-v1.27.7
+      image: ubuntu-2204-kube-v1.29.4
       sshKeyName: metal3ci-key
 ---
 apiVersion: infrastructure.cluster.x-k8s.io/v1alpha6
 kind: OpenStackMachineTemplate
 metadata:
-  name: prow-md-0-v1-27-7
+  name: prow-worker-v1-29-4
 spec:
   template:
     spec:
@@ -55,5 +55,5 @@ spec:
       identityRef:
         kind: Secret
         name: prow-cloud-config
-      image: ubuntu-2204-kube-v1.27.7
+      image: ubuntu-2204-kube-v1.29.4
       sshKeyName: metal3ci-key


### PR DESCRIPTION
This upgrades the control-plane and all MachineDeployments to Kubernetes v1.29.4.

Changes are already applied.