### PR TITLE
Test capm3 release 1.6 with golang 1.22

### DIFF
--- a/prow/manifests/overlays/metal3/config.yaml
+++ b/prow/manifests/overlays/metal3/config.yaml
@@ -1022,6 +1022,7 @@ presubmits:
     branches:
     - main
     - release-1.7
+    - release-1.6
     skip_if_only_changed: '(((^|/)OWNERS)|((^|/)OWNERS_ALIASES)|(\.md))$'
     decorate: true
     spec:
@@ -1037,7 +1038,6 @@ presubmits:
         imagePullPolicy: Always
   - name: gomod
     branches:
-    - release-1.6
     - release-1.5
     skip_if_only_changed: '(((^|/)OWNERS)|((^|/)OWNERS_ALIASES)|(\.md))$'
     decorate: true
@@ -1057,6 +1057,7 @@ presubmits:
     branches:
     - main
     - release-1.7
+    - release-1.6
     run_if_changed: "^(Makefile|hack/.*)$"
     decorate: true
     spec:
@@ -1069,7 +1070,6 @@ presubmits:
         imagePullPolicy: Always
   - name: test
     branches:
-    - release-1.6
     - release-1.5
     run_if_changed: "^(Makefile|hack/.*)$"
     decorate: true
@@ -1133,6 +1133,7 @@ presubmits:
     branches:
     - main
     - release-1.7
+    - release-1.6
     skip_if_only_changed: '(((^|/)OWNERS)|((^|/)OWNERS_ALIASES)|(\.md))$'
     decorate: true
     spec:
@@ -1148,7 +1149,6 @@ presubmits:
         imagePullPolicy: Always
   - name: generate
     branches:
-    - release-1.6
     - release-1.5
     skip_if_only_changed: '(((^|/)OWNERS)|((^|/)OWNERS_ALIASES)|(\.md))$'
     decorate: true
@@ -1167,6 +1167,7 @@ presubmits:
     branches:
     - main
     - release-1.7
+    - release-1.6
     skip_if_only_changed: '(((^|/)OWNERS)|((^|/)OWNERS_ALIASES)|(\.md))$'
     decorate: true
     spec:
@@ -1182,7 +1183,6 @@ presubmits:
         imagePullPolicy: Always
   - name: unit
     branches:
-    - release-1.6
     - release-1.5
     skip_if_only_changed: '(((^|/)OWNERS)|((^|/)OWNERS_ALIASES)|(\.md))$'
     decorate: true
@@ -1217,6 +1217,7 @@ presubmits:
     branches:
     - main
     - release-1.7
+    - release-1.6
     run_if_changed: "^api|^test|^Makefile$"
     decorate: true
     spec:
@@ -1232,7 +1233,6 @@ presubmits:
         imagePullPolicy: Always
   - name: build
     branches:
-    - release-1.6
     - release-1.5
     run_if_changed: "^api|^test|^Makefile$"
     decorate: true


### PR DESCRIPTION
Since golang 1.20 is already deprecated

This is needed for PR: https://github.com/metal3-io/cluster-api-provider-metal3/pull/1858