### PR TITLE
Prow: Bump infra and cluster-resources

### DIFF
--- a/prow/README.md
+++ b/prow/README.md
@@ -341,7 +341,8 @@ images (see sections above).
 
    ```bash
    kind create cluster
-   clusterctl init --infrastructure=openstack:v0.7.1
+   clusterctl init --infrastructure=openstack:v0.10.0 --core=cluster-api:v1.7.1 \
+      --bootstrap=kubeadm:v1.7.1 --control-plane=kubeadm:v1.7.1
    ```
 
 1. Create cluster.
@@ -377,7 +378,8 @@ images (see sections above).
 
    ```bash
    unset KUBECONFIG
-   clusterctl init --kubeconfig=kubeconfig.yaml --infrastructure=openstack:v0.7.1
+   clusterctl init --infrastructure=openstack:v0.10.0 --core=cluster-api:v1.7.1 \
+      --bootstrap=kubeadm:v1.7.1 --control-plane=kubeadm:v1.7.1
    clusterctl move --to-kubeconfig=kubeconfig.yaml
    export KUBECONFIG=kubeconfig.yaml
    ```

--- a/prow/cluster-resources/kustomization.yaml
+++ b/prow/cluster-resources/kustomization.yaml
@@ -1,15 +1,15 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
-- https://raw.githubusercontent.com/projectcalico/calico/v3.26.1/manifests/calico.yaml
-- https://raw.githubusercontent.com/kubernetes/cloud-provider-openstack/v1.28.0/manifests/controller-manager/cloud-controller-manager-roles.yaml
-- https://raw.githubusercontent.com/kubernetes/cloud-provider-openstack/v1.28.0/manifests/controller-manager/cloud-controller-manager-role-bindings.yaml
-- https://raw.githubusercontent.com/kubernetes/cloud-provider-openstack/v1.28.0/manifests/controller-manager/openstack-cloud-controller-manager-ds.yaml
-- https://raw.githubusercontent.com/kubernetes/cloud-provider-openstack/v1.28.0/manifests/cinder-csi-plugin/cinder-csi-controllerplugin-rbac.yaml
-- https://raw.githubusercontent.com/kubernetes/cloud-provider-openstack/v1.28.0/manifests/cinder-csi-plugin/cinder-csi-controllerplugin.yaml
-- https://raw.githubusercontent.com/kubernetes/cloud-provider-openstack/v1.28.0/manifests/cinder-csi-plugin/cinder-csi-nodeplugin-rbac.yaml
-- https://raw.githubusercontent.com/kubernetes/cloud-provider-openstack/v1.28.0/manifests/cinder-csi-plugin/cinder-csi-nodeplugin.yaml
-- https://raw.githubusercontent.com/kubernetes/cloud-provider-openstack/v1.28.0/manifests/cinder-csi-plugin/csi-cinder-driver.yaml
+- https://raw.githubusercontent.com/projectcalico/calico/v3.27.3/manifests/calico.yaml
+- https://raw.githubusercontent.com/kubernetes/cloud-provider-openstack/v1.29.0/manifests/controller-manager/cloud-controller-manager-roles.yaml
+- https://raw.githubusercontent.com/kubernetes/cloud-provider-openstack/v1.29.0/manifests/controller-manager/cloud-controller-manager-role-bindings.yaml
+- https://raw.githubusercontent.com/kubernetes/cloud-provider-openstack/v1.29.0/manifests/controller-manager/openstack-cloud-controller-manager-ds.yaml
+- https://raw.githubusercontent.com/kubernetes/cloud-provider-openstack/v1.29.0/manifests/cinder-csi-plugin/cinder-csi-controllerplugin-rbac.yaml
+- https://raw.githubusercontent.com/kubernetes/cloud-provider-openstack/v1.29.0/manifests/cinder-csi-plugin/cinder-csi-controllerplugin.yaml
+- https://raw.githubusercontent.com/kubernetes/cloud-provider-openstack/v1.29.0/manifests/cinder-csi-plugin/cinder-csi-nodeplugin-rbac.yaml
+- https://raw.githubusercontent.com/kubernetes/cloud-provider-openstack/v1.29.0/manifests/cinder-csi-plugin/cinder-csi-nodeplugin.yaml
+- https://raw.githubusercontent.com/kubernetes/cloud-provider-openstack/v1.29.0/manifests/cinder-csi-plugin/csi-cinder-driver.yaml
 - autoscaler.yaml
 - coredns-pdb.yaml
 

--- a/prow/infra/kustomization.yaml
+++ b/prow/infra/kustomization.yaml
@@ -1,7 +1,7 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
-- https://github.com/kubernetes/ingress-nginx/deploy/static/provider/cloud?ref=controller-v1.9.6
+- https://github.com/kubernetes/ingress-nginx/deploy/static/provider/cloud?ref=controller-v1.10.1
 - cluster-issuer-http.yaml
 - storageclass.yaml
 - ingress-controller-pdb.yaml


### PR DESCRIPTION
This bumps the version of
- calico to v3.27.3
- cloud-provider-openstack and the CSI plugin to v1.29.0
- ingress-nginx to v1.10.1
- CAPI to v1.7.1
- CAPO to v0.10.0

Note that we do not have declarative config for CAPI and CAPO so the changes for them are just for the documentation.

Changes are already applied.