### PR TITLE
Uplift kubernetes version to v1.31.0 for image building

### DIFF
--- a/jenkins/image_building/build-image.sh
+++ b/jenkins/image_building/build-image.sh
@@ -65,9 +65,9 @@ fi
 if [[ "${IMAGE_TYPE}" == "node" ]]; then
   # The default data source for cloud-init element is exclusively Amazon EC2
   export DIB_CLOUD_INIT_DATASOURCES="ConfigDrive"
-  export KUBERNETES_VERSION="${KUBERNETES_VERSION:-"v1.30.0"}"
-  export CRIO_VERSION="${CRIO_VERSION:-"v1.30.0"}"
-  export CRICTL_VERSION="${CRICTL_VERSION-"v1.30.0"}"
+  export KUBERNETES_VERSION="${KUBERNETES_VERSION:-"v1.31.0"}"
+  export CRIO_VERSION="${CRIO_VERSION:-"v1.30.4"}"
+  export CRICTL_VERSION="${CRICTL_VERSION-"v1.31.1"}"
   img_name="${IMAGE_OS^^}_${numeric_release}_NODE_IMAGE_K8S_${KUBERNETES_VERSION}"
 else
   commit_short="$(git rev-parse --short HEAD)"


### PR DESCRIPTION
Uplifts Uplift kubernetes version to v1.31.0 for image building. Also uplifts crio and crictl

Part of: https://github.com/metal3-io/cluster-api-provider-metal3/issues/1887