### PR TITLE
Adjust timeout for tests

### DIFF
--- a/jenkins/jobs/capm3-e2e-tests.pipeline
+++ b/jenkins/jobs/capm3-e2e-tests.pipeline
@@ -1,8 +1,8 @@
 
 ci_git_credential_id = 'metal3-jenkins-github-token'
 
-// 4 hours
-int TIMEOUT = 14400
+// 3 hours
+int TIMEOUT = 10800
 
 script {
 
@@ -23,11 +23,14 @@ script {
 
   if  ("${GINKGO_FOCUS}" == 'integration' || "${GINKGO_FOCUS}" == 'basic') {
     agent_label = "metal3ci-4c16gb-${IMAGE_OS}"
-    TIMEOUT=7200 // 2h
+    TIMEOUT=10800 // 3h
+  } else if ( "${EPHEMERAL_TEST}" == 'true' ) {
+    TIMEOUT=18000 // 5h
+    agent_label = "metal3ci-large-${IMAGE_OS}"
   } else {
     agent_label = "metal3ci-large-${IMAGE_OS}"
   }
-        
+
 }
 
 pipeline {

--- a/jenkins/jobs/dev_env_integration_tests.pipeline
+++ b/jenkins/jobs/dev_env_integration_tests.pipeline
@@ -4,8 +4,8 @@ ci_git_credential_id = "metal3-jenkins-github-token"
 
 // 10 minutes
 def CLEAN_TIMEOUT = 600
-// 2 hours
-def TIMEOUT = 7200
+// 3 hours
+def TIMEOUT = 10800
 
 script {
   UPDATED_REPO = "https://github.com/${env.REPO_OWNER}/${env.REPO_NAME}.git"


### PR DESCRIPTION
This PR:
- sets timeout for integration tests to 3 hours (Due to ongoing CI infrastructure changes)
- sets timeout to 5h for Ephemeral tests
