### PR TITLE
:bug: Increase timeout minutes for node image building pipeline

### DIFF
--- a/jenkins/jobs/image_building.pipeline
+++ b/jenkins/jobs/image_building.pipeline
@@ -37,7 +37,7 @@ pipeline {
     }
     stage('Build Ubuntu CI image') {
       options {
-        timeout(time: 40, unit: 'MINUTES')
+        timeout(time: 3, unit: 'HOURS')
       }
       environment {
         IMAGE_OS = "ubuntu"
@@ -57,7 +57,7 @@ pipeline {
     }
     stage('Building Centos CI image'){
       options {
-        timeout(time: 40, unit: 'MINUTES')
+        timeout(time: 3, unit: 'HOURS')
       }
       environment {
         IMAGE_OS = "centos"


### PR DESCRIPTION
Because we run the `dev-env` test to verify the images after building them, 40 minutes isn't long enough.