### PR TITLE
remove e2e from bmo 0.6 branch as required

### DIFF
--- a/prow/manifests/overlays/metal3/config.yaml
+++ b/prow/manifests/overlays/metal3/config.yaml
@@ -690,7 +690,7 @@ presubmits:
     - release-0.6
     agent: jenkins
     always_run: false
-    optional: false
+    optional: true
   - name: metal3-centos-e2e-integration-test-release-1-6
     branches:
     - release-0.5


### PR DESCRIPTION
BMO e2e was agreed to be good enough. For some reason, integration e2e centos was left on in 0.6 branch, but correctly removed from main and 0.5.