### PR TITLE
Add image testing to node image building process

### DIFF
--- a/jenkins/image_building/build-image.sh
+++ b/jenkins/image_building/build-image.sh
@@ -11,6 +11,8 @@ current_dir="$(dirname "$(readlink -f "${0}")")"
 source "${current_dir}/upload-ci-image.sh"
 # shellcheck disable=SC1091
 source "${current_dir}/upload-node-image.sh"
+# shellcheck disable=SC1091
+source "${current_dir}/verify-node-image.sh"
 
 # Disable needrestart interactive mode
 sudo sed -i "s/^#\$nrconf{restart} = 'i';/\$nrconf{restart} = 'a';/" /etc/needrestart/needrestart.conf > /dev/null || true
@@ -66,6 +68,8 @@ export HOSTNAME="${img_name}"
 disk-image-create --no-tmpfs -a amd64 -o "${img_name}".qcow2 "${IMAGE_OS}"-"${IMAGE_TYPE}" block-device-efi
 
 if [[ "${IMAGE_TYPE}" == "node" ]]; then
+  verify_node_image "${img_name}" 
+  echo "Image testing successful."
   upload_node_image "${img_name}"
 else
   upload_ci_image "${img_name}"

--- a/jenkins/image_building/verify-node-image.sh
+++ b/jenkins/image_building/verify-node-image.sh
@@ -1,0 +1,30 @@
+#!/usr/bin/env bash
+
+set -eux
+
+verify_node_image() {
+    img_name="$1"
+
+    IMAGE_DIR="$(dirname "$(readlink -f "${0}")")"
+
+    # So that no extra components are built later
+    export IMAGE_TESTING="true"
+
+    # Tests expect the image name to have the file type extension 
+    export IMAGE_NAME="${img_name}.qcow2"
+    export IMAGE_OS="${IMAGE_OS}"
+    export IMAGE_TYPE="${IMAGE_TYPE}"
+    export IMAGE_LOCATION="${IMAGE_DIR}"
+
+    # Similar config to periodic integration tests
+    export REPO_BRANCH="main"
+    export REPO_ORG="metal3-io"
+    export REPO_NAME="metal3-dev-env"
+    export UPDATED_REPO="metal3-io/metal3-dev-env"
+    export UPDATED_BRANCH="main"
+    export NUM_NODES=2
+    
+    export IRONIC_INSTALL_TYPE="rpm"
+
+    "${IMAGE_DIR}/../scripts/dynamic_worker_workflow/dev_env_integration_tests.sh" 
+}

--- a/jenkins/scripts/dynamic_worker_workflow/test_env.sh
+++ b/jenkins/scripts/dynamic_worker_workflow/test_env.sh
@@ -11,8 +11,10 @@ if [[ "${REPO_NAME}" == "metal3-dev-env" ]]; then
 
     # If the target repo and branch are the same as the source repo and branch
     # we're running a periodic test, that is not for a PR, so we build the CAPM3, BMO and IPAM images)
+    # Last option checks if IMAGE_TESTING is set, in which case we are running tests to verify new image
+    # and don't need to build everything
 
-    if [[ "${UPDATED_BRANCH}" == "${REPO_BRANCH}" ]] && [[ "${UPDATED_REPO}" == *"${REPO_ORG}/${REPO_NAME}"* ]]; then
+    if [[ "${UPDATED_BRANCH}" == "${REPO_BRANCH}" ]] && [[ "${UPDATED_REPO}" == *"${REPO_ORG}/${REPO_NAME}"* ]] && [[ -n "${IMAGE_TESTING:-}" ]]; then
         export BUILD_BMO_LOCALLY="true"
         export BUILD_CAPM3_LOCALLY="true"
         export BUILD_IPAM_LOCALLY="true"


### PR DESCRIPTION
With this change, build node images will be verified with integration tests before they are pushed online.