### PR TITLE
:seedling: Make sure the git clone destination is empty

### DIFF
--- a/jenkins/scripts/dynamic_worker_workflow/dev_env_integration_tests.sh
+++ b/jenkins/scripts/dynamic_worker_workflow/dev_env_integration_tests.sh
@@ -50,8 +50,10 @@ else
 fi
 
 # Clone the source repository
-git clone "https://github.com/${REPO_ORG}/${REPO_NAME}.git" "${HOME}/tested_repo"
-cd "${HOME}/tested_repo"
+REPO_LOCATION=${REPO_LOCATION:-"${HOME}/tested_repo"}
+rm -rf "${REPO_LOCATION}"
+git clone "https://github.com/${REPO_ORG}/${REPO_NAME}.git" "${REPO_LOCATION}"
+cd "${REPO_LOCATION}"
 git checkout "${REPO_BRANCH}"
 # If the target and source repos and branches are identical, don't try to merge
 if [[ "${UPDATED_REPO}" != *"${REPO_ORG}/${REPO_NAME}"* ]] ||
@@ -70,7 +72,7 @@ cd "${HOME}"
 
 if [[ "${REPO_NAME}" == "metal3-dev-env" ]]; then
     # it will already be cloned to tested_repo
-    pushd "${HOME}/tested_repo"
+    pushd "${REPO_LOCATION}"
 else
     # clone metal3-dev-env and run the test from there
     git clone "${METAL3REPO}" "${HOME}/metal3"


### PR DESCRIPTION
Cleanup the test repo location (`$HOME/tested_repo`) before cloning. To avoid the issue we face in CI: https://jenkins.nordix.org/job/metal3_periodic_node_image_building/34/consoleFull

```
+ /home/****/workspace/metal3_periodic_node_image_building/jenkins/image_building/../scripts/dynamic_worker_workflow/dev_env_integration_tests.sh
fatal: destination path '/home/****/tested_repo' already exists and is not an empty directory.
```