### PR TITLE
Set dev env tests as required for metal3-dev-env repo

### DIFF
--- a/prow/manifests/overlays/metal3/config.yaml
+++ b/prow/manifests/overlays/metal3/config.yaml
@@ -1491,7 +1491,7 @@ presubmits:
   - name: metal3-ubuntu-e2e-integration-test-main
     agent: jenkins
     always_run: false
-    optional: false
+    optional: true
   - name: metal3-ubuntu-e2e-integration-test-release-1-7
     agent: jenkins
     always_run: false
@@ -1622,7 +1622,7 @@ presubmits:
   - name: metal3-dev-env-integration-test-ubuntu-main
     agent: jenkins
     always_run: false
-    optional: true
+    optional: false
   - name: metal3-dev-env-integration-test-ubuntu-release-1-7
     agent: jenkins
     always_run: false


### PR DESCRIPTION
metal3-dev-env tests should be required for PR in metal3-dev-env repo. 