### PR TITLE
convert fullstack jobs to be prow compatible

### DIFF
--- a/jenkins/jobs/dynamic_fullstack_building.pipeline
+++ b/jenkins/jobs/dynamic_fullstack_building.pipeline
@@ -1,17 +1,48 @@
 import java.text.SimpleDateFormat
 
+// Token for retrieving the GitHub credentials from the Jenkis key storage
+ci_git_credential_id = 'metal3-jenkins-github-username-token'
+
 // 3 hours
 def TIMEOUT = 10800
+
+script {
+
+  UPDATED_REPO = "https://github.com/${env.REPO_OWNER}/${env.REPO_NAME}.git"
+  echo "Test triggered from ${UPDATED_REPO}"
+  ci_git_url = "https://github.com/metal3-io/project-infra.git"
+
+  if ("${env.REPO_OWNER}" == 'metal3-io' && "${env.REPO_NAME}" == 'project-infra') {
+    ci_git_branch = (env.PULL_PULL_SHA) ?: 'main'
+    ci_git_base = (env.PULL_BASE_REF) ?: 'main'
+    // Fetch the base branch and the ci_git_branch when running on project-infra PR
+    refspec = '+refs/heads/' + ci_git_base + ':refs/remotes/origin/' + ci_git_base + ' ' + ci_git_branch
+  } else {
+    ci_git_branch = 'main'
+    refspec = '+refs/heads/*:refs/remotes/origin/*'
+  }
+    echo "Checkout ${ci_git_url} branch ${ci_git_branch}"
+}
 
 pipeline {
   agent { label 'metal3ci-8c32gb-ubuntu' }
   environment {
+    // supplied by prow
+    REPO_ORG = "${env.REPO_OWNER}"
+    REPO_NAME = "${env.REPO_NAME}"
+    REPO_BRANCH = "${env.PULL_BASE_REF}"
+    UPDATED_BRANCH = "${env.PULL_PULL_SHA}"
+    PR_ID = "${env.PULL_NUMBER}"
+    // pipeline script local
+    UPDATED_REPO = "${UPDATED_REPO}"
     METAL3_CI_USER="metal3ci"
     RT_URL="https://artifactory.nordix.org/artifactory"
     CURRENT_DIR = sh (
                       script: 'readlink -f "."',
                       returnStdout: true
                      ).trim()
+    // jenkins job auto generates
+    BUILD_TAG = "${env.BUILD_TAG}"
   }
   stages {
     stage('Building and testing full Metal3 stack'){
@@ -22,13 +53,32 @@ pipeline {
         script {
           CURRENT_START_TIME = System.currentTimeMillis()
         }
+        /* Checkout CI Repo */
+        checkout([
+          $class: 'GitSCM',
+          branches: [
+            [name: ci_git_branch]
+            ],
+          doGenerateSubmoduleConfigurations: false,
+          extensions: [
+              [$class: 'WipeWorkspace'],
+              [$class: 'CleanCheckout'],
+              [$class: 'CleanBeforeCheckout']
+              ],
+          submoduleCfg: [],
+          userRemoteConfigs: [
+              [credentialsId: ci_git_credential_id,url: ci_git_url, refspec: refspec]
+              ]
+          ])
         /* Pass all the credentials */
         withCredentials([usernamePassword(credentialsId: 'infra-nordix-artifactory-api-key', usernameVariable: 'RT_USER', passwordVariable: 'RT_TOKEN')]) {
           withCredentials([usernamePassword(credentialsId: 'metal3ci_harbor', usernameVariable: 'DOCKER_USER', passwordVariable: 'DOCKER_PASSWORD')])  {
             withCredentials([string(credentialsId: 'metal3-clusterctl-github-token', variable: 'GITHUB_TOKEN')]) {
               /* Fullstack building script */
-              timestamps {
-                sh './jenkins/scripts/dynamic_worker_workflow/fullstack.sh'
+              ansiColor('xterm') {
+                timestamps {
+                  sh './jenkins/scripts/dynamic_worker_workflow/fullstack.sh'
+                }
               }
             }
           }

--- a/jenkins/scripts/dynamic_worker_workflow/fullstack.sh
+++ b/jenkins/scripts/dynamic_worker_workflow/fullstack.sh
@@ -10,7 +10,6 @@ echo "Running Ironic image building script"
 
 IPA_REPO="${IPA_REPO:-https://opendev.org/openstack/ironic-python-agent.git}"
 IPA_BRANCH="${IPA_BRANCH:-master}"
-IPA_REF="${IPA_REF:-HEAD}"
 IPA_BUILDER_REPO="${IPA_BUILDER_REPO:-https://opendev.org/openstack/ironic-python-agent-builder.git}"
 IPA_BUILDER_BRANCH="${IPA_BUILDER_BRANCH:-master}"
 IPA_BUILDER_COMMIT="${IPA_BUILDER_COMMIT:-HEAD}"

--- a/prow/config/jobs/metal3-io/project-infra.yaml
+++ b/prow/config/jobs/metal3-io/project-infra.yaml
@@ -239,3 +239,9 @@ presubmits:
     agent: jenkins
     always_run: false
     optional: true
+  - name: metal3-fullstack-build
+    branches:
+    - main
+    agent: jenkins
+    always_run: false
+    optional: true


### PR DESCRIPTION
This PR:
 - Converts the previously mostly unused and outdated project_infra
 fullstack PR jobs to use prow triggers instead of "ghprb" triggers
 - Makes both the periodic and the PR fullstack jobs use the same prow
 compatible pipeline script
 - Removes the variable related to IPA git reference from the fullstack
 wrapper script as the IPA builder uses the branch name as reference.

This change is needed because the Metal3-io project does no longer uses the
Jenkins ghprb plugin, instead the PR jobs are triggered via GitHub or Prow.