### PR TITLE
Prow: Increase max prowjob age to 24h

### DIFF
--- a/prow/manifests/overlays/metal3/config.yaml
+++ b/prow/manifests/overlays/metal3/config.yaml
@@ -5,7 +5,7 @@ log_level: debug
 # Sinker configurations (for cleanup)
 sinker:
   resync_period: 1m
-  max_prowjob_age: 4h
+  max_prowjob_age: 24h
   max_pod_age: 30m
   terminated_pod_ttl: 2h
 


### PR DESCRIPTION
Now that we trigger jenkins jobs through Prow, we have some jobs that can take more than 4h. Increasing to 24h.

Edit: I suspect this may be why we have seen some jobs fail but report success (https://github.com/kubernetes-sigs/prow/issues/142). If the prowjob was cleaned up, then what would the jenkins-operator do? :thinking: 