### PR TITLE
:seedling: Set trap to run `make clean` after integration test

### DIFF
--- a/jenkins/image_building/verify-node-image.sh
+++ b/jenkins/image_building/verify-node-image.sh
@@ -11,6 +11,9 @@ verify_node_image() {
     # So that no extra components are built later
     export IMAGE_TESTING="true"
 
+    # Run "make clean" after test, so that next job can start from clean state
+    export CLEANUP_AFTERWARDS="true"
+
     # Tests expect the image name to have the file type extension 
     export IMAGE_NAME="${img_name}.qcow2"
     export IMAGE_OS="${IMAGE_OS}"

--- a/jenkins/scripts/dynamic_worker_workflow/dev_env_integration_tests.sh
+++ b/jenkins/scripts/dynamic_worker_workflow/dev_env_integration_tests.sh
@@ -82,5 +82,12 @@ fi
 
 echo "Running the tests"
 
+cleanup() {
+    if [[ "${CLEANUP_AFTERWARDS:-}" == "true" ]]; then
+        make clean
+    fi
+}
+trap cleanup EXIT
+
 make
 make test


### PR DESCRIPTION
Add an option to cleanup the system (by running dev-env `make clean`) after integration test. This is to make sure the next pipeline can start from a clean state, hence avoid issues like the one we see in https://jenkins.nordix.org/job/metal3_periodic_node_image_building/38/