### PR TITLE
Remove old SSH key from the CI image

### DIFF
--- a/jenkins/image_building/authorized_keys
+++ b/jenkins/image_building/authorized_keys
@@ -1,2 +1,1 @@
-ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIIpxfHuI2qfTYPrL4+thyHSS78Qj9ehp2/GYxuNXthgS estjorvas@est.tech
 ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIKWxiMImeu5YzBDPwAbayWwSa4Fasj6KGpN59t/2yO9V estjorvas@est.tech


### PR DESCRIPTION
This is part of the CI key rotation. The new key seems to work in most of the CI jobs. This PR gets rid of the old one.
Signed-off-by: Kashif Khan <kashif.khan@est.tech>