### PR TITLE
Prow: Enable reporting again in jenkins-operator

### DIFF
--- a/prow/manifests/overlays/metal3/external-plugins/jenkins-operator.yaml
+++ b/prow/manifests/overlays/metal3/external-plugins/jenkins-operator.yaml
@@ -45,7 +45,7 @@ spec:
         - --github-token-path=/etc/github/token
         - --github-endpoint=http://ghproxy
         - --github-endpoint=https://api.github.com
-        - --skip-report=true
+        - --skip-report=false
         - --dry-run=false
         ports:
         # Used for serving logs so that they can be displayed by deck


### PR DESCRIPTION
Disabling the reporting did get rid of the double failure messages, but it also broke updates to the status contexts. They only updated after jobs completed or not at all.
Therefore we enable reporting again.