### PR TITLE
improve initrd verification logic

### DIFF
--- a/jenkins/image_building/initrd_sdk/unlock-mount-luks.sh
+++ b/jenkins/image_building/initrd_sdk/unlock-mount-luks.sh
@@ -144,6 +144,10 @@ if _is_luks "${root_device_path}"; then
         config_drive_path="${config_drive_common}${config_drive_part_num}"
     fi
     if _is_luks "${config_drive_path}"; then
+        # Create an empty file to signal to other services that the config
+        # drive was also encrypted, other services might want to know
+        # if they need to keep an eye out for the config drive
+        true > "/tmp/crypt_config"
         printf "Unlocking config drive %s\n" "${config_drive_path}"
         printf "INFO: config-drive:%s disk:%s part_count:%s " \
             "${config_drive_path}" "${root_device}" "${part_count}"

--- a/jenkins/image_building/initrd_sdk/verify-realroot.sh
+++ b/jenkins/image_building/initrd_sdk/verify-realroot.sh
@@ -8,12 +8,20 @@ set -eu
 while true; do
     if [[ -e "/realroot/bin" ]]; then
         printf "INFO: Realroot mount point is present.\n"
-        break
+        # /tmp/crypt_config is created by the unlock script that supposed to
+        # run in an earlier stage
+        if [[ ! -e "/tmp/crypt_config"  ]]; then
+            printf "INFO: Config drive is not encrypted.\n"
+            break
+        elif [[ -e "/dev/mapper/config-2" ]]; then
+            printf "INFO: Config drive has been unlocked.\n"
+            break
+        fi
     else
-        printf "INFO: Waiting for realroot!\n"
+        printf "INFO: Waiting for realroot and/or config drive!\n"
         # Introduce a 1-second delay using the read command
         # sleep might not be available but this way we stress
         # the CPU less
-        read -r -t 1 || true
+        read -r -t 1 < /dev/zero || true
     fi
 done


### PR DESCRIPTION
This commit adds the following changes:

- Implements a feature for the initrd sdk that makes it possible to verify that both the root and the config drive partitions have been decrypted.
- Now the verify script is reading /dev/zero in order to generate the 1s delay, instead of reading from interactive stdin. In environments where the verify script is executed in the background or by other services e.g. cron, systemd etc... the read command returns immediately thus not providing sufficient delay.