### PR TITLE
Update prow config to match jenkins pipelines

### DIFF
--- a/prow/manifests/overlays/metal3/config.yaml
+++ b/prow/manifests/overlays/metal3/config.yaml
@@ -834,37 +834,13 @@ presubmits:
     always_run: false
     optional: true
   # name: {job_prefix}-e2e-{k8s_versions}-upgrade-test-{capm3_target_branch}
-  - name: metal3-e2e-1-28-1-29-upgrade-test-main
+  - name: metal3-e2e-1-29-1-30-upgrade-test-main
     branches:
     - main
     agent: jenkins
     always_run: false
     optional: true
-  - name: metal3-e2e-1-27-1-28-upgrade-test-main
-    branches:
-    - main
-    agent: jenkins
-    always_run: false
-    optional: true
-  - name: metal3-e2e-1-26-1-27-upgrade-test-main
-    branches:
-    - main
-    agent: jenkins
-    always_run: false
-    optional: true
-  - name: metal3-e2e-1-28-1-29-upgrade-test-release-1-7
-    branches:
-    - release-0.6
-    agent: jenkins
-    always_run: false
-    optional: true
-  - name: metal3-e2e-1-27-1-28-upgrade-test-release-1-7
-    branches:
-    - release-0.6
-    agent: jenkins
-    always_run: false
-    optional: true
-  - name: metal3-e2e-1-26-1-27-upgrade-test-release-1-7
+  - name: metal3-e2e-1-29-1-30-upgrade-test-release-1-7
     branches:
     - release-0.6
     agent: jenkins
@@ -873,30 +849,6 @@ presubmits:
   - name: metal3-e2e-1-28-1-29-upgrade-test-release-1-6
     branches:
     - release-0.5
-    agent: jenkins
-    always_run: false
-    optional: true
-  - name: metal3-e2e-1-27-1-28-upgrade-test-release-1-6
-    branches:
-    - release-0.5
-    agent: jenkins
-    always_run: false
-    optional: true
-  - name: metal3-e2e-1-26-1-27-upgrade-test-release-1-6
-    branches:
-    - release-0.5
-    agent: jenkins
-    always_run: false
-    optional: true
-  - name: metal3-e2e-1-28-1-29-upgrade-test-release-1-5
-    branches:
-    - release-0.4
-    agent: jenkins
-    always_run: false
-    optional: true
-  - name: metal3-e2e-1-27-1-28-upgrade-test-release-1-5
-    branches:
-    - release-0.4
     agent: jenkins
     always_run: false
     optional: true
@@ -1436,37 +1388,13 @@ presubmits:
     always_run: false
     optional: true
   # name: {job_prefix}-e2e-{k8s_versions}-upgrade-test-{capm3_target_branch}
-  - name: metal3-e2e-1-28-1-29-upgrade-test-main
+  - name: metal3-e2e-1-29-1-30-upgrade-test-main
     branches:
     - main
     agent: jenkins
     always_run: false
     optional: true
-  - name: metal3-e2e-1-27-1-28-upgrade-test-main
-    branches:
-    - main
-    agent: jenkins
-    always_run: false
-    optional: true
-  - name: metal3-e2e-1-26-1-27-upgrade-test-main
-    branches:
-    - main
-    agent: jenkins
-    always_run: false
-    optional: true
-  - name: metal3-e2e-1-28-1-29-upgrade-test-release-1-7
-    branches:
-    - release-1.7
-    agent: jenkins
-    always_run: false
-    optional: true
-  - name: metal3-e2e-1-27-1-28-upgrade-test-release-1-7
-    branches:
-    - release-1.7
-    agent: jenkins
-    always_run: false
-    optional: true
-  - name: metal3-e2e-1-26-1-27-upgrade-test-release-1-7
+  - name: metal3-e2e-1-29-1-30-upgrade-test-release-1-7
     branches:
     - release-1.7
     agent: jenkins
@@ -1475,30 +1403,6 @@ presubmits:
   - name: metal3-e2e-1-28-1-29-upgrade-test-release-1-6
     branches:
     - release-1.6
-    agent: jenkins
-    always_run: false
-    optional: true
-  - name: metal3-e2e-1-27-1-28-upgrade-test-release-1-6
-    branches:
-    - release-1.6
-    agent: jenkins
-    always_run: false
-    optional: true
-  - name: metal3-e2e-1-26-1-27-upgrade-test-release-1-6
-    branches:
-    - release-1.6
-    agent: jenkins
-    always_run: false
-    optional: true
-  - name: metal3-e2e-1-28-1-29-upgrade-test-release-1-5
-    branches:
-    - release-1.5
-    agent: jenkins
-    always_run: false
-    optional: true
-  - name: metal3-e2e-1-27-1-28-upgrade-test-release-1-5
-    branches:
-    - release-1.5
     agent: jenkins
     always_run: false
     optional: true
@@ -1737,47 +1641,15 @@ presubmits:
     always_run: false
     optional: true
   # name: {job_prefix}-e2e-{k8s_versions}-upgrade-test-{capm3_target_branch}
-  - name: metal3-e2e-1-28-1-29-upgrade-test-main
+  - name: metal3-e2e-1-29-1-30-upgrade-test-main
     agent: jenkins
     always_run: false
     optional: true
-  - name: metal3-e2e-1-27-1-28-upgrade-test-main
-    agent: jenkins
-    always_run: false
-    optional: true
-  - name: metal3-e2e-1-26-1-27-upgrade-test-main
-    agent: jenkins
-    always_run: false
-    optional: true
-  - name: metal3-e2e-1-28-1-29-upgrade-test-release-1-7
-    agent: jenkins
-    always_run: false
-    optional: true
-  - name: metal3-e2e-1-27-1-28-upgrade-test-release-1-7
-    agent: jenkins
-    always_run: false
-    optional: true
-  - name: metal3-e2e-1-26-1-27-upgrade-test-release-1-7
+  - name: metal3-e2e-1-29-1-30-upgrade-test-release-1-7
     agent: jenkins
     always_run: false
     optional: true
   - name: metal3-e2e-1-28-1-29-upgrade-test-release-1-6
-    agent: jenkins
-    always_run: false
-    optional: true
-  - name: metal3-e2e-1-27-1-28-upgrade-test-release-1-6
-    agent: jenkins
-    always_run: false
-    optional: true
-  - name: metal3-e2e-1-26-1-27-upgrade-test-release-1-6
-    agent: jenkins
-    always_run: false
-    optional: true
-  - name: metal3-e2e-1-28-1-29-upgrade-test-release-1-5
-    agent: jenkins
-    always_run: false
-    optional: true
-  - name: metal3-e2e-1-27-1-28-upgrade-test-release-1-5
     agent: jenkins
     always_run: false
     optional: true
@@ -2038,47 +1910,15 @@ presubmits:
     always_run: false
     optional: true
   # name: {job_prefix}-e2e-{k8s_versions}-upgrade-test-{capm3_target_branch}
-  - name: metal3-e2e-1-28-1-29-upgrade-test-main
+  - name: metal3-e2e-1-29-1-30-upgrade-test-main
     agent: jenkins
     always_run: false
     optional: true
-  - name: metal3-e2e-1-27-1-28-upgrade-test-main
-    agent: jenkins
-    always_run: false
-    optional: true
-  - name: metal3-e2e-1-26-1-27-upgrade-test-main
-    agent: jenkins
-    always_run: false
-    optional: true
-  - name: metal3-e2e-1-28-1-29-upgrade-test-release-1-7
-    agent: jenkins
-    always_run: false
-    optional: true
-  - name: metal3-e2e-1-27-1-28-upgrade-test-release-1-7
-    agent: jenkins
-    always_run: false
-    optional: true
-  - name: metal3-e2e-1-26-1-27-upgrade-test-release-1-7
+  - name: metal3-e2e-1-29-1-30-upgrade-test-release-1-7
     agent: jenkins
     always_run: false
     optional: true
   - name: metal3-e2e-1-28-1-29-upgrade-test-release-1-6
-    agent: jenkins
-    always_run: false
-    optional: true
-  - name: metal3-e2e-1-27-1-28-upgrade-test-release-1-6
-    agent: jenkins
-    always_run: false
-    optional: true
-  - name: metal3-e2e-1-26-1-27-upgrade-test-release-1-6
-    agent: jenkins
-    always_run: false
-    optional: true
-  - name: metal3-e2e-1-28-1-29-upgrade-test-release-1-5
-    agent: jenkins
-    always_run: false
-    optional: true
-  - name: metal3-e2e-1-27-1-28-upgrade-test-release-1-5
     agent: jenkins
     always_run: false
     optional: true
@@ -2613,37 +2453,13 @@ presubmits:
     always_run: false
     optional: true
   # name: {job_prefix}-e2e-{k8s_versions}-upgrade-test-{capm3_target_branch}
-  - name: metal3-e2e-1-28-1-29-upgrade-test-main
+  - name: metal3-e2e-1-29-1-30-upgrade-test-main
     branches:
     - main
     agent: jenkins
     always_run: false
     optional: true
-  - name: metal3-e2e-1-27-1-28-upgrade-test-main
-    branches:
-    - main
-    agent: jenkins
-    always_run: false
-    optional: true
-  - name: metal3-e2e-1-26-1-27-upgrade-test-main
-    branches:
-    - main
-    agent: jenkins
-    always_run: false
-    optional: true
-  - name: metal3-e2e-1-28-1-29-upgrade-test-release-1-7
-    branches:
-    - release-1.7
-    agent: jenkins
-    always_run: false
-    optional: true
-  - name: metal3-e2e-1-27-1-28-upgrade-test-release-1-7
-    branches:
-    - release-1.7
-    agent: jenkins
-    always_run: false
-    optional: true
-  - name: metal3-e2e-1-26-1-27-upgrade-test-release-1-7
+  - name: metal3-e2e-1-29-1-30-upgrade-test-release-1-7
     branches:
     - release-1.7
     agent: jenkins
@@ -2652,30 +2468,6 @@ presubmits:
   - name: metal3-e2e-1-28-1-29-upgrade-test-release-1-6
     branches:
     - release-1.6
-    agent: jenkins
-    always_run: false
-    optional: true
-  - name: metal3-e2e-1-27-1-28-upgrade-test-release-1-6
-    branches:
-    - release-1.6
-    agent: jenkins
-    always_run: false
-    optional: true
-  - name: metal3-e2e-1-26-1-27-upgrade-test-release-1-6
-    branches:
-    - release-1.6
-    agent: jenkins
-    always_run: false
-    optional: true
-  - name: metal3-e2e-1-28-1-29-upgrade-test-release-1-5
-    branches:
-    - release-1.5
-    agent: jenkins
-    always_run: false
-    optional: true
-  - name: metal3-e2e-1-27-1-28-upgrade-test-release-1-5
-    branches:
-    - release-1.5
     agent: jenkins
     always_run: false
     optional: true


### PR DESCRIPTION
In Jenkins it was decided that only one upgrade pipeline is kept per branch. This change was not done for prow config this causes a mismatch in configs and prow promotes people to run jobs that do not exist.

Fixes: #837