### PR TITLE
Test bmo release 0.6 with golang 1.22

### DIFF
--- a/prow/manifests/overlays/metal3/config.yaml
+++ b/prow/manifests/overlays/metal3/config.yaml
@@ -382,21 +382,6 @@ presubmits:
   - name: gomod
     branches:
     - main
-    skip_if_only_changed: '(((^|/)OWNERS)|((^|/)OWNERS_ALIASES)|(\.md))$'
-    decorate: true
-    spec:
-      containers:
-      - args:
-        - ./hack/gomod.sh
-        command:
-        - sh
-        env:
-        - name: IS_CONTAINER
-          value: "TRUE"
-        image: quay.io/metal3-io/basic-checks:golang-1.22
-        imagePullPolicy: Always
-  - name: gomod
-    branches:
     - release-0.6
     skip_if_only_changed: '(((^|/)OWNERS)|((^|/)OWNERS_ALIASES)|(\.md))$'
     decorate: true
@@ -409,7 +394,7 @@ presubmits:
         env:
         - name: IS_CONTAINER
           value: "TRUE"
-        image: docker.io/golang:1.21
+        image: quay.io/metal3-io/basic-checks:golang-1.22
         imagePullPolicy: Always
   - name: gomod
     branches:
@@ -503,29 +488,6 @@ presubmits:
   - name: generate
     branches:
     - main
-    skip_if_only_changed: '(((^|/)OWNERS)|((^|/)OWNERS_ALIASES)|(\.md))$'
-    decorate: true
-    spec:
-      containers:
-      - args:
-        - ./hack/generate.sh
-        command:
-        - sh
-        env:
-        - name: IS_CONTAINER
-          value: "TRUE"
-        - name: DEPLOY_KERNEL_URL
-          value: "http://172.22.0.1/images/ironic-python-agent.kernel"
-        - name: DEPLOY_RAMDISK_URL
-          value: "http://172.22.0.1/images/ironic-python-agent.initramfs"
-        - name: IRONIC_ENDPOINT
-          value: "http://localhost:6385/v1/"
-        - name: IRONIC_INSPECTOR_ENDPOINT
-          value: "http://localhost:5050/v1/"
-        image: quay.io/metal3-io/basic-checks:golang-1.22
-        imagePullPolicy: Always
-  - name: generate
-    branches:
     - release-0.6
     skip_if_only_changed: '(((^|/)OWNERS)|((^|/)OWNERS_ALIASES)|(\.md))$'
     decorate: true
@@ -546,7 +508,7 @@ presubmits:
           value: "http://localhost:6385/v1/"
         - name: IRONIC_INSPECTOR_ENDPOINT
           value: "http://localhost:5050/v1/"
-        image: docker.io/golang:1.21
+        image: quay.io/metal3-io/basic-checks:golang-1.22
         imagePullPolicy: Always
   - name: generate
     branches:
@@ -593,18 +555,6 @@ presubmits:
   - name: test
     branches:
     - main
-    run_if_changed: "^(Makefile|hack/.*)$"
-    decorate: true
-    spec:
-      containers:
-      - args:
-        - test
-        command:
-        - make
-        image: quay.io/metal3-io/basic-checks:golang-1.22
-        imagePullPolicy: Always
-  - name: test
-    branches:
     - release-0.6
     run_if_changed: "^(Makefile|hack/.*)$"
     decorate: true
@@ -614,7 +564,7 @@ presubmits:
         - test
         command:
         - make
-        image: docker.io/golang:1.21
+        image: quay.io/metal3-io/basic-checks:golang-1.22
         imagePullPolicy: Always
   - name: test
     branches:


### PR DESCRIPTION
Since golang 1.21 is deprecating in August 2024

Needed for this PR in BMO: https://github.com/metal3-io/baremetal-operator/pull/1824