### PR TITLE
Prow: Update CAPO resources to use v1beta1 API

### DIFF
--- a/prow/capo-cluster/cluster.yaml
+++ b/prow/capo-cluster/cluster.yaml
@@ -13,6 +13,6 @@ spec:
     kind: KubeadmControlPlane
     name: prow-control-plane
   infrastructureRef:
-    apiVersion: infrastructure.cluster.x-k8s.io/v1alpha6
+    apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
     kind: OpenStackCluster
     name: prow

--- a/prow/capo-cluster/infra-md.yaml
+++ b/prow/capo-cluster/infra-md.yaml
@@ -21,7 +21,7 @@ spec:
       clusterName: prow
       failureDomain: nova
       infrastructureRef:
-        apiVersion: infrastructure.cluster.x-k8s.io/v1alpha6
+        apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
         kind: OpenStackMachineTemplate
         name: prow-worker-v1-29-4
       version: v1.29.4

--- a/prow/capo-cluster/kubeadmcontrolplane.yaml
+++ b/prow/capo-cluster/kubeadmcontrolplane.yaml
@@ -29,7 +29,7 @@ spec:
         name: '{{ local_hostname }}'
   machineTemplate:
     infrastructureRef:
-      apiVersion: infrastructure.cluster.x-k8s.io/v1alpha6
+      apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
       kind: OpenStackMachineTemplate
       name: prow-control-plane-v1-29-4
   replicas: 1

--- a/prow/capo-cluster/machinedeployment.yaml
+++ b/prow/capo-cluster/machinedeployment.yaml
@@ -21,7 +21,7 @@ spec:
       clusterName: prow
       failureDomain: nova
       infrastructureRef:
-        apiVersion: infrastructure.cluster.x-k8s.io/v1alpha6
+        apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
         kind: OpenStackMachineTemplate
         name: prow-worker-v1-29-4
       version: v1.29.4

--- a/prow/capo-cluster/openstackcluster.yaml
+++ b/prow/capo-cluster/openstackcluster.yaml
@@ -1,24 +1,47 @@
-apiVersion: infrastructure.cluster.x-k8s.io/v1alpha6
+apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
 kind: OpenStackCluster
 metadata:
   name: prow
 spec:
   apiServerLoadBalancer:
     enabled: true
-    allowedCidrs:
+    allowedCIDRs:
     - 10.6.0.0/24
-  cloudName: prow
-  dnsNameservers:
-  - 8.8.8.8
-  externalNetworkId: fba95253-5543-4078-b793-e2de58c31378
+  externalNetwork:
+    id: fba95253-5543-4078-b793-e2de58c31378
   identityRef:
-    kind: Secret
+    cloudName: prow
     name: prow-cloud-config
-  managedSecurityGroups: true
-  nodeCidr: 10.6.0.0/24
+  managedSecurityGroups:
+    allNodesSecurityGroupRules:
+    - description: Calico - BGP
+      direction: ingress
+      etherType: IPv4
+      name: BGP (calico)
+      portRangeMax: 179
+      portRangeMin: 179
+      protocol: tcp
+      remoteManagedGroups:
+      - controlplane
+      - worker
+    - description: Calico IP-in-IP
+      direction: ingress
+      etherType: IPv4
+      name: IP-in-IP (calico)
+      protocol: "4"
+      remoteManagedGroups:
+      - controlplane
+      - worker
+    allowAllInClusterTraffic: false
+  managedSubnets:
+  - cidr: 10.6.0.0/24
+    dnsNameservers:
+    - 8.8.8.8
   bastion:
     enabled: true
-    instance:
+    spec:
       flavor: 1C-2GB-50GB
-      image: "Ubuntu 22.04.1 Jammy Jellyfish 230124"
+      image:
+        filter:
+          name: "Ubuntu 22.04.1 Jammy Jellyfish 230124"
       sshKeyName: metal3ci-key

--- a/prow/capo-cluster/openstackmachinetemplates.yaml
+++ b/prow/capo-cluster/openstackmachinetemplates.yaml
@@ -1,59 +1,63 @@
-apiVersion: infrastructure.cluster.x-k8s.io/v1alpha6
+apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
 kind: OpenStackMachineTemplate
 metadata:
   name: prow-control-plane-v1-28-7
 spec:
   template:
     spec:
-      cloudName: prow
       flavor: 4C-4GB-100GB
       identityRef:
-        kind: Secret
+        cloudName: prow
         name: prow-cloud-config
-      image: ubuntu-2204-kube-v1.28.7
+      image:
+        filter:
+          name: ubuntu-2204-kube-v1.28.7
       sshKeyName: metal3ci-key
 ---
-apiVersion: infrastructure.cluster.x-k8s.io/v1alpha6
+apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
 kind: OpenStackMachineTemplate
 metadata:
   name: prow-md-0-v1-28-7
 spec:
   template:
     spec:
-      cloudName: prow
       flavor: 8C-16GB-100GB
       identityRef:
-        kind: Secret
+        cloudName: prow
         name: prow-cloud-config
-      image: ubuntu-2204-kube-v1.28.7
+      image:
+        filter:
+          name: ubuntu-2204-kube-v1.28.7
       sshKeyName: metal3ci-key
 ---
-apiVersion: infrastructure.cluster.x-k8s.io/v1alpha6
+apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
 kind: OpenStackMachineTemplate
 metadata:
   name: prow-control-plane-v1-29-4
 spec:
   template:
     spec:
-      cloudName: prow
       flavor: 4C-4GB-100GB
       identityRef:
-        kind: Secret
+        cloudName: prow
         name: prow-cloud-config
-      image: ubuntu-2204-kube-v1.29.4
+      image:
+        filter:
+          name: ubuntu-2204-kube-v1.29.4
       sshKeyName: metal3ci-key
 ---
-apiVersion: infrastructure.cluster.x-k8s.io/v1alpha6
+apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
 kind: OpenStackMachineTemplate
 metadata:
   name: prow-worker-v1-29-4
 spec:
   template:
     spec:
-      cloudName: prow
       flavor: 8C-16GB-100GB
       identityRef:
-        kind: Secret
+        cloudName: prow
         name: prow-cloud-config
-      image: ubuntu-2204-kube-v1.29.4
+      image:
+        filter:
+          name: ubuntu-2204-kube-v1.29.4
       sshKeyName: metal3ci-key


### PR DESCRIPTION
The latest release of CAPO came with a new API version. This commit updates all manifests to use that version. This is essentially a no-op in the cluster as all resources are anyway converted back and forth automatically by the webhook as needed.

The biggest change are the managed security groups. They used to be hard-coded in CAPO to match what is needed for Calico. Now they must be specified explicitly.