### PR TITLE
🐛 Fixing EPHEMERAL_TEST variable

### DIFF
--- a/jenkins/jobs/capm3-e2e-tests.pipeline
+++ b/jenkins/jobs/capm3-e2e-tests.pipeline
@@ -24,7 +24,7 @@ script {
   if  ("${GINKGO_FOCUS}" == 'integration' || "${GINKGO_FOCUS}" == 'basic') {
     agent_label = "metal3ci-4c16gb-${IMAGE_OS}"
     TIMEOUT=10800 // 3h
-  } else if ( "${EPHEMERAL_TEST}" == 'true' ) {
+  } else if ( "${env.EPHEMERAL_TEST}" == 'true' ) {
     TIMEOUT=18000 // 5h
     agent_label = "metal3ci-large-${IMAGE_OS}"
   } else {
@@ -52,7 +52,7 @@ pipeline {
         NUM_NODES = "${NUM_NODES}"
         CAPI_VERSION = "${CAPI_VERSION}"
         CAPM3_VERSION = "${CAPM3_VERSION}"
-        EPHEMERAL_TEST="${EPHEMERAL_TEST}"
+        EPHEMERAL_TEST = "${EPHEMERAL_TEST}"
         KUBERNETES_VERSION_UPGRADE_FROM = "${KUBERNETES_VERSION_UPGRADE_FROM}"
         KUBERNETES_VERSION_UPGRADE_TO = "${KUBERNETES_VERSION_UPGRADE_TO}"
         KUBECTL_SHA256 = "${KUBECTL_SHA256}"


### PR DESCRIPTION
e2e tests fail with the following error:
```
Also:   org.jenkinsci.plugins.workflow.actions.ErrorAction$ErrorId: e674ac0b-023f-4ef1-bb05-8ae6135101ec
groovy.lang.MissingPropertyException: No such property: EPHEMERAL_TEST for class: groovy.lang.Binding
```
ref: https://jenkins.nordix.org/view/Metal3%20Periodic/job/metal3-periodic-e2e-1-28-1-29-upgrade-main/32/console 

This PR is fixing it.