### PR TITLE
Add new key to authorized_keys in the DiB build

### DIFF
--- a/jenkins/image_building/authorized_keys
+++ b/jenkins/image_building/authorized_keys
@@ -1,1 +1,2 @@
 ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIIpxfHuI2qfTYPrL4+thyHSS78Qj9ehp2/GYxuNXthgS estjorvas@est.tech
+ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIKWxiMImeu5YzBDPwAbayWwSa4Fasj6KGpN59t/2yO9V estjorvas@est.tech

--- a/jenkins/image_building/build-image.sh
+++ b/jenkins/image_building/build-image.sh
@@ -22,7 +22,7 @@ sudo pip3 install diskimage-builder python-openstackclient
 export ELEMENTS_PATH="${current_dir}/dib_elements"
 export DIB_DEV_USER_USERNAME="metal3ci"
 export DIB_DEV_USER_PWDLESS_SUDO="yes"
-export DIB_DEV_USER_AUTHORIZED_KEYS="${current_dir}/id_ed25519_metal3ci.pub"
+export DIB_DEV_USER_AUTHORIZED_KEYS="${current_dir}/authorized_keys"
 
 if [[ "${IMAGE_OS}" == "ubuntu" ]]; then
   export DIB_RELEASE=jammy


### PR DESCRIPTION
This is part of rotating keys we will eventually remove the old key once we have verified everything works with the new key.
The new key details are available in the password manager. 

Fixes: #765 
