### PR TITLE
Prow: Skip job report from jenkins-operator

### DIFF
--- a/prow/manifests/overlays/metal3/external-plugins/jenkins-operator.yaml
+++ b/prow/manifests/overlays/metal3/external-plugins/jenkins-operator.yaml
@@ -45,6 +45,7 @@ spec:
         - --github-token-path=/etc/github/token
         - --github-endpoint=http://ghproxy
         - --github-endpoint=https://api.github.com
+        - --skip-report=true
         - --dry-run=false
         ports:
         # Used for serving logs so that they can be displayed by deck


### PR DESCRIPTION
We currently see double comments on github when jenkins jobs fail. I think the issue is that the jenkins-operator reports the failure once and prow itself reports it a second time (since the job also has a corresponding prowjob). If this is accurate, we can solve the issue by disabling reports from the jenkins-operator, which is what this commit does.