### PR TITLE
Update prow config to test release 1.7 of capm3 with go v1.22

### DIFF
--- a/prow/manifests/overlays/metal3/config.yaml
+++ b/prow/manifests/overlays/metal3/config.yaml
@@ -1021,21 +1021,6 @@ presubmits:
   - name: gomod
     branches:
     - main
-    skip_if_only_changed: '(((^|/)OWNERS)|((^|/)OWNERS_ALIASES)|(\.md))$'
-    decorate: true
-    spec:
-      containers:
-      - args:
-        - ./hack/gomod.sh
-        command:
-        - sh
-        env:
-        - name: IS_CONTAINER
-          value: "TRUE"
-        image: docker.io/golang:1.22
-        imagePullPolicy: Always
-  - name: gomod
-    branches:
     - release-1.7
     skip_if_only_changed: '(((^|/)OWNERS)|((^|/)OWNERS_ALIASES)|(\.md))$'
     decorate: true
@@ -1048,7 +1033,7 @@ presubmits:
         env:
         - name: IS_CONTAINER
           value: "TRUE"
-        image: docker.io/golang:1.21
+        image: docker.io/golang:1.22
         imagePullPolicy: Always
   - name: gomod
     branches:
@@ -1071,18 +1056,6 @@ presubmits:
   - name: test
     branches:
     - main
-    run_if_changed: "^(Makefile|hack/.*)$"
-    decorate: true
-    spec:
-      containers:
-      - args:
-        - test
-        command:
-        - make
-        image: docker.io/golang:1.22
-        imagePullPolicy: Always
-  - name: test
-    branches:
     - release-1.7
     run_if_changed: "^(Makefile|hack/.*)$"
     decorate: true
@@ -1092,7 +1065,7 @@ presubmits:
         - test
         command:
         - make
-        image: docker.io/golang:1.21
+        image: docker.io/golang:1.22
         imagePullPolicy: Always
   - name: test
     branches:
@@ -1159,21 +1132,6 @@ presubmits:
   - name: generate
     branches:
     - main
-    skip_if_only_changed: '(((^|/)OWNERS)|((^|/)OWNERS_ALIASES)|(\.md))$'
-    decorate: true
-    spec:
-      containers:
-      - args:
-        - ./hack/codegen.sh
-        command:
-        - sh
-        env:
-        - name: IS_CONTAINER
-          value: "TRUE"
-        image: docker.io/golang:1.22
-        imagePullPolicy: Always
-  - name: generate
-    branches:
     - release-1.7
     skip_if_only_changed: '(((^|/)OWNERS)|((^|/)OWNERS_ALIASES)|(\.md))$'
     decorate: true
@@ -1186,7 +1144,7 @@ presubmits:
         env:
         - name: IS_CONTAINER
           value: "TRUE"
-        image: docker.io/golang:1.21
+        image: docker.io/golang:1.22
         imagePullPolicy: Always
   - name: generate
     branches:
@@ -1208,21 +1166,6 @@ presubmits:
   - name: unit
     branches:
     - main
-    skip_if_only_changed: '(((^|/)OWNERS)|((^|/)OWNERS_ALIASES)|(\.md))$'
-    decorate: true
-    spec:
-      containers:
-      - args:
-        - ./hack/unit.sh
-        command:
-        - sh
-        env:
-        - name: IS_CONTAINER
-          value: "TRUE"
-        image: docker.io/golang:1.22
-        imagePullPolicy: Always
-  - name: unit
-    branches:
     - release-1.7
     skip_if_only_changed: '(((^|/)OWNERS)|((^|/)OWNERS_ALIASES)|(\.md))$'
     decorate: true
@@ -1235,7 +1178,7 @@ presubmits:
         env:
         - name: IS_CONTAINER
           value: "TRUE"
-        image: docker.io/golang:1.21
+        image: docker.io/golang:1.22
         imagePullPolicy: Always
   - name: unit
     branches:
@@ -1273,21 +1216,6 @@ presubmits:
   - name: build
     branches:
     - main
-    run_if_changed: "^api|^test|^Makefile$"
-    decorate: true
-    spec:
-      containers:
-      - args:
-        - ./hack/build.sh
-        command:
-        - sh
-        env:
-        - name: IS_CONTAINER
-          value: "TRUE"
-        image: docker.io/golang:1.22
-        imagePullPolicy: Always
-  - name: build
-    branches:
     - release-1.7
     run_if_changed: "^api|^test|^Makefile$"
     decorate: true
@@ -1300,7 +1228,7 @@ presubmits:
         env:
         - name: IS_CONTAINER
           value: "TRUE"
-        image: docker.io/golang:1.21
+        image: docker.io/golang:1.22
         imagePullPolicy: Always
   - name: build
     branches:


### PR DESCRIPTION
Go 1.21 is deprecating in August and 1.7 release is still supported in capm3 so bump the go version in testing to be able to get the capm3 PR in. 

It will say this is needed for the following PR: https://github.com/metal3-io/cluster-api-provider-metal3/pull/1852