### PR TITLE
Fix unbound var and specify repo dir in full path

### DIFF
--- a/jenkins/jobs/dev_env_integration_tests.pipeline
+++ b/jenkins/jobs/dev_env_integration_tests.pipeline
@@ -27,10 +27,11 @@ script {
 pipeline {
   agent { label agent_label }
   environment {
-    METAL3_CI_USER="metal3ci"
     REPO_ORG = "${env.REPO_OWNER}"
     REPO_NAME = "${env.REPO_NAME}"
     REPO_BRANCH = "${env.PULL_BASE_REF}"
+    UPDATED_REPO = "${UPDATED_REPO}"
+    UPDATED_BRANCH = "${env.PULL_PULL_SHA}"
     BUILD_TAG = "${env.BUILD_TAG}"
     PR_ID = "${env.PULL_NUMBER}"
     IMAGE_OS = "${IMAGE_OS}"

--- a/jenkins/scripts/dynamic_worker_workflow/dev_env_integration_tests.sh
+++ b/jenkins/scripts/dynamic_worker_workflow/dev_env_integration_tests.sh
@@ -28,7 +28,7 @@ export BUILD_IRONIC_IMAGE_LOCALLY=""
 if [[ "${IRONIC_INSTALL_TYPE}" == "source" ]]; then
     IRONIC_FROM_SOURCE="true"
     if [[ "${REPO_NAME}" == "ironic-image" ]]; then
-        export IRONIC_LOCAL_IMAGE="/home/${USER}/tested_repo"
+        export IRONIC_LOCAL_IMAGE="${HOME}/tested_repo"
     else
         BUILD_IRONIC_IMAGE_LOCALLY="true"
     fi
@@ -50,8 +50,8 @@ else
 fi
 
 # Clone the source repository
-git clone "https://github.com/${REPO_ORG}/${REPO_NAME}.git" tested_repo
-cd tested_repo
+git clone "https://github.com/${REPO_ORG}/${REPO_NAME}.git" "${HOME}/tested_repo"
+cd "${HOME}/tested_repo"
 git checkout "${REPO_BRANCH}"
 # If the target and source repos and branches are identical, don't try to merge
 if [[ "${UPDATED_REPO}" != *"${REPO_ORG}/${REPO_NAME}"* ]] ||
@@ -66,14 +66,15 @@ if [[ "${UPDATED_REPO}" != *"${REPO_ORG}/${REPO_NAME}"* ]] ||
     # Merging the PR with the target branch
     git merge "${UPDATED_BRANCH}" || exit
 fi
+cd "${HOME}"
 
 if [[ "${REPO_NAME}" == "metal3-dev-env" ]]; then
     # it will already be cloned to tested_repo
-    pushd tested_repo
+    pushd "${HOME}/tested_repo"
 else
     # clone metal3-dev-env and run the test from there
-    git clone "${METAL3REPO}" metal3
-    pushd metal3
+    git clone "${METAL3REPO}" "${HOME}/metal3"
+    pushd "${HOME}/metal3"
     git checkout "${METAL3BRANCH}"
 fi
 

--- a/jenkins/scripts/dynamic_worker_workflow/e2e_tests.sh
+++ b/jenkins/scripts/dynamic_worker_workflow/e2e_tests.sh
@@ -73,8 +73,8 @@ else
 fi
 
 # Clone the source repository
-git clone "https://github.com/${REPO_ORG}/${REPO_NAME}.git" tested_repo
-cd tested_repo
+git clone "https://github.com/${REPO_ORG}/${REPO_NAME}.git" "${HOME}/tested_repo"
+cd "${HOME}/tested_repo"
 git checkout "${REPO_BRANCH}"
 # If the target and source repos and branches are identical, don't try to merge
 if [[ "${UPDATED_REPO}" != *"${REPO_ORG}/${REPO_NAME}"* ]] ||
@@ -90,18 +90,18 @@ if [[ "${UPDATED_REPO}" != *"${REPO_ORG}/${REPO_NAME}"* ]] ||
     # Merging the PR with the target branch
     git merge "${UPDATED_BRANCH}" || exit
 fi
-cd ../
+cd "${HOME}/"
 
 if [[ "${REPO_NAME}" == "metal3-dev-env" ]] ||
     [[ "${REPO_NAME}" == "cluster-api-provider-metal3" ]] \
     ; then
     # If we are testing e2e from capm3,
     # it will already be cloned to tested_repo
-    pushd tested_repo
+    pushd /"home/${USER}/tested_repo"
 else
     # if the test is e2e clone capm3 and run the test from there
-    git clone "${CAPM3REPO}" metal3
-    pushd metal3
+    git clone "${CAPM3REPO}" "${HOME}/metal3"
+    pushd "${HOME}/metal3"
     git checkout "${CAPM3BRANCH}"
 fi
 

--- a/jenkins/scripts/dynamic_worker_workflow/fetch_logs.sh
+++ b/jenkins/scripts/dynamic_worker_workflow/fetch_logs.sh
@@ -71,7 +71,7 @@ fetch_k8s_logs()
 }
 
 # Fetch k8s logs
-fetch_k8s_logs "management_cluster" "/home/metal3ci/.kube/config"
+fetch_k8s_logs "management_cluster" "${HOME}/.kube/config"
 
 # Fetch Ironic containers logs before pivoting to the target cluster, if they exist
 if [[ -d /tmp/"${CONTAINER_RUNTIME}" ]] && [[ -n "$(ls /tmp/"${CONTAINER_RUNTIME}"/)" ]]; then
@@ -121,7 +121,7 @@ if [[ -d "${BML_LOG_LOCATION}" ]]; then
 fi
 
 mkdir -p "${LOGS_DIR}/cluster-api-config"
-cp -r "/home/metal3ci/.cluster-api/." "${LOGS_DIR}/cluster-api-config/"
+cp -r "${HOME}/.cluster-api/." "${LOGS_DIR}/cluster-api-config/"
 
 tar -cvzf "${LOGS_TARBALL}" "${LOGS_DIR}"/*
 

--- a/jenkins/scripts/dynamic_worker_workflow/run_clean.sh
+++ b/jenkins/scripts/dynamic_worker_workflow/run_clean.sh
@@ -12,9 +12,9 @@ fi
 if [[ "${REPO_NAME}" == "metal3-dev-env" ]] ||
    [[ "${REPO_NAME}" == "cluster-api-provider-metal3" ]] \
     ; then
-    pushd tested_repo
+    pushd "${HOME}/tested_repo"
 else
-    pushd metal3
+    pushd "${HOME}/metal3"
 fi
 
 make clean

--- a/jenkins/scripts/dynamic_worker_workflow/test_env.sh
+++ b/jenkins/scripts/dynamic_worker_workflow/test_env.sh
@@ -21,32 +21,32 @@ if [[ "${REPO_NAME}" == "metal3-dev-env" ]]; then
 elif [[ "${REPO_NAME}" == "baremetal-operator" ]]; then
     export BMOREPO="${UPDATED_REPO}"
     export BMOBRANCH="${UPDATED_BRANCH}"
-    export BMOPATH="/home/${USER}/tested_repo"
+    export BMOPATH="${HOME}/tested_repo"
     export BUILD_BMO_LOCALLY="true"
     export IRONIC_KEEPALIVED_LOCAL_IMAGE="${BMOPATH}/resources/keepalived-docker"
 
 elif [[ "${REPO_NAME}" == "ip-address-manager" ]]; then
     export IPAMREPO="${UPDATED_REPO}"
     export IPAMBRANCH="${UPDATED_BRANCH}"
-    export IPAMPATH="/home/${USER}/tested_repo"
+    export IPAMPATH="${HOME}/tested_repo"
     export BUILD_IPAM_LOCALLY="true"
 
 elif [[ "${REPO_NAME}" == "ironic-image" ]]; then
-    export IRONIC_LOCAL_IMAGE="/home/${USER}/tested_repo"
+    export IRONIC_LOCAL_IMAGE="${HOME}/tested_repo"
     # Build/test the sushy-tools/vbmc images, since they are defined in this repo
     export SUSHY_TOOLS_LOCAL_IMAGE="${IRONIC_LOCAL_IMAGE}/resources/sushy-tools"
     export VBMC_LOCAL_IMAGE="${IRONIC_LOCAL_IMAGE}/resources/vbmc"
 
 elif [[ "${REPO_NAME}" == "mariadb-image" ]]; then
-    export MARIADB_LOCAL_IMAGE="/home/${USER}/tested_repo"
+    export MARIADB_LOCAL_IMAGE="${HOME}/tested_repo"
 
 elif [[ "${REPO_NAME}" == "ironic-ipa-downloader" ]]; then
-    export IPA_DOWNLOADER_LOCAL_IMAGE="/home/${USER}/tested_repo"
+    export IPA_DOWNLOADER_LOCAL_IMAGE="${HOME}/tested_repo"
 
 elif [[ "${REPO_NAME}" == "cluster-api-provider-metal3" ]]; then
     export CAPM3REPO="${UPDATED_REPO}"
     export CAPM3BRANCH="${UPDATED_BRANCH}"
-    export CAPM3PATH="/home/${USER}/tested_repo"
+    export CAPM3PATH="${HOME}/tested_repo"
     export BUILD_CAPM3_LOCALLY="true"
 fi
 


### PR DESCRIPTION
Dev tests are failing with UPDATED_REPO unbound variable issue. It was initially defined and was not passed to test env. This PR fixes this issue. 
Also specifies full path for cloning repos.