### PR TITLE
Prow cleanup and use DNS hook.

### DIFF
--- a/prow/manifests/base/hook.yaml
+++ b/prow/manifests/base/hook.yaml
@@ -85,8 +85,6 @@ spec:
     app: hook
   ports:
   - port: 8888
-  # TODO: Remove this or turn back to ClusterIP when DNS is set up properly.
-  type: LoadBalancer
 ---
 apiVersion: v1
 kind: ServiceAccount


### PR DESCRIPTION
This PR will remove the loadbalancer and revert back to DNS hook.