### PR TITLE
Catch curl upload error when upload fails

### DIFF
--- a/jenkins/image_building/upload-node-image.sh
+++ b/jenkins/image_building/upload-node-image.sh
@@ -10,7 +10,7 @@ rt_delete_artifact() {
 rt_upload_artifact() {
     local src_path="${1:?}"
     local dst_path="${2:?}"
-    curl -s -XPUT -u"${RT_USER:?}:${RT_TOKEN:?}" "${RT_URL}/${dst_path}" -T "${src_path}"
+    curl -s --fail-with-body -XPUT -u"${RT_USER:?}:${RT_TOKEN:?}" "${RT_URL}/${dst_path}" -T "${src_path}"
 }
 
 rt_list_directory() {

--- a/jenkins/scripts/artifactory/utils.sh
+++ b/jenkins/scripts/artifactory/utils.sh
@@ -21,10 +21,10 @@ rt_upload_artifact() {
   ANONYMOUS="${3:-1}"
 
   _CMD="curl \
-    $( ([[ "${ANONYMOUS}" != 1 ]] && echo " -u${RT_USER:?}:${RT_TOKEN:?}") || true) \
+    --fail-with-body \
+    $( ([[ "${ANONYMOUS}" -ne 1 ]] && echo " -u${RT_USER:?}:${RT_TOKEN:?}") || true) \
     ${RT_URL}/${DST_PATH} \
     -T ${SRC_PATH}"
-
   eval "${_CMD}"
 }
 
@@ -46,7 +46,7 @@ rt_download_artifact() {
   ANONYMOUS="${3:-1}"
 
   _CMD="curl -s \
-    $( ([[ "${ANONYMOUS}" != 1 ]] && echo " -u${RT_USER:?}:${RT_TOKEN:?}") || true) \
+    $( ([[ "${ANONYMOUS}" -ne 1 ]] && echo " -u${RT_USER:?}:${RT_TOKEN:?}") || true) \
     -XGET \
     ${RT_URL}/${SRC_PATH} \
     -o ${DST_PATH}"
@@ -71,7 +71,7 @@ rt_cat_artifact() {
   ANONYMOUS="${2:-1}"
 
   _CMD="curl -s \
-    $( ([[ "${ANONYMOUS}" != 1 ]] && echo " -u${RT_USER:?}:${RT_TOKEN:?}") || true) \
+    $( ([[ "${ANONYMOUS}" -ne 1 ]] && echo " -u${RT_USER:?}:${RT_TOKEN:?}") || true) \
     -XGET \
     ${RT_URL}/${SRC_PATH}"
 
@@ -95,7 +95,7 @@ rt_delete_artifact() {
   ANONYMOUS="${2:-1}"
 
   _CMD="curl -s \
-    $( ([[ "${ANONYMOUS}" != 1 ]] && echo " -u${RT_USER:?}:${RT_TOKEN:?}") || true) \
+    $( ([[ "${ANONYMOUS}" -ne 1 ]] && echo " -u${RT_USER:?}:${RT_TOKEN:?}") || true) \
     -XDELETE \
     ${RT_URL}/${DST_PATH}"
 
@@ -120,7 +120,7 @@ rt_list_directory() {
   ANONYMOUS="${2:-1}"
 
   _CMD="curl -s \
-    $( ([[ "${ANONYMOUS}" != 1 ]] && echo " -u${RT_USER:?}:${RT_TOKEN:?}") || true) \
+    $( ([[ "${ANONYMOUS}" -ne 1 ]] && echo " -u${RT_USER:?}:${RT_TOKEN:?}") || true) \
     -XGET \
     ${RT_URL}/api/storage/${DST_PATH}"
 


### PR DESCRIPTION
Jenkins job did not fail when curl upload file failed, it finished successfull eenthough images were not uploaded. 
https://jenkins.nordix.org/view/Metal3%20Periodic/job/metal3_periodic_node_image_building/97/consoleFull

```
{
  "errors" : [ {
    "status" : 403,
   "message" : "Login has failed. Due to Incorrect username/password or locked user."
  } ]
```

This PR fixes this issue.

Also corrects number comparison conditions.  