### PR TITLE
add missing dockerfile-directory for basic-checks

### DIFF
--- a/.github/workflows/build-images-action.yml
+++ b/.github/workflows/build-images-action.yml
@@ -19,6 +19,7 @@ jobs:
     with:
       image-name: 'basic-checks'
       image-tag: 'golang-1.22'
+      dockerfile-directory: 'prow/container-images/basic-checks'
       pushImage: true
     secrets:
       QUAY_USERNAME: ${{ secrets.QUAY_USERNAME }}


### PR DESCRIPTION
Add missing dockerfile-directory input for basic-checks image build, which was added in #865 