### PR TITLE
:seedling: Use basic-checks image instead of docker.io/golang for basic tests in BMO repo

### DIFF
--- a/prow/manifests/overlays/metal3/config.yaml
+++ b/prow/manifests/overlays/metal3/config.yaml
@@ -393,7 +393,7 @@ presubmits:
         env:
         - name: IS_CONTAINER
           value: "TRUE"
-        image: docker.io/golang:1.22
+        image: quay.io/metal3-io/basic-checks:golang-1.22
         imagePullPolicy: Always
   - name: gomod
     branches:
@@ -522,7 +522,7 @@ presubmits:
           value: "http://localhost:6385/v1/"
         - name: IRONIC_INSPECTOR_ENDPOINT
           value: "http://localhost:5050/v1/"
-        image: docker.io/golang:1.22
+        image: quay.io/metal3-io/basic-checks:golang-1.22
         imagePullPolicy: Always
   - name: generate
     branches:
@@ -601,7 +601,7 @@ presubmits:
         - test
         command:
         - make
-        image: docker.io/golang:1.22
+        image: quay.io/metal3-io/basic-checks:golang-1.22
         imagePullPolicy: Always
   - name: test
     branches:


### PR DESCRIPTION
As mentioned by https://github.com/metal3-io/project-infra/pull/796, this PR is to replace `docker.io/golang` with `quay.io/metal3-io/basic-checks` image