### PR TITLE
add reusable container build as trigger file path

### DIFF
--- a/.github/workflows/build-images-action.yml
+++ b/.github/workflows/build-images-action.yml
@@ -7,6 +7,7 @@ on:
     paths:
     - 'prow/container-images/**/Dockerfile'
     - '.github/workflows/build-images-action.yml'
+    - '.github/workflows/container-image-build.yml'
 
 permissions:
   contents: read


### PR DESCRIPTION
Add reusable container build file as trigger file path for the build-image-action.