### PR TITLE
Move image building jobs to private cloud

### DIFF
--- a/jenkins/jobs/image_building.pipeline
+++ b/jenkins/jobs/image_building.pipeline
@@ -15,7 +15,7 @@ pipeline {
   stages {
     stage('SCM') {
       matrix {
-        agent { label "metal3ci-jenkins" }
+        agent { label "metal3ci-8c16gb-ubuntu" }
         options { ansiColor('xterm') }
         axes {
           axis {


### PR DESCRIPTION
This PR moves image building jobs to private cloud by changing jenkins worker label. 

Tested here:
Node image building https://jenkins.nordix.org/view/Metal3%20Periodic/job/metal3_periodic_node_image_building/84/
CI image building https://jenkins.nordix.org/view/Metal3%20Periodic/job/metal3_periodic_ci_image_building/62/