### PR TITLE
add cherrypicker to sles-ironic-python-agent-builder

### DIFF
--- a/prow/manifests/overlays/metal3/plugins.yaml
+++ b/prow/manifests/overlays/metal3/plugins.yaml
@@ -114,6 +114,11 @@ external_plugins:
     events:
     - pull_request
     - issue_comment
+  - name: cherrypicker
+    events:
+    - issue_comment
+    - pull_request
+    endpoint: http://cherrypicker
   metal3-io:
   - name: needs-rebase
     # No endpoint specified implies "http://{{name}}".


### PR DESCRIPTION
It has two branches, enable cherrypicker for it.