### PR TITLE
Build qcow2 image instead of raw by default

### DIFF
--- a/jenkins/image_building/build-image.sh
+++ b/jenkins/image_building/build-image.sh
@@ -65,7 +65,7 @@ fi
 
 export HOSTNAME="${img_name}"
 
-disk-image-create --no-tmpfs -a amd64 -o "${img_name}".raw -t raw "${IMAGE_OS}"-"${IMAGE_TYPE}" block-device-efi
+disk-image-create --no-tmpfs -a amd64 -o "${img_name}".qcow2 "${IMAGE_OS}"-"${IMAGE_TYPE}" block-device-efi
 
 if [[ "${IMAGE_TYPE}" == "node" ]]; then
   verify_node_image "${img_name}"

--- a/jenkins/image_building/upload-ci-image.sh
+++ b/jenkins/image_building/upload-ci-image.sh
@@ -38,7 +38,6 @@ upload_ci_image_cleura() {
   export OS_AUTH_VERSION=3
   export OS_IDENTITY_API_VERSION=3
 
-  qemu-img convert -f raw -O qcow2 "${img_name}".raw "${img_name}".qcow2
   openstack image create "${img_name}" --file "${img_name}".qcow2 --disk-format=qcow2
   # delete old images (keeps latest five)
   delete_old_images
@@ -67,6 +66,7 @@ upload_ci_image_xerces() {
   export OS_USER_DOMAIN_NAME="xerces"
   export OS_IDENTITY_API_VERSION=3
 
+  qemu-img convert -f qcow2 -O raw "${img_name}".qcow2 "${img_name}".raw
   openstack image create "${img_name}" --file "${img_name}".raw --disk-format=raw
 
   # delete old images (keeps latest five)


### PR DESCRIPTION
https://github.com/metal3-io/project-infra/pull/784/ changed the default image format to be created to raw. But this also effect node image building and we still want qcow2 to be the format for that. This PR changes this behavior to build qcow2 images by default. This PR also ensures we delete the images once uploaded to openstack from dynamic worker vms.