### PR TITLE
fix IPA git commit/branch refference

### DIFF
--- a/jenkins/scripts/dynamic_worker_workflow/build_ipa.sh
+++ b/jenkins/scripts/dynamic_worker_workflow/build_ipa.sh
@@ -66,7 +66,7 @@ METADATA_PATH="/tmp/metadata.txt"
 
 sudo rm -rf "${IPA_BUILD_WORKSPACE}"
 # Update apt packages
-sudo apt-get update -y 
+sudo apt-get update -y
 
 # Install required packages
 sudo apt-get install --yes python3-pip python3-virtualenv qemu-utils
@@ -114,7 +114,8 @@ python3 -m pip install "./${IPA_BUILDER_PATH}"
 # Configure the IPA builder to pull the IPA source from Nordix fork
 export DIB_REPOLOCATION_ironic_python_agent="${IPA_BUILD_WORKSPACE}/ironic-python-agent"
 export DIB_REPOREF_requirements="${OPENSTACK_REQUIREMENTS_REF}"
-export DIB_REPOREF_ironic_python_agent="${IPA_REF}"
+export DIB_REPOREF_ironic_python_agent="${IPA_BRANCH}"
+export DIB_REPOLOCATION_ironic_python_agent="${IPA_REPO}"
 export DIB_DEV_USER_USERNAME=metal3
 if [ "${ENABLE_DEV_USER_PASS}" == "true" ]; then
 export DIB_DEV_USER_PWDLESS_SUDO=yes


### PR DESCRIPTION
This commit:
 - Fixes an icorrect value assignment for IPA repository refference This bug was causing the build tooling to not check out the specified IPA branch instead it was checking out the mian
 - Adds missing IPA repository address variable