### PR TITLE
bump go 1.22 for ironic-standalone-operator

### DIFF
--- a/prow/manifests/overlays/metal3/config.yaml
+++ b/prow/manifests/overlays/metal3/config.yaml
@@ -329,7 +329,7 @@ presubmits:
         env:
         - name: IS_CONTAINER
           value: "TRUE"
-        image: docker.io/golang:1.21
+        image: docker.io/golang:1.22
         imagePullPolicy: Always
   - name: markdownlint
     run_if_changed: '(\.md|markdownlint\.sh)$'


### PR DESCRIPTION
Bump Go image to 1.22 for ironic-standalone-operator tests, as we're bumping Go to 1.22 there.