### PR TITLE
:bug: Fix IMAGE_LOCATION in build-image.sh

### DIFF
--- a/jenkins/image_building/build-image.sh
+++ b/jenkins/image_building/build-image.sh
@@ -3,14 +3,19 @@
 set -eux
 
 current_dir="$(dirname "$(readlink -f "${0}")")"
+REPO_ROOT="$(realpath "${current_dir}/../..")"
 
 cleanup() {
   deactivate || true
-  sudo rm -f "${img_name}".{raw,qcow2}
+  sudo rm -f "${REPO_ROOT}/${img_name}".{raw,qcow2}
+  sudo rm -rf "${REPO_ROOT}/${img_name}.d"
   sudo rm -rf "${current_dir}/dib"
 }
 
 trap cleanup EXIT
+
+# Make sure we run everything in the repo root
+cd "${REPO_ROOT}" || true
 
 export IMAGE_OS="${IMAGE_OS}"
 export IMAGE_TYPE="${IMAGE_TYPE}"
@@ -76,7 +81,7 @@ disk-image-create --no-tmpfs -a amd64 -o "${img_name}".qcow2 "${IMAGE_OS}"-"${IM
 
 
 if [[ "${IMAGE_TYPE}" == "node" ]]; then
-  verify_node_image "${img_name}"
+  verify_node_image "${img_name}" "${REPO_ROOT}"
   echo "Image testing successful."
   upload_node_image "${img_name}"
 else

--- a/jenkins/image_building/verify-node-image.sh
+++ b/jenkins/image_building/verify-node-image.sh
@@ -3,9 +3,10 @@
 set -eux
 
 verify_node_image() {
-    img_name="$1"
+    current_dir="$(dirname "$(readlink -f "${0}")")"
 
-    IMAGE_DIR="$(dirname "$(readlink -f "${0}")")"
+    img_name="$1"
+    IMAGE_DIR="${2:-"$current_dir"}"
 
     # So that no extra components are built later
     export IMAGE_TESTING="true"
@@ -26,5 +27,5 @@ verify_node_image() {
     
     export IRONIC_INSTALL_TYPE="rpm"
 
-    "${IMAGE_DIR}/../scripts/dynamic_worker_workflow/dev_env_integration_tests.sh" 
+    "${current_dir}/../scripts/dynamic_worker_workflow/dev_env_integration_tests.sh"
 }


### PR DESCRIPTION
[node_image_building](https://jenkins.nordix.org/job/metal3_periodic_node_image_building/) is currently failing because the location of the file is incorrect. The built image locates in the directory, from where the script is run (which is the repo root), while the verify script assumes that image locates in `jenkins/image_building`.

This PR fixes the IMAGE_LOCATION, so that dev-env could find the image.

Edit: Also add the `${IMAGE_NAME}.d` directory cleanup. This directory was created as a part of the image building.