### PR TITLE
🌱 Increasing timeout of ephemeral tests

### DIFF
--- a/jenkins/jobs/capm3-e2e-tests.pipeline
+++ b/jenkins/jobs/capm3-e2e-tests.pipeline
@@ -28,7 +28,7 @@ script {
     agent_label = "metal3ci-8c24gb-${IMAGE_OS}"
     TIMEOUT=14400 // 4h
   } else if ( "${env.EPHEMERAL_TEST}" == 'true' ) {
-    TIMEOUT=18000 // 5h
+    TIMEOUT=21600 // 6h
     agent_label = "metal3ci-large-${IMAGE_OS}"
   } else {
     agent_label = "metal3ci-large-${IMAGE_OS}"


### PR DESCRIPTION
Ephemeral tests are taking more than 5 hours. This PR is changing the timeout of Ephemeral tests to 6 hours.
ref: https://jenkins.nordix.org/view/Metal3%20Periodic/job/metal3-periodic-centos-e2e-ephemeral-test-main/44/console 