### PR TITLE
Move k8s upgrade and e2e other feature tests to private cloud

### DIFF
--- a/jenkins/jobs/capm3-e2e-tests.pipeline
+++ b/jenkins/jobs/capm3-e2e-tests.pipeline
@@ -21,9 +21,12 @@ script {
   }
     echo "Checkout ${ci_git_url} branch ${ci_git_branch}"
 
-  if  ("${GINKGO_FOCUS}" == 'integration' || "${GINKGO_FOCUS}" == 'basic') {
+  if  ( "${GINKGO_FOCUS}" == 'integration' || "${GINKGO_FOCUS}" == 'basic' ) {
     agent_label = "metal3ci-8c16gb-${IMAGE_OS}"
     TIMEOUT=10800 // 3h
+  } else if ( "${GINKGO_FOCUS}" == 'k8s-upgrade' ) {
+    agent_label = "metal3ci-8c24gb-${IMAGE_OS}"
+    TIMEOUT=14400 // 4h
   } else if ( "${env.EPHEMERAL_TEST}" == 'true' ) {
     TIMEOUT=18000 // 5h
     agent_label = "metal3ci-large-${IMAGE_OS}"

--- a/jenkins/jobs/e2e_features_test.pipeline
+++ b/jenkins/jobs/e2e_features_test.pipeline
@@ -25,14 +25,16 @@ script {
   if ("${GINKGO_FOCUS}" == 'pivoting') {
     BUILD_TAG = "${env.BUILD_TAG}-pivoting-based"
     TIMEOUT = 18000 // 5h for node reuse
+    agent_label="metal3ci-large-${IMAGE_OS}"
   } else if ("${GINKGO_FOCUS}" == 'remediation') {
     BUILD_TAG = "${env.BUILD_TAG}-remediation-based"
     TIMEOUT = 18000 // 5h for remediation
+    agent_label="metal3ci-large-${IMAGE_OS}"
   } else {
     BUILD_TAG = "${env.BUILD_TAG}-other-features"
     GINKGO_SKIP = "pivoting remediation" // Allow non pivoting features
+    agent_label="metal3ci-8c24gb-${IMAGE_OS}"
   }
-  agent_label="metal3ci-large-${IMAGE_OS}"
 }
 
 pipeline {


### PR DESCRIPTION
This PR moves k8s upgrade and e2e other features(not including remediation and pivoting) tests to private cloud.

tested here:
k8s upgrade - https://jenkins.nordix.org/job/metal3-e2e-1-29-1-30-upgrade-test-release-1-7/8/
features https://jenkins.nordix.org/job/metal3-centos-e2e-feature-test-release-1-7-features/11