### PR TITLE
🌱 Bump ingress-nginx in prow to v1.10.4

### DIFF
--- a/prow/README.md
+++ b/prow/README.md
@@ -320,7 +320,7 @@ Now you are ready to create the files.
 
 For accessing an existing instance, you can simply get the relevant credentials
 and files from the password manager and put them in the correct places (see the
-section for generating secret files). Check the IP of the bastion in cleura and
+section for generating secret files). Check the IP of the bastion in xerces and
 set it in the environment variable `BASTION_FLOATING_IP`. After this you just
 need to set up a proxy for accessing the API through the bastion:
 

--- a/prow/infra/kustomization.yaml
+++ b/prow/infra/kustomization.yaml
@@ -1,7 +1,7 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
-- https://github.com/kubernetes/ingress-nginx/deploy/static/provider/cloud?ref=controller-v1.10.1
+- https://github.com/kubernetes/ingress-nginx/deploy/static/provider/cloud?ref=controller-v1.10.4
 - cluster-issuer-http.yaml
 - storageclass.yaml
 - ingress-controller-pdb.yaml

--- a/prow/manifests/overlays/metal3/kustomization.yaml
+++ b/prow/manifests/overlays/metal3/kustomization.yaml
@@ -14,9 +14,6 @@ resources:
 - pdb.yaml
 - limitrange.yaml
 
-commonLabels:
-  app.kubernetes.io/instance: metal3
-  app.kubernetes.io/part-of: prow
 
 # For some of the configmaps and secrets we could use suffix hash,
 # but some will be used directly by prow, which cannot know about
@@ -93,3 +90,8 @@ patches:
 - path: toleration-node-selector-patch.yaml
   target:
     kind: Deployment
+labels:
+- includeSelectors: true
+  pairs:
+    app.kubernetes.io/instance: metal3
+    app.kubernetes.io/part-of: prow


### PR DESCRIPTION
Bump Ingress-Nginx to v1.10.4 because of a severity CVE on v1.10.1

This PR also:
- Fix cloud reference in prow README
- Update prow overlays to new kustomize syntax.