### PR TITLE
add OWNERS_ALIASES support

### DIFF
--- a/OWNERS
+++ b/OWNERS
@@ -1,16 +1,11 @@
 # See the OWNERS docs at https://go.k8s.io/owners
 
 approvers:
-- kashifest
-- lentzi90
-- mboukhalfa
-- Sunnatillo
-- tuminoid
+- project-infra-maintainers
 
 reviewers:
-- adilGhaffarDev
-- Rozzii
-- smoshiur1237
+- project-infra-maintainers
+- project-infra-reviewers
 
 emeritus_approvers:
 - fmuyassarov

--- a/OWNERS_ALIASES
+++ b/OWNERS_ALIASES
@@ -1,0 +1,14 @@
+# See the OWNERS docs: https://git.k8s.io/community/contributors/guide/owners.md
+
+aliases:
+  project-infra-maintainers:
+  - kashifest
+  - lentzi90
+  - mboukhalfa
+  - Sunnatillo
+  - tuminoid
+
+  project-infra-reviewers:
+  - adilGhaffarDev
+  - Rozzii
+  - smoshiur1237


### PR DESCRIPTION
Add OWNERS_ALIASES file so we can reuse the groups. This way we can assign maintainers as reviewers, so blunderbuss will take both approvers and reviewers into question of picking relevant reviewers. In most of Metal3 repos, we have same or more approvers than reviewers, which causes all the review requests currently to pile up to the same 2-3 people, while approvers get none.