### PR TITLE
🌱 Fix Calico CrashLoopBackOff in ubuntu e2e tests

### DIFF
--- a/jenkins/image_building/dib_elements/ubuntu-node/post-install.d/90-pre-pull-images
+++ b/jenkins/image_building/dib_elements/ubuntu-node/post-install.d/90-pre-pull-images
@@ -1,10 +1,9 @@
 #!/usr/bin/env bash
 
 set -eux
-
 export USERDATA_HOSTNAME=${HOSTNAME:-"metal3node-test"}
 
-sudo sed -i "/^127.0.0.1/c\127.0.0.1 ${USERDATA_HOSTNAME}" /etc/hosts
+sudo sed -i "/^127.0.0.1/ s/$/ ${USERDATA_HOSTNAME}/" /etc/hosts
 sudo sed -i "s/MACAddressPolicy=persistent/MACAddressPolicy=none/g" /usr/lib/systemd/network/99-default.link
 
 for container in $(env | grep "CALICO_*" | cut -f2 -d'='); do


### PR DESCRIPTION
In Ubuntu e2e tests calico-node pods are stuck in `CrashLoopBackOff` because of missing `localhost` in `/etc/hosts` file this PR is fixing it.


calico-node error:
`kubelet  Liveness probe failed: calico/node is not ready: Felix is not live: Get "http://localhost:9099/liveness": dial tcp: lookup localhost on 8.8.8.8:53: no such host`