### PR TITLE
Prow: Enable triggering of GitHub workflows

### DIFF
--- a/prow/manifests/overlays/metal3/plugins.yaml
+++ b/prow/manifests/overlays/metal3/plugins.yaml
@@ -152,3 +152,7 @@ require_matching_label:
 
 override:
   allow_top_level_owners: true
+
+triggers:
+- # Enable prow to trigger GitHub workflows.
+  trigger_github_workflows: true


### PR DESCRIPTION
This should allow Prow to trigger (and re-trigger) workflows, making it possible for non-admins to re-run failed workflows.