### PR TITLE
delete local images after they're uploaded

### DIFF
--- a/jenkins/image_building/build-image.sh
+++ b/jenkins/image_building/build-image.sh
@@ -21,7 +21,7 @@ sudo apt-get update
 sudo apt-get install python3-pip qemu qemu-kvm -y
 sudo pip3 install diskimage-builder python-openstackclient
 # TODO(Sunnatillo): When newer version than 3.32.0 of disk-image builder released remove changes
-# done by this commit. 
+# done by this commit.
 sudo -H pip install virtualenv
 
 # sudo pip3 install diskimage-builder python-openstackclient
@@ -68,7 +68,7 @@ export HOSTNAME="${img_name}"
 disk-image-create --no-tmpfs -a amd64 -o "${img_name}".raw -t raw "${IMAGE_OS}"-"${IMAGE_TYPE}" block-device-efi
 
 if [[ "${IMAGE_TYPE}" == "node" ]]; then
-  verify_node_image "${img_name}" 
+  verify_node_image "${img_name}"
   echo "Image testing successful."
   upload_node_image "${img_name}"
 else
@@ -77,4 +77,5 @@ else
 fi
 
 deactivate
+sudo rm -f "${img_name}".{raw,qcow2}
 sudo rm -rf "${current_dir}/dib"


### PR DESCRIPTION
Delete local images after they're uploaded as they're huge and might cause disk space issues if dynamic worker is reused.

Reference: https://github.com/metal3-io/project-infra/pull/784 