### PR TITLE
Make BMO e2e tests optional

### DIFF
--- a/prow/manifests/overlays/metal3/config.yaml
+++ b/prow/manifests/overlays/metal3/config.yaml
@@ -703,7 +703,7 @@ presubmits:
     agent: jenkins
     # Don't run unless triggered to avoid wasting resources
     always_run: false
-    optional: false
+    optional: true
   - name: metal3-bmo-e2e-test-optional-pull
     # E2e tests do not exist before release-0.5
     branches:


### PR DESCRIPTION
We are moving the GitHub workflows so we should no longer require the jenkins job. Still leaving it as optional though so we can trigger it if wanted.