### PR TITLE
remove last of the jenkins ghprb branch protections

### DIFF
--- a/prow/manifests/overlays/metal3/config.yaml
+++ b/prow/manifests/overlays/metal3/config.yaml
@@ -99,15 +99,6 @@ branch-protection:
       # To turn this off for a given job, set "optional: true"
       # in the job definition.
       protect: true
-      repos:
-        metal3-dev-tools:
-          # Use this to specify that a status coming from outside of prow is
-          # required.  We use this to require functional jobs running in
-          # jenkins are required, for example.
-          branches:
-            main:
-              required_status_checks:
-                contexts: ["test-integration-metal3-dev-tools-centos", "test-integration-metal3-dev-tools-ubuntu"]
     metal3-io:
       # Require "always_run: true" jobs to pass before merging.
       # To turn this off for a given job, set "optional: true"


### PR DESCRIPTION
Last of the jenkins GHPRB based branch protections can be removed, they have been removed from JJB and no longer exist.