### PR TITLE
extending the initrd_sdk

### DIFF
--- a/jenkins/image_building/initrd_sdk/README.md
+++ b/jenkins/image_building/initrd_sdk/README.md
@@ -21,3 +21,20 @@ dracut and the script relies on only two external tools `blkid` and
 `systemd-cryptsetup`. If an image was built with `dracut` and the `dracut`
 module `crypt` is enabled then both `blkid` and `systemd-cryptsetup` should be
 present in the initrd environment.
+
+## unseal-and-open-luks.service
+
+This is the systemd service unit file that automatically starts the
+`unlock-mount-luks.sh`. This service has to be enabled with `systemctl enable`
+during or after the initrd build process.
+
+## verify-realroot.sh
+
+This script is used to provide a controlled wait loop in order to give time
+to other systemd services to prepare the root file system. The intention is to
+have a deterministic check/wait loop before the initrd root switching is
+initiated in order to avoid potential race conditions.
+
+This script has to be executed by the `initrd-sitch-root.service` as a
+`ExecStartPre` option such as:
+`ExecStartPre=/bin/sh -c '/etc/verify-realroot.sh'`

--- a/jenkins/image_building/initrd_sdk/unseal-and-open-luks.service
+++ b/jenkins/image_building/initrd_sdk/unseal-and-open-luks.service
@@ -1,0 +1,13 @@
+[Unit]
+Description=Unseal TPM key and open LUKS volume
+DefaultDependencies=no
+Before=initrd.target
+Wants=initrd-fs.target
+
+[Service]
+Type=oneshot
+ExecStart=/bin/sh -c '/etc/unlock-mount-luks.sh'
+RemainAfterExit=yes
+
+[Install]
+WantedBy=initrd-switch-root.target

--- a/jenkins/image_building/initrd_sdk/verify-realroot.sh
+++ b/jenkins/image_building/initrd_sdk/verify-realroot.sh
@@ -1,0 +1,19 @@
+#!/bin/bash
+
+set -eu
+
+# This script is used to prvide a controlled wait loop in order to give time
+# to other systemd srvices to prepare the root file system.
+
+while true; do
+    if [[ -e "/realroot/bin" ]]; then
+        printf "INFO: Realroot mount point is present.\n"
+        break
+    else
+        printf "INFO: Waiting for realroot!\n"
+        # Introduce a 1-second delay using the read command
+        # sleep might not be available but this way we stress
+        # the CPU less
+        read -r -t 1 || true
+    fi
+done


### PR DESCRIPTION
This commit adds:

- New script used to avoid race conditions while running root switching
- New systemd unit file that is used to run the previously introduced unlock-mount-luks.sh
- Documentation about the new files