### PR TITLE
add dependabot config for github actions bumps

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,15 @@
+# Please see the documentation for all configuration options:
+# https://docs.github.com/github/administering-a-repository/configuration-options-for-dependency-updates
+
+version: 2
+updates:
+## main branch config starts here
+- package-ecosystem: "github-actions"
+  directory: "/" # Location of package manifests
+  schedule:
+    interval: "monthly"
+    day: "thursday"
+  target-branch: main
+  labels:
+  - "ok-to-test"
+## main branch config ends here


### PR DESCRIPTION
We have now multiple reusable github actions hosted via project-infra so we also need Dependabot config to keep the up to date.