### PR TITLE
cleanup basic-checks image

### DIFF
--- a/prow/container-images/basic-checks/Dockerfile
+++ b/prow/container-images/basic-checks/Dockerfile
@@ -2,4 +2,6 @@ ARG GO_VERSION=1.22
 FROM docker.io/golang:${GO_VERSION}
 
 # Install packages
-RUN apt-get update && apt-get install -y libvirt-dev
+RUN apt-get update \
+    && apt-get install -y libvirt-dev \
+    && apt-get clean


### PR DESCRIPTION
Make basic-checks image a bit smaller by running apt-get clean after package installation.