### PR TITLE
:seedling: Add config for basic-checks container image

### DIFF
--- a/prow/container-images/basic-checks/Dockerfile
+++ b/prow/container-images/basic-checks/Dockerfile
@@ -1,0 +1,5 @@
+ARG GO_VERSION=1.22
+FROM docker.io/golang:${GO_VERSION}
+
+# Install packages
+RUN apt-get update && apt-get install -y libvirt-dev

--- a/prow/container-images/basic-checks/README.md
+++ b/prow/container-images/basic-checks/README.md
@@ -1,0 +1,11 @@
+# Basic-checks image
+
+This Dockerfile is used to create the `quay.io/metal3-io/basic-checks` image,
+which is used to run the basic tests in prow.
+
+## Steps to build `basic-checks` image
+
+- Determine the go version to use, for e.g. `1.22`
+- Login to quay.io `docker login quay.io
+- Build the image with `docker build --build-arg GO_VERSION=1.22 -t quay.io/metal3-io/basic-checks:golang-1.22`
+- Push the image to quay: `docker push quay.io/metal3-io/basic-checks:golang-1.22`


### PR DESCRIPTION
In prow we are currently using `docker.io/golang` as the container image to run various basic tests: `generate`, `gomod`, lint, etc. It has worked well so far, but will fail the tests if something extra is required from the container environment, as in the case of https://github.com/metal3-io/baremetal-operator/pull/1767, which requires libvirt.

This PR adds a new Dockerfile that will be used to build a new container image, that takes `docker.io/golang` as base. For now we configure it so that a new container image will be pushed once a new tag is pushed to the github repository.