### PR TITLE
Increase BMO e2e timeout

### DIFF
--- a/jenkins/jobs/bmo_e2e_tests.pipeline
+++ b/jenkins/jobs/bmo_e2e_tests.pipeline
@@ -1,7 +1,7 @@
 import java.text.SimpleDateFormat
 
-// 1 hour
-def TIMEOUT = 3600
+// 2 hour
+def TIMEOUT = 7200
 
 // Set defaults for non-PR jobs
 def pullSha = (env.PULL_PULL_SHA) ?: "main"


### PR DESCRIPTION
We are seeing some optional jobs hit the 1 h timeout. This commit increases the timeout to 2 h.