### PR TITLE
Fix git credentials ID

### DIFF
--- a/jenkins/jobs/bml_integration_tests.pipeline
+++ b/jenkins/jobs/bml_integration_tests.pipeline
@@ -1,6 +1,6 @@
 import java.text.SimpleDateFormat
 
-ci_git_credential_id = "metal3-jenkins-github-token"
+ci_git_credential_id = "metal3-jenkins-github-username-token"
 
 // 3 hours
 def TIMEOUT = 10800

--- a/jenkins/jobs/bmo_e2e_tests.pipeline
+++ b/jenkins/jobs/bmo_e2e_tests.pipeline
@@ -40,7 +40,7 @@ pipeline {
             steps {
               checkout scmGit(
                   branches: [[name: pullSha]],
-                  userRemoteConfigs: [[url: repoUrl, credentialsId: "metal3-jenkins-github-token", refspec: refspec]],
+                  userRemoteConfigs: [[url: repoUrl, credentialsId: "metal3-jenkins-github-username-token", refspec: refspec]],
                   extensions: [[$class: "WipeWorkspace"],
                   [$class: "CleanCheckout"],
                   [$class: "CleanBeforeCheckout"],

--- a/jenkins/jobs/capm3-e2e-tests.pipeline
+++ b/jenkins/jobs/capm3-e2e-tests.pipeline
@@ -1,5 +1,5 @@
 
-ci_git_credential_id = 'metal3-jenkins-github-token'
+ci_git_credential_id = 'metal3-jenkins-github-username-token'
 
 // 3 hours
 int TIMEOUT = 10800

--- a/jenkins/jobs/dev_env_integration_tests.pipeline
+++ b/jenkins/jobs/dev_env_integration_tests.pipeline
@@ -1,6 +1,6 @@
 import java.text.SimpleDateFormat
 
-ci_git_credential_id = "metal3-jenkins-github-token"
+ci_git_credential_id = "metal3-jenkins-github-username-token"
 
 // 10 minutes
 def CLEAN_TIMEOUT = 600
@@ -9,7 +9,7 @@ def TIMEOUT = 10800
 
 script {
   UPDATED_REPO = "https://github.com/${env.REPO_OWNER}/${env.REPO_NAME}.git"
-  echo "Test triggered from ${UPDATED_REPO}" 
+  echo "Test triggered from ${UPDATED_REPO}"
   ci_git_url = "https://github.com/metal3-io/project-infra.git"
 
   if ("${env.REPO_OWNER}" == "metal3-io" && "${env.REPO_NAME}" == "project-infra") {

--- a/jenkins/jobs/image_building.pipeline
+++ b/jenkins/jobs/image_building.pipeline
@@ -1,4 +1,4 @@
-ci_git_credential_id = "metal3-jenkins-github-token"
+ci_git_credential_id = "metal3-jenkins-github-username-token"
 ci_git_branch = "main"
 ci_git_url = "https://github.com/metal3-io/project-infra.git"
 

--- a/jenkins/jobs/integration_tests.pipeline
+++ b/jenkins/jobs/integration_tests.pipeline
@@ -1,6 +1,6 @@
 import java.text.SimpleDateFormat
 
-ci_git_credential_id = "metal3-jenkins-github-token"
+ci_git_credential_id = "metal3-jenkins-github-username-token"
 
 // 10 minutes
 def CLEAN_TIMEOUT = 600

--- a/jenkins/jobs/integration_tests_clean.pipeline
+++ b/jenkins/jobs/integration_tests_clean.pipeline
@@ -1,11 +1,11 @@
 import java.text.SimpleDateFormat
 
-ci_git_credential_id = "metal3-jenkins-github-token"
+ci_git_credential_id = "metal3-jenkins-github-username-token"
 def TIMEOUT = 1800
 
 script {
   UPDATED_REPO = "https://github.com/${env.REPO_OWNER}/${env.REPO_NAME}.git"
-  echo "Test triggered from ${UPDATED_REPO}" 
+  echo "Test triggered from ${UPDATED_REPO}"
   ci_git_url = "https://github.com/metal3-io/project-infra.git"
 
   if ("${env.REPO_OWNER}" == "metal3-io" && "${env.REPO_NAME}" == "project-infra") {

--- a/jenkins/jobs/parallel_e2e_features_test.pipeline
+++ b/jenkins/jobs/parallel_e2e_features_test.pipeline
@@ -1,6 +1,6 @@
 import java.text.SimpleDateFormat
 
-ci_git_credential_id = "metal3-jenkins-github-token"
+ci_git_credential_id = "metal3-jenkins-github-username-token"
 
 // 10 minutes
 def CLEAN_TIMEOUT = 600
@@ -109,7 +109,7 @@ pipeline {
               ansiColor('xterm') {
                 timestamps {
                   sh "./jenkins/scripts/dynamic_worker_workflow/e2e_tests.sh"
-                }  
+                }
               }
             }
           }
@@ -167,7 +167,7 @@ pipeline {
               ]
             ]
             ])
-            
+
             withCredentials([string(credentialsId: 'metal3-clusterctl-github-token', variable: 'GITHUB_TOKEN')]) {
               ansiColor('xterm') {
                 timestamps {
@@ -232,12 +232,12 @@ pipeline {
               ]
             ]
             ])
-            
+
             withCredentials([string(credentialsId: 'metal3-clusterctl-github-token', variable: 'GITHUB_TOKEN')]) {
               ansiColor('xterm') {
                 timestamps {
                   sh "./jenkins/scripts/dynamic_worker_workflow/e2e_tests.sh"
-                }  
+                }
               }
             }
           }
@@ -264,7 +264,7 @@ pipeline {
             }
           }
         }
-      }   
+      }
     }
   }
 }

--- a/jenkins/jobs/prow_integration_tests.pipeline
+++ b/jenkins/jobs/prow_integration_tests.pipeline
@@ -1,6 +1,6 @@
 import java.text.SimpleDateFormat
 
-ci_git_credential_id = "metal3-jenkins-github-token"
+ci_git_credential_id = "metal3-jenkins-github-username-token"
 
 // 10 minutes
 def CLEAN_TIMEOUT = 600
@@ -10,7 +10,7 @@ KUBECTL_SHA256=(env.KUBECTL_SHA256)
 
 script {
   UPDATED_REPO = "https://github.com/${env.REPO_OWNER}/${env.REPO_NAME}.git"
-  echo "Test triggered from ${UPDATED_REPO}" 
+  echo "Test triggered from ${UPDATED_REPO}"
   ci_git_url = "https://github.com/metal3-io/project-infra.git"
 
   if ("${env.REPO_OWNER}" == "metal3-io" && "${env.REPO_NAME}" == "project-infra") {
@@ -36,10 +36,10 @@ pipeline {
   agent { label 'metal3-static-workers' }
   environment {
     METAL3_CI_USER="metal3ci"
-    // Defined in the job project 
+    // Defined in the job project
     REPO_ORG = "${env.REPO_OWNER}"
     REPO_NAME = "${env.REPO_NAME}"
-    // Defined in prow env vars 
+    // Defined in prow env vars
     // https://docs.prow.k8s.io/docs/jobs/#job-environment-variables
     REPO_BRANCH = "${env.PULL_BASE_REF}"
     UPDATED_BRANCH = "${env.PULL_PULL_SHA}"


### PR DESCRIPTION
We have been using the wrong credentials ID, resulting in "not found" errors (but still working without credentials). The thing is that the git plugin only supports username/password, NOT token. We have been trying to use a token for checking out the tested repo. We have been using the correct credentials for checking out project-infra though.

This PR changes all pipelines to use the same credentials ID we always used for checking out project-infra.