### PR TITLE
Fix e2e integration test run from metal3-dev-env repo PR

### DIFF
--- a/jenkins/scripts/dynamic_worker_workflow/e2e_tests.sh
+++ b/jenkins/scripts/dynamic_worker_workflow/e2e_tests.sh
@@ -106,9 +106,7 @@ if [[ "${UPDATED_REPO}" != *"${REPO_ORG}/${REPO_NAME}"* ]] ||
 fi
 cd "${HOME}/"
 
-if [[ "${REPO_NAME}" == "metal3-dev-env" ]] ||
-    [[ "${REPO_NAME}" == "cluster-api-provider-metal3" ]] \
-    ; then
+if [[ "${REPO_NAME}" == "cluster-api-provider-metal3" ]] ; then
     # If we are testing e2e from capm3,
     # it will already be cloned to tested_repo
     pushd /"home/${USER}/tested_repo"


### PR DESCRIPTION
This fixes the issue of running e2e integration tests from wrong repo for metal3-dev-env PR tests. 
Example here: https://jenkins.nordix.org/view/Metal3/job/metal3-centos-e2e-integration-test-release-1-7/20/console