### PR TITLE
:bug: Remove KIND_NODE_IMAGE_VERSION from the build image pipeline

### DIFF
--- a/jenkins/jobs/image_building.pipeline
+++ b/jenkins/jobs/image_building.pipeline
@@ -11,7 +11,6 @@ pipeline {
     KUBERNETES_VERSION = "${KUBERNETES_VERSION}"
     CRICTL_VERSION = "${CRICTL_VERSION}"
     CRIO_VERSION = "${CRIO_VERSION}"
-    KIND_NODE_IMAGE_VERSION = "${KIND_NODE_IMAGE_VERSION}"
     RT_URL="https://artifactory.nordix.org/artifactory"
   }
   stages {


### PR DESCRIPTION
This param is not set anywhere, so this should be just a mistake. It's creating problem in `verify_node_image`, with `KIND_NODE_IMAGE_VERSION` is set to "null"

```
++ export KIND_NODE_IMAGE_VERSION=null
++ KIND_NODE_IMAGE_VERSION=null
++ export KIND_NODE_IMAGE=registry.nordix.org/docker-hub-proxy/kindest/node:null

++ sudo docker pull registry.nordix.org/docker-hub-proxy/kindest/node:null
Error response from daemon: unknown: resource not found: repo docker-hub-proxy/kindest/node, tag null not found
```

https://jenkins.nordix.org/view/Metal3%20Periodic/job/metal3_periodic_node_image_building/36/console