### PR TITLE
:seedling: Adapt ci-image wf to image-build pipeline

### DIFF
--- a/jenkins/image_building/build-image.sh
+++ b/jenkins/image_building/build-image.sh
@@ -63,9 +63,4 @@ export HOSTNAME="${img_name}"
 
 disk-image-create --no-tmpfs -a amd64 -o "${img_name}".qcow2 "${IMAGE_OS}"-"${IMAGE_TYPE}" block-device-efi
 
-if [[ "${IMAGE_TYPE}" == "node" ]]; then
-  echo "${img_name}" > "${REPO_ROOT}/image_name.txt"
-else
-  upload_ci_image_cleura "${img_name}"
-  upload_ci_image_xerces "${img_name}"
-fi
+echo "${img_name}" > "${REPO_ROOT}/image_name.txt"

--- a/jenkins/image_building/upload-ci-image.sh
+++ b/jenkins/image_building/upload-ci-image.sh
@@ -22,6 +22,15 @@ delete_old_images() {
   done
 }
 
+install_openstack_client() {
+  rm -rf venv
+  python3 -m venv venv
+
+  # shellcheck source=/dev/null
+  . venv/bin/activate
+  pip install python-openstackclient==7.0.0
+}
+
 upload_ci_image_cleura() {
 
   img_name="$1"
@@ -75,3 +84,10 @@ upload_ci_image_xerces() {
   #unset openstack variables
   unset "${!OS_@}"
 }
+
+# If the script was run directly (i.e. not sourced), run both of the upload functions
+if [[ "${BASH_SOURCE[0]}" == "${0}" ]]; then
+    install_openstack_client
+    upload_ci_image_cleura "$@"
+    upload_ci_image_xerces "$@"
+fi

--- a/jenkins/jobs/image_building.pipeline
+++ b/jenkins/jobs/image_building.pipeline
@@ -56,9 +56,12 @@ pipeline {
               }
             }
           }
-          stage("Verify the new CI image") {
+          stage("Verify the new node image") {
             options {
               timeout(time: 3, unit: 'HOURS')
+            }
+            when {
+              expression { env.IMAGE_TYPE == 'node' }
             }
             steps {
               echo "Testing new ${IMAGE_OS} CI image"
@@ -72,7 +75,7 @@ pipeline {
               }
             }
           }
-          stage("Upload the new CI Image") {
+          stage("Upload the new Image") {
             options {
               timeout(time: 30, unit: 'MINUTES')
             }
@@ -84,11 +87,17 @@ pipeline {
               ]) {
                 script {
                   def imageName = readFile("image_name.txt").trim()
-
-                  sh """
                   echo "Uploading ${imageName}"
-                  ./jenkins/image_building/upload-node-image.sh ${imageName}
-                  """
+
+                  if (env.IMAGE_TYPE == 'node') {
+                    sh """
+                    ./jenkins/image_building/upload-node-image.sh ${imageName}
+                    """
+                  } else {
+                    sh """
+                    ./jenkins/image_building/upload-ci-image.sh ${imageName}
+                    """
+                  }
                 }
               }
             }


### PR DESCRIPTION
In node image build, we have changed the pipeline so that building and uploading images happen in different jenkins stages. This PR updates the ci-image build, which also uses the same pipeline, to that schema.

This change was tested on:
https://jenkins.nordix.org/blue/organizations/jenkins/metal3_periodic_ci_image_building/detail/metal3_periodic_ci_image_building/59/pipeline/

and

https://jenkins.nordix.org/blue/organizations/jenkins/metal3_periodic_node_image_building/detail/metal3_periodic_node_image_building/79/pipeline/93/