### PR TITLE
Move BMO e2e jobs to run on Xerces workers

### DIFF
--- a/jenkins/jobs/bmo_e2e_tests.pipeline
+++ b/jenkins/jobs/bmo_e2e_tests.pipeline
@@ -18,7 +18,7 @@ pipeline {
   stages {
     stage("Run Baremetal Operator e2e tests") {
       matrix {
-        agent { label "metal3-workers" }
+        agent { label "metal3ci-8c16gb-ubuntu" }
         // Skip redfish on PRs, test all for periodic jobs
         when {
           anyOf {


### PR DESCRIPTION
We are trying to reduce Cleura usage and move jobs to Xerces. BMO e2e tests are a good first candidate.