### PR TITLE
:seedling: Change image-building pipeline to a matrix

### DIFF
--- a/jenkins/image_building/build-image.sh
+++ b/jenkins/image_building/build-image.sh
@@ -7,7 +7,6 @@ REPO_ROOT="$(realpath "${current_dir}/../..")"
 
 cleanup() {
   deactivate || true
-  sudo rm -f "${REPO_ROOT}/${img_name}".{raw,qcow2}
   sudo rm -rf "${REPO_ROOT}/${img_name}.d"
   sudo rm -rf "${current_dir}/dib"
 }
@@ -22,10 +21,6 @@ export IMAGE_TYPE="${IMAGE_TYPE}"
 
 # shellcheck disable=SC1091
 source "${current_dir}/upload-ci-image.sh"
-# shellcheck disable=SC1091
-source "${current_dir}/upload-node-image.sh"
-# shellcheck disable=SC1091
-source "${current_dir}/verify-node-image.sh"
 
 # Disable needrestart interactive mode
 sudo sed -i "s/^#\$nrconf{restart} = 'i';/\$nrconf{restart} = 'a';/" /etc/needrestart/needrestart.conf > /dev/null || true
@@ -79,11 +74,8 @@ export HOSTNAME="${img_name}"
 
 disk-image-create --no-tmpfs -a amd64 -o "${img_name}".qcow2 "${IMAGE_OS}"-"${IMAGE_TYPE}" block-device-efi
 
-
 if [[ "${IMAGE_TYPE}" == "node" ]]; then
-  verify_node_image "${img_name}" "${REPO_ROOT}"
-  echo "Image testing successful."
-  upload_node_image "${img_name}"
+  echo "${img_name}" > "${REPO_ROOT}/image_name.txt"
 else
   upload_ci_image_cleura "${img_name}"
   upload_ci_image_xerces "${img_name}"

--- a/jenkins/image_building/upload-node-image.sh
+++ b/jenkins/image_building/upload-node-image.sh
@@ -68,3 +68,8 @@ upload_node_image() {
         echo "${MAPFILE[i]} has been deleted!"
     done
 }
+
+# If the script was run directly (i.e. not sourced), run the upload_node_image func
+if [[ "${BASH_SOURCE[0]}" == "${0}" ]]; then
+    upload_node_image "$@"
+fi

--- a/jenkins/image_building/verify-node-image.sh
+++ b/jenkins/image_building/verify-node-image.sh
@@ -4,15 +4,16 @@ set -eux
 
 verify_node_image() {
     current_dir="$(dirname "$(readlink -f "${0}")")"
+    REPO_ROOT="$(realpath "${current_dir}/../..")"
 
     img_name="$1"
-    IMAGE_DIR="${2:-"$current_dir"}"
+    IMAGE_DIR="${2:-"${REPO_ROOT}"}"
 
     # So that no extra components are built later
     export IMAGE_TESTING="true"
 
     # Run "make clean" after test, so that next job can start from clean state
-    export CLEANUP_AFTERWARDS="true"
+    export CLEANUP_AFTERWARDS="${CLEANUP_AFTERWARDS:-false}"
 
     # Tests expect the image name to have the file type extension 
     export IMAGE_NAME="${img_name}.qcow2"
@@ -32,3 +33,8 @@ verify_node_image() {
 
     "${current_dir}/../scripts/dynamic_worker_workflow/dev_env_integration_tests.sh"
 }
+
+# If the script was run directly (i.e. not sourced), run the verify_node_image func
+if [[ "${BASH_SOURCE[0]}" == "${0}" ]]; then
+    verify_node_image "$@"
+fi

--- a/jenkins/jobs/image_building.pipeline
+++ b/jenkins/jobs/image_building.pipeline
@@ -3,8 +3,7 @@ ci_git_branch = "main"
 ci_git_url = "https://github.com/metal3-io/project-infra.git"
 
 pipeline {
-  agent { label 'metal3ci-jenkins' }
-  options { ansiColor('xterm') }
+  agent none
   environment {
     IMAGE_TYPE = "${IMAGE_TYPE}"
     METAL3_CI_USER="metal3ci"
@@ -15,61 +14,84 @@ pipeline {
   }
   stages {
     stage('SCM') {
-      options {
-        timeout(time: 5, unit: 'MINUTES')
-      }
-      steps {
-        /* Checkout CI Repo */
-        checkout([$class: 'GitSCM',
-                 branches: [[name: ci_git_branch]],
-                 doGenerateSubmoduleConfigurations: false,
-                 extensions: [[$class: 'WipeWorkspace'],
-                 [$class: 'CleanCheckout'],
-                 [$class: 'CleanBeforeCheckout']],
-                 submoduleCfg: [],
-                 userRemoteConfigs: [[credentialsId: ci_git_credential_id,
-                 url: ci_git_url]]])
-        script {
-          CURRENT_START_TIME = System.currentTimeMillis()
-        }
-      }
-    }
-    stage('Build Ubuntu CI image') {
-      options {
-        timeout(time: 3, unit: 'HOURS')
-      }
-      environment {
-        IMAGE_OS = "ubuntu"
-      }
-      steps {
-        echo 'Building Ubuntu CI image'
-        withCredentials([
-          usernamePassword(credentialsId: 'xerces-est-metal3ci', usernameVariable: 'OPENSTACK_USERNAME_XERCES', passwordVariable: 'OPENSTACK_PASSWORD_XERCES'),
-          usernamePassword(credentialsId: 'metal3ci_city_cloud_openstack_credentials', usernameVariable: 'OPENSTACK_USERNAME_CLEURA', passwordVariable: 'OPENSTACK_PASSWORD_CLEURA'),
-          usernamePassword(credentialsId: 'infra-nordix-artifactory-api-key', usernameVariable: 'RT_USER', passwordVariable: 'RT_TOKEN')
-        ]) {
-          catchError([stageResult: 'FAILURE', message: "Failed to build Ubuntu CI image"]) {
-            sh "./jenkins/image_building/build-image.sh"
+      matrix {
+        agent { label "metal3ci-jenkins" }
+        options { ansiColor('xterm') }
+        axes {
+          axis {
+            name 'IMAGE_OS'
+            values 'ubuntu', 'centos'
           }
         }
-      }
-    }
-    stage('Building Centos CI image'){
-      options {
-        timeout(time: 3, unit: 'HOURS')
-      }
-      environment {
-        IMAGE_OS = "centos"
-      }
-      steps {
-        echo 'Building Centos CI image'
-        withCredentials([
-          usernamePassword(credentialsId: 'xerces-est-metal3ci', usernameVariable: 'OPENSTACK_USERNAME_XERCES', passwordVariable: 'OPENSTACK_PASSWORD_XERCES'),
-          usernamePassword(credentialsId: 'metal3ci_city_cloud_openstack_credentials', usernameVariable: 'OPENSTACK_USERNAME_CLEURA', passwordVariable: 'OPENSTACK_PASSWORD_CLEURA'),
-          usernamePassword(credentialsId: 'infra-nordix-artifactory-api-key', usernameVariable: 'RT_USER', passwordVariable: 'RT_TOKEN')
-        ]) {
-          catchError([stageResult: 'FAILURE', message: "Failed to build Centos CI image"]) {
-            sh "./jenkins/image_building/build-image.sh"
+        environment {
+          IMAGE_OS = "${IMAGE_OS}"
+        }
+        stages {
+          stage("Checkout CI Repo") {
+            options {
+              timeout(time: 5, unit: 'MINUTES')
+            }
+            steps {
+              checkout([$class: 'GitSCM',
+                       branches: [[name: ci_git_branch]],
+                       doGenerateSubmoduleConfigurations: false,
+                       extensions: [[$class: 'WipeWorkspace'],
+                       [$class: 'CleanCheckout'],
+                       [$class: 'CleanBeforeCheckout']],
+                       submoduleCfg: [],
+                       userRemoteConfigs: [[credentialsId: ci_git_credential_id,
+                       url: ci_git_url]]])
+            }
+          }
+          stage("Build CI image") {
+            options {
+              timeout(time: 1, unit: 'HOURS')
+            }
+            steps {
+              echo "Building ${IMAGE_OS} CI image"
+              script {
+                sh """
+                ./jenkins/image_building/build-image.sh
+                """
+              }
+            }
+          }
+          stage("Verify the new CI image") {
+            options {
+              timeout(time: 3, unit: 'HOURS')
+            }
+            steps {
+              echo "Testing new ${IMAGE_OS} CI image"
+              script {
+                def imageName = readFile("image_name.txt").trim()
+
+                sh """
+                echo "Testing ${imageName}"
+                ./jenkins/image_building/verify-node-image.sh ${imageName}
+                """
+              }
+            }
+          }
+          stage("Upload the new CI Image") {
+            options {
+              timeout(time: 30, unit: 'MINUTES')
+            }
+            steps {
+              withCredentials([
+                usernamePassword(credentialsId: 'xerces-est-metal3ci', usernameVariable: 'OPENSTACK_USERNAME_XERCES', passwordVariable: 'OPENSTACK_PASSWORD_XERCES'),
+                usernamePassword(credentialsId: 'metal3ci_city_cloud_openstack_credentials', usernameVariable: 'OPENSTACK_USERNAME_CLEURA', passwordVariable: 'OPENSTACK_PASSWORD_CLEURA'),
+                usernamePassword(credentialsId: 'infra-nordix-artifactory-api-key', usernameVariable: 'RT_USER', passwordVariable: 'RT_TOKEN')
+              ]) {
+                script {
+                  def imageName = readFile("image_name.txt").trim()
+
+                  sh """
+                  echo "Uploading ${imageName}"
+                  ./jenkins/image_building/upload-node-image.sh ${imageName}
+                  """
+                }
+              }
+            }
           }
         }
       }

--- a/jenkins/scripts/dynamic_worker_workflow/dev_env_integration_tests.sh
+++ b/jenkins/scripts/dynamic_worker_workflow/dev_env_integration_tests.sh
@@ -84,6 +84,7 @@ echo "Running the tests"
 
 cleanup() {
     if [[ "${CLEANUP_AFTERWARDS:-}" == "true" ]]; then
+        echo "Cleaning up the environment"
         make clean
     fi
 }


### PR DESCRIPTION
This is to split ubuntu and centos image building into separate VMs and have proper indication for each step results in Jenkins UI.