### PR TITLE
Prow: Define jobs per release branch

### DIFF
--- a/prow/README.md
+++ b/prow/README.md
@@ -4,6 +4,18 @@
 
 Metal3 Prow dashboard: <https://prow.apps.test.metal3.io>
 
+## Prow config and jobs
+
+The configuration files for prow are in the `config` directory. The prow jobs
+have been split out into multiple files to make managing them easier. They can
+be found under `config/jobs`. They are all collected into a ConfigMap
+`job-config` that prow can access.
+
+The jobs are sorted based on github organization and repository. For
+repositories with release branches, we keep one file per branch. This way it is
+easy to add tests for a new branch by copying an existing file, and removing
+tests for a branch by just deleting the corresponding file.
+
 ## Access Controls
 
 - To merge, patches must have `/approve` and `/lgtm`, which apply the `approved`

--- a/prow/config/jobs/metal3-io/baremetal-operator-release-0.5.yaml
+++ b/prow/config/jobs/metal3-io/baremetal-operator-release-0.5.yaml
@@ -1,5 +1,93 @@
 presubmits:
   metal3-io/baremetal-operator:
+  - name: gomod
+    branches:
+    - release-0.5
+    skip_if_only_changed: '(((^|/)OWNERS)|((^|/)OWNERS_ALIASES)|(\.md))$'
+    decorate: true
+    spec:
+      containers:
+      - args:
+        - ./hack/gomod.sh
+        command:
+        - sh
+        env:
+        - name: IS_CONTAINER
+          value: "TRUE"
+        image: quay.io/metal3-io/basic-checks:golang-1.22
+        imagePullPolicy: Always
+  - name: shellcheck
+    branches:
+    - release-0.5
+    run_if_changed: '((\.sh)|^Makefile)$'
+    decorate: true
+    spec:
+      containers:
+      - args:
+        - ./hack/shellcheck.sh
+        command:
+        - sh
+        env:
+        - name: IS_CONTAINER
+          value: "TRUE"
+        image: docker.io/koalaman/shellcheck-alpine:v0.10.0@sha256:5921d946dac740cbeec2fb1c898747b6105e585130cc7f0602eec9a10f7ddb63
+        imagePullPolicy: Always
+  - name: generate
+    branches:
+    - release-0.5
+    skip_if_only_changed: '(((^|/)OWNERS)|((^|/)OWNERS_ALIASES)|(\.md))$'
+    decorate: true
+    spec:
+      containers:
+      - args:
+        - ./hack/generate.sh
+        command:
+        - sh
+        env:
+        - name: IS_CONTAINER
+          value: "TRUE"
+        - name: DEPLOY_KERNEL_URL
+          value: "http://172.22.0.1/images/ironic-python-agent.kernel"
+        - name: DEPLOY_RAMDISK_URL
+          value: "http://172.22.0.1/images/ironic-python-agent.initramfs"
+        - name: IRONIC_ENDPOINT
+          value: "http://localhost:6385/v1/"
+        - name: IRONIC_INSPECTOR_ENDPOINT
+          value: "http://localhost:5050/v1/"
+        image: quay.io/metal3-io/basic-checks:golang-1.22
+        imagePullPolicy: Always
+  # NOTE: The test jobs are for verifying Makefile and hack/* script changes only
+  - name: test
+    branches:
+    - release-0.5
+    run_if_changed: "^(Makefile|hack/.*)$"
+    decorate: true
+    spec:
+      containers:
+      - args:
+        - test
+        command:
+        - make
+        image: quay.io/metal3-io/basic-checks:golang-1.22
+        imagePullPolicy: Always
+  - name: manifestlint
+    branches:
+    - release-0.5
+    skip_if_only_changed: '(((^|/)OWNERS)|((^|/)OWNERS_ALIASES)|(\.md))$'
+    decorate: true
+    spec:
+      containers:
+      - args:
+        - ./hack/manifestlint.sh
+        command:
+        - sh
+        env:
+        - name: IS_CONTAINER
+          value: "TRUE"
+        - name: KUBECONFORM_PATH
+          value: "/"
+        image: ghcr.io/yannh/kubeconform:v0.6.2-alpine@sha256:49b5f6b320d30c1b8b72a7abdf02740ac9dc36a3ba23b934d1c02f7b37e6e740
+        imagePullPolicy: Always
   - name: markdownlint
     branches:
     - release-0.5

--- a/prow/config/jobs/metal3-io/baremetal-operator-release-0.6.yaml
+++ b/prow/config/jobs/metal3-io/baremetal-operator-release-0.6.yaml
@@ -1,5 +1,109 @@
 presubmits:
   metal3-io/baremetal-operator:
+  - name: gomod
+    branches:
+    - release-0.6
+    skip_if_only_changed: '(((^|/)OWNERS)|((^|/)OWNERS_ALIASES)|(\.md))$'
+    decorate: true
+    spec:
+      containers:
+      - args:
+        - ./hack/gomod.sh
+        command:
+        - sh
+        env:
+        - name: IS_CONTAINER
+          value: "TRUE"
+        image: quay.io/metal3-io/basic-checks:golang-1.22
+        imagePullPolicy: Always
+  - name: markdownlint
+    branches:
+    - release-0.6
+    run_if_changed: '(\.md|markdownlint\.sh)$'
+    decorate: true
+    spec:
+      containers:
+      - args:
+        - ./hack/markdownlint.sh
+        command:
+        - sh
+        env:
+        - name: IS_CONTAINER
+          value: "TRUE"
+        image: docker.io/pipelinecomponents/markdownlint-cli2:0.12.0@sha256:a3977fba9814f10d33a1d69ae607dc808e7a6470b2ba03e84c17193c0791aac0
+        imagePullPolicy: Always
+  - name: shellcheck
+    branches:
+    - release-0.6
+    run_if_changed: '((\.sh)|^Makefile)$'
+    decorate: true
+    spec:
+      containers:
+      - args:
+        - ./hack/shellcheck.sh
+        command:
+        - sh
+        env:
+        - name: IS_CONTAINER
+          value: "TRUE"
+        image: docker.io/koalaman/shellcheck-alpine:v0.10.0@sha256:5921d946dac740cbeec2fb1c898747b6105e585130cc7f0602eec9a10f7ddb63
+        imagePullPolicy: Always
+  - name: generate
+    branches:
+    - release-0.6
+    skip_if_only_changed: '(((^|/)OWNERS)|((^|/)OWNERS_ALIASES)|(\.md))$'
+    decorate: true
+    spec:
+      containers:
+      - args:
+        - ./hack/generate.sh
+        command:
+        - sh
+        env:
+        - name: IS_CONTAINER
+          value: "TRUE"
+        - name: DEPLOY_KERNEL_URL
+          value: "http://172.22.0.1/images/ironic-python-agent.kernel"
+        - name: DEPLOY_RAMDISK_URL
+          value: "http://172.22.0.1/images/ironic-python-agent.initramfs"
+        - name: IRONIC_ENDPOINT
+          value: "http://localhost:6385/v1/"
+        - name: IRONIC_INSPECTOR_ENDPOINT
+          value: "http://localhost:5050/v1/"
+        image: quay.io/metal3-io/basic-checks:golang-1.22
+        imagePullPolicy: Always
+  # NOTE: The test jobs are for verifying Makefile and hack/* script changes only
+  - name: test
+    branches:
+    - release-0.6
+    run_if_changed: "^(Makefile|hack/.*)$"
+    decorate: true
+    spec:
+      containers:
+      - args:
+        - test
+        command:
+        - make
+        image: quay.io/metal3-io/basic-checks:golang-1.22
+        imagePullPolicy: Always
+  - name: manifestlint
+    branches:
+    - release-0.6
+    skip_if_only_changed: '(((^|/)OWNERS)|((^|/)OWNERS_ALIASES)|(\.md))$'
+    decorate: true
+    spec:
+      containers:
+      - args:
+        - ./hack/manifestlint.sh
+        command:
+        - sh
+        env:
+        - name: IS_CONTAINER
+          value: "TRUE"
+        - name: KUBECONFORM_PATH
+          value: "/"
+        image: ghcr.io/yannh/kubeconform:v0.6.2-alpine@sha256:49b5f6b320d30c1b8b72a7abdf02740ac9dc36a3ba23b934d1c02f7b37e6e740
+        imagePullPolicy: Always
   - name: metal3-centos-e2e-basic-test-release-1-7
     branches:
     - release-0.6

--- a/prow/config/jobs/metal3-io/baremetal-operator-release-0.8.yaml
+++ b/prow/config/jobs/metal3-io/baremetal-operator-release-0.8.yaml
@@ -1,5 +1,109 @@
 presubmits:
   metal3-io/baremetal-operator:
+  - name: gomod
+    branches:
+    - release-0.8
+    skip_if_only_changed: '(((^|/)OWNERS)|((^|/)OWNERS_ALIASES)|(\.md))$'
+    decorate: true
+    spec:
+      containers:
+      - args:
+        - ./hack/gomod.sh
+        command:
+        - sh
+        env:
+        - name: IS_CONTAINER
+          value: "TRUE"
+        image: quay.io/metal3-io/basic-checks:golang-1.22
+        imagePullPolicy: Always
+  - name: markdownlint
+    branches:
+    - release-0.8
+    run_if_changed: '(\.md|markdownlint\.sh)$'
+    decorate: true
+    spec:
+      containers:
+      - args:
+        - ./hack/markdownlint.sh
+        command:
+        - sh
+        env:
+        - name: IS_CONTAINER
+          value: "TRUE"
+        image: docker.io/pipelinecomponents/markdownlint-cli2:0.12.0@sha256:a3977fba9814f10d33a1d69ae607dc808e7a6470b2ba03e84c17193c0791aac0
+        imagePullPolicy: Always
+  - name: shellcheck
+    branches:
+    - release-0.8
+    run_if_changed: '((\.sh)|^Makefile)$'
+    decorate: true
+    spec:
+      containers:
+      - args:
+        - ./hack/shellcheck.sh
+        command:
+        - sh
+        env:
+        - name: IS_CONTAINER
+          value: "TRUE"
+        image: docker.io/koalaman/shellcheck-alpine:v0.10.0@sha256:5921d946dac740cbeec2fb1c898747b6105e585130cc7f0602eec9a10f7ddb63
+        imagePullPolicy: Always
+  - name: generate
+    branches:
+    - release-0.8
+    skip_if_only_changed: '(((^|/)OWNERS)|((^|/)OWNERS_ALIASES)|(\.md))$'
+    decorate: true
+    spec:
+      containers:
+      - args:
+        - ./hack/generate.sh
+        command:
+        - sh
+        env:
+        - name: IS_CONTAINER
+          value: "TRUE"
+        - name: DEPLOY_KERNEL_URL
+          value: "http://172.22.0.1/images/ironic-python-agent.kernel"
+        - name: DEPLOY_RAMDISK_URL
+          value: "http://172.22.0.1/images/ironic-python-agent.initramfs"
+        - name: IRONIC_ENDPOINT
+          value: "http://localhost:6385/v1/"
+        - name: IRONIC_INSPECTOR_ENDPOINT
+          value: "http://localhost:5050/v1/"
+        image: quay.io/metal3-io/basic-checks:golang-1.22
+        imagePullPolicy: Always
+  # NOTE: The test jobs are for verifying Makefile and hack/* script changes only
+  - name: test
+    branches:
+    - release-0.8
+    run_if_changed: "^(Makefile|hack/.*)$"
+    decorate: true
+    spec:
+      containers:
+      - args:
+        - test
+        command:
+        - make
+        image: quay.io/metal3-io/basic-checks:golang-1.22
+        imagePullPolicy: Always
+  - name: manifestlint
+    branches:
+    - release-0.8
+    skip_if_only_changed: '(((^|/)OWNERS)|((^|/)OWNERS_ALIASES)|(\.md))$'
+    decorate: true
+    spec:
+      containers:
+      - args:
+        - ./hack/manifestlint.sh
+        command:
+        - sh
+        env:
+        - name: IS_CONTAINER
+          value: "TRUE"
+        - name: KUBECONFORM_PATH
+          value: "/"
+        image: ghcr.io/yannh/kubeconform:v0.6.2-alpine@sha256:49b5f6b320d30c1b8b72a7abdf02740ac9dc36a3ba23b934d1c02f7b37e6e740
+        imagePullPolicy: Always
   - name: metal3-centos-e2e-basic-test-release-1-8
     branches:
     - release-0.8

--- a/prow/config/jobs/metal3-io/baremetal-operator.yaml
+++ b/prow/config/jobs/metal3-io/baremetal-operator.yaml
@@ -1,6 +1,8 @@
 presubmits:
   metal3-io/baremetal-operator:
   - name: gomod
+    branches:
+    - main
     skip_if_only_changed: '(((^|/)OWNERS)|((^|/)OWNERS_ALIASES)|(\.md))$'
     decorate: true
     spec:
@@ -17,8 +19,6 @@ presubmits:
   - name: markdownlint
     branches:
     - main
-    - release-0.8
-    - release-0.6
     run_if_changed: '(\.md|markdownlint\.sh)$'
     decorate: true
     spec:
@@ -33,6 +33,8 @@ presubmits:
         image: docker.io/pipelinecomponents/markdownlint-cli2:0.12.0@sha256:a3977fba9814f10d33a1d69ae607dc808e7a6470b2ba03e84c17193c0791aac0
         imagePullPolicy: Always
   - name: shellcheck
+    branches:
+    - main
     run_if_changed: '((\.sh)|^Makefile)$'
     decorate: true
     spec:
@@ -47,6 +49,8 @@ presubmits:
         image: docker.io/koalaman/shellcheck-alpine:v0.10.0@sha256:5921d946dac740cbeec2fb1c898747b6105e585130cc7f0602eec9a10f7ddb63
         imagePullPolicy: Always
   - name: generate
+    branches:
+    - main
     skip_if_only_changed: '(((^|/)OWNERS)|((^|/)OWNERS_ALIASES)|(\.md))$'
     decorate: true
     spec:
@@ -70,6 +74,8 @@ presubmits:
         imagePullPolicy: Always
   # NOTE: The test jobs are for verifying Makefile and hack/* script changes only
   - name: test
+    branches:
+    - main
     run_if_changed: "^(Makefile|hack/.*)$"
     decorate: true
     spec:
@@ -81,6 +87,8 @@ presubmits:
         image: quay.io/metal3-io/basic-checks:golang-1.22
         imagePullPolicy: Always
   - name: manifestlint
+    branches:
+    - main
     skip_if_only_changed: '(((^|/)OWNERS)|((^|/)OWNERS_ALIASES)|(\.md))$'
     decorate: true
     spec:

--- a/prow/config/jobs/metal3-io/cluster-api-provider-metal3.yaml
+++ b/prow/config/jobs/metal3-io/cluster-api-provider-metal3.yaml
@@ -1,6 +1,8 @@
 presubmits:
   metal3-io/cluster-api-provider-metal3:
   - name: gomod
+    branches:
+    - main
     skip_if_only_changed: '(((^|/)OWNERS)|((^|/)OWNERS_ALIASES)|(\.md))$'
     decorate: true
     spec:
@@ -16,6 +18,8 @@ presubmits:
         imagePullPolicy: Always
   # NOTE: The test jobs are for verifying Makefile and hack/* script changes only
   - name: test
+    branches:
+    - main
     run_if_changed: "^(Makefile|hack/.*)$"
     decorate: true
     spec:
@@ -29,8 +33,6 @@ presubmits:
   - name: markdownlint
     branches:
     - main
-    - release-1.8
-    - release-1.7
     run_if_changed: '(\.md|markdownlint\.sh)$'
     decorate: true
     spec:
@@ -45,6 +47,8 @@ presubmits:
         image: docker.io/pipelinecomponents/markdownlint-cli2:0.12.0@sha256:a3977fba9814f10d33a1d69ae607dc808e7a6470b2ba03e84c17193c0791aac0
         imagePullPolicy: Always
   - name: shellcheck
+    branches:
+    - main
     run_if_changed: '((\.sh)|^Makefile)$'
     decorate: true
     spec:
@@ -59,6 +63,8 @@ presubmits:
         image: docker.io/koalaman/shellcheck-alpine:v0.10.0@sha256:5921d946dac740cbeec2fb1c898747b6105e585130cc7f0602eec9a10f7ddb63
         imagePullPolicy: Always
   - name: generate
+    branches:
+    - main
     skip_if_only_changed: '(((^|/)OWNERS)|((^|/)OWNERS_ALIASES)|(\.md))$'
     decorate: true
     spec:
@@ -73,6 +79,8 @@ presubmits:
         image: docker.io/golang:1.22
         imagePullPolicy: Always
   - name: unit
+    branches:
+    - main
     skip_if_only_changed: '(((^|/)OWNERS)|((^|/)OWNERS_ALIASES)|(\.md))$'
     decorate: true
     spec:
@@ -87,6 +95,8 @@ presubmits:
         image: docker.io/golang:1.22
         imagePullPolicy: Always
   - name: manifestlint
+    branches:
+    - main
     skip_if_only_changed: '(((^|/)OWNERS)|((^|/)OWNERS_ALIASES)|(\.md))$'
     decorate: true
     spec:
@@ -103,6 +113,8 @@ presubmits:
         image: ghcr.io/yannh/kubeconform:v0.6.2-alpine@sha256:49b5f6b320d30c1b8b72a7abdf02740ac9dc36a3ba23b934d1c02f7b37e6e740
         imagePullPolicy: Always
   - name: build
+    branches:
+    - main
     run_if_changed: "^api|^test|^Makefile$"
     decorate: true
     spec:

--- a/prow/config/jobs/metal3-io/cluster-api-provier-metal3-release-1.6.yaml
+++ b/prow/config/jobs/metal3-io/cluster-api-provier-metal3-release-1.6.yaml
@@ -1,5 +1,117 @@
 presubmits:
   metal3-io/cluster-api-provider-metal3:
+  - name: gomod
+    branches:
+    - release-1.6
+    skip_if_only_changed: '(((^|/)OWNERS)|((^|/)OWNERS_ALIASES)|(\.md))$'
+    decorate: true
+    spec:
+      containers:
+      - args:
+        - ./hack/gomod.sh
+        command:
+        - sh
+        env:
+        - name: IS_CONTAINER
+          value: "TRUE"
+        image: docker.io/golang:1.22
+        imagePullPolicy: Always
+  # NOTE: The test jobs are for verifying Makefile and hack/* script changes only
+  - name: test
+    branches:
+    - release-1.6
+    run_if_changed: "^(Makefile|hack/.*)$"
+    decorate: true
+    spec:
+      containers:
+      - args:
+        - test
+        command:
+        - make
+        image: docker.io/golang:1.22
+        imagePullPolicy: Always
+  - name: shellcheck
+    branches:
+    - release-1.6
+    run_if_changed: '((\.sh)|^Makefile)$'
+    decorate: true
+    spec:
+      containers:
+      - args:
+        - ./hack/shellcheck.sh
+        command:
+        - sh
+        env:
+        - name: IS_CONTAINER
+          value: "TRUE"
+        image: docker.io/koalaman/shellcheck-alpine:v0.10.0@sha256:5921d946dac740cbeec2fb1c898747b6105e585130cc7f0602eec9a10f7ddb63
+        imagePullPolicy: Always
+  - name: generate
+    branches:
+    - release-1.6
+    skip_if_only_changed: '(((^|/)OWNERS)|((^|/)OWNERS_ALIASES)|(\.md))$'
+    decorate: true
+    spec:
+      containers:
+      - args:
+        - ./hack/codegen.sh
+        command:
+        - sh
+        env:
+        - name: IS_CONTAINER
+          value: "TRUE"
+        image: docker.io/golang:1.22
+        imagePullPolicy: Always
+  - name: unit
+    branches:
+    - release-1.6
+    skip_if_only_changed: '(((^|/)OWNERS)|((^|/)OWNERS_ALIASES)|(\.md))$'
+    decorate: true
+    spec:
+      containers:
+      - args:
+        - ./hack/unit.sh
+        command:
+        - sh
+        env:
+        - name: IS_CONTAINER
+          value: "TRUE"
+        image: docker.io/golang:1.22
+        imagePullPolicy: Always
+  - name: manifestlint
+    branches:
+    - release-1.6
+    skip_if_only_changed: '(((^|/)OWNERS)|((^|/)OWNERS_ALIASES)|(\.md))$'
+    decorate: true
+    spec:
+      containers:
+      - args:
+        - ./hack/manifestlint.sh
+        command:
+        - sh
+        env:
+        - name: IS_CONTAINER
+          value: "TRUE"
+        - name: KUBECONFORM_PATH
+          value: "/"
+        image: ghcr.io/yannh/kubeconform:v0.6.2-alpine@sha256:49b5f6b320d30c1b8b72a7abdf02740ac9dc36a3ba23b934d1c02f7b37e6e740
+        imagePullPolicy: Always
+  - name: build
+    branches:
+    - release-1.6
+    run_if_changed: "^api|^test|^Makefile$"
+    decorate: true
+    spec:
+      containers:
+      - args:
+        - ./hack/build.sh
+        command:
+        - sh
+        env:
+        - name: IS_CONTAINER
+          value: "TRUE"
+        image: docker.io/golang:1.22
+        imagePullPolicy: Always
   - name: markdownlint
     branches:
     - release-1.6

--- a/prow/config/jobs/metal3-io/cluster-api-provier-metal3-release-1.7.yaml
+++ b/prow/config/jobs/metal3-io/cluster-api-provier-metal3-release-1.7.yaml
@@ -1,5 +1,133 @@
 presubmits:
   metal3-io/cluster-api-provider-metal3:
+  - name: gomod
+    branches:
+    - release-1.7
+    skip_if_only_changed: '(((^|/)OWNERS)|((^|/)OWNERS_ALIASES)|(\.md))$'
+    decorate: true
+    spec:
+      containers:
+      - args:
+        - ./hack/gomod.sh
+        command:
+        - sh
+        env:
+        - name: IS_CONTAINER
+          value: "TRUE"
+        image: docker.io/golang:1.22
+        imagePullPolicy: Always
+  # NOTE: The test jobs are for verifying Makefile and hack/* script changes only
+  - name: test
+    branches:
+    - release-1.7
+    run_if_changed: "^(Makefile|hack/.*)$"
+    decorate: true
+    spec:
+      containers:
+      - args:
+        - test
+        command:
+        - make
+        image: docker.io/golang:1.22
+        imagePullPolicy: Always
+  - name: markdownlint
+    branches:
+    - release-1.7
+    run_if_changed: '(\.md|markdownlint\.sh)$'
+    decorate: true
+    spec:
+      containers:
+      - args:
+        - ./hack/markdownlint.sh
+        command:
+        - sh
+        env:
+        - name: IS_CONTAINER
+          value: "TRUE"
+        image: docker.io/pipelinecomponents/markdownlint-cli2:0.12.0@sha256:a3977fba9814f10d33a1d69ae607dc808e7a6470b2ba03e84c17193c0791aac0
+        imagePullPolicy: Always
+  - name: shellcheck
+    branches:
+    - release-1.7
+    run_if_changed: '((\.sh)|^Makefile)$'
+    decorate: true
+    spec:
+      containers:
+      - args:
+        - ./hack/shellcheck.sh
+        command:
+        - sh
+        env:
+        - name: IS_CONTAINER
+          value: "TRUE"
+        image: docker.io/koalaman/shellcheck-alpine:v0.10.0@sha256:5921d946dac740cbeec2fb1c898747b6105e585130cc7f0602eec9a10f7ddb63
+        imagePullPolicy: Always
+  - name: generate
+    branches:
+    - release-1.7
+    skip_if_only_changed: '(((^|/)OWNERS)|((^|/)OWNERS_ALIASES)|(\.md))$'
+    decorate: true
+    spec:
+      containers:
+      - args:
+        - ./hack/codegen.sh
+        command:
+        - sh
+        env:
+        - name: IS_CONTAINER
+          value: "TRUE"
+        image: docker.io/golang:1.22
+        imagePullPolicy: Always
+  - name: unit
+    branches:
+    - release-1.7
+    skip_if_only_changed: '(((^|/)OWNERS)|((^|/)OWNERS_ALIASES)|(\.md))$'
+    decorate: true
+    spec:
+      containers:
+      - args:
+        - ./hack/unit.sh
+        command:
+        - sh
+        env:
+        - name: IS_CONTAINER
+          value: "TRUE"
+        image: docker.io/golang:1.22
+        imagePullPolicy: Always
+  - name: manifestlint
+    branches:
+    - release-1.7
+    skip_if_only_changed: '(((^|/)OWNERS)|((^|/)OWNERS_ALIASES)|(\.md))$'
+    decorate: true
+    spec:
+      containers:
+      - args:
+        - ./hack/manifestlint.sh
+        command:
+        - sh
+        env:
+        - name: IS_CONTAINER
+          value: "TRUE"
+        - name: KUBECONFORM_PATH
+          value: "/"
+        image: ghcr.io/yannh/kubeconform:v0.6.2-alpine@sha256:49b5f6b320d30c1b8b72a7abdf02740ac9dc36a3ba23b934d1c02f7b37e6e740
+        imagePullPolicy: Always
+  - name: build
+    branches:
+    - release-1.7
+    run_if_changed: "^api|^test|^Makefile$"
+    decorate: true
+    spec:
+      containers:
+      - args:
+        - ./hack/build.sh
+        command:
+        - sh
+        env:
+        - name: IS_CONTAINER
+          value: "TRUE"
+        image: docker.io/golang:1.22
+        imagePullPolicy: Always
   - name: metal3-centos-e2e-basic-test-release-1-7
     branches:
     - release-1.7

--- a/prow/config/jobs/metal3-io/cluster-api-provier-metal3-release-1.8.yaml
+++ b/prow/config/jobs/metal3-io/cluster-api-provier-metal3-release-1.8.yaml
@@ -1,5 +1,133 @@
 presubmits:
   metal3-io/cluster-api-provider-metal3:
+  - name: gomod
+    branches:
+    - release-1.8
+    skip_if_only_changed: '(((^|/)OWNERS)|((^|/)OWNERS_ALIASES)|(\.md))$'
+    decorate: true
+    spec:
+      containers:
+      - args:
+        - ./hack/gomod.sh
+        command:
+        - sh
+        env:
+        - name: IS_CONTAINER
+          value: "TRUE"
+        image: docker.io/golang:1.22
+        imagePullPolicy: Always
+  # NOTE: The test jobs are for verifying Makefile and hack/* script changes only
+  - name: test
+    branches:
+    - release-1.8
+    run_if_changed: "^(Makefile|hack/.*)$"
+    decorate: true
+    spec:
+      containers:
+      - args:
+        - test
+        command:
+        - make
+        image: docker.io/golang:1.22
+        imagePullPolicy: Always
+  - name: markdownlint
+    branches:
+    - release-1.8
+    run_if_changed: '(\.md|markdownlint\.sh)$'
+    decorate: true
+    spec:
+      containers:
+      - args:
+        - ./hack/markdownlint.sh
+        command:
+        - sh
+        env:
+        - name: IS_CONTAINER
+          value: "TRUE"
+        image: docker.io/pipelinecomponents/markdownlint-cli2:0.12.0@sha256:a3977fba9814f10d33a1d69ae607dc808e7a6470b2ba03e84c17193c0791aac0
+        imagePullPolicy: Always
+  - name: shellcheck
+    branches:
+    - release-1.8
+    run_if_changed: '((\.sh)|^Makefile)$'
+    decorate: true
+    spec:
+      containers:
+      - args:
+        - ./hack/shellcheck.sh
+        command:
+        - sh
+        env:
+        - name: IS_CONTAINER
+          value: "TRUE"
+        image: docker.io/koalaman/shellcheck-alpine:v0.10.0@sha256:5921d946dac740cbeec2fb1c898747b6105e585130cc7f0602eec9a10f7ddb63
+        imagePullPolicy: Always
+  - name: generate
+    branches:
+    - release-1.8
+    skip_if_only_changed: '(((^|/)OWNERS)|((^|/)OWNERS_ALIASES)|(\.md))$'
+    decorate: true
+    spec:
+      containers:
+      - args:
+        - ./hack/codegen.sh
+        command:
+        - sh
+        env:
+        - name: IS_CONTAINER
+          value: "TRUE"
+        image: docker.io/golang:1.22
+        imagePullPolicy: Always
+  - name: unit
+    branches:
+    - release-1.8
+    skip_if_only_changed: '(((^|/)OWNERS)|((^|/)OWNERS_ALIASES)|(\.md))$'
+    decorate: true
+    spec:
+      containers:
+      - args:
+        - ./hack/unit.sh
+        command:
+        - sh
+        env:
+        - name: IS_CONTAINER
+          value: "TRUE"
+        image: docker.io/golang:1.22
+        imagePullPolicy: Always
+  - name: manifestlint
+    branches:
+    - release-1.8
+    skip_if_only_changed: '(((^|/)OWNERS)|((^|/)OWNERS_ALIASES)|(\.md))$'
+    decorate: true
+    spec:
+      containers:
+      - args:
+        - ./hack/manifestlint.sh
+        command:
+        - sh
+        env:
+        - name: IS_CONTAINER
+          value: "TRUE"
+        - name: KUBECONFORM_PATH
+          value: "/"
+        image: ghcr.io/yannh/kubeconform:v0.6.2-alpine@sha256:49b5f6b320d30c1b8b72a7abdf02740ac9dc36a3ba23b934d1c02f7b37e6e740
+        imagePullPolicy: Always
+  - name: build
+    branches:
+    - release-1.8
+    run_if_changed: "^api|^test|^Makefile$"
+    decorate: true
+    spec:
+      containers:
+      - args:
+        - ./hack/build.sh
+        command:
+        - sh
+        env:
+        - name: IS_CONTAINER
+          value: "TRUE"
+        image: docker.io/golang:1.22
+        imagePullPolicy: Always
   - name: metal3-centos-e2e-basic-test-release-1-8
     branches:
     - release-1.8

--- a/prow/config/jobs/metal3-io/ip-address-manager-release-1.6.yaml
+++ b/prow/config/jobs/metal3-io/ip-address-manager-release-1.6.yaml
@@ -1,5 +1,100 @@
 presubmits:
   metal3-io/ip-address-manager:
+  - name: gomod
+    branches:
+    - release-1.6
+    skip_if_only_changed: '(((^|/)OWNERS)|((^|/)OWNERS_ALIASES)|(\.md))$'
+    decorate: true
+    spec:
+      containers:
+      - args:
+        - ./hack/gomod.sh
+        command:
+        - sh
+        env:
+        - name: IS_CONTAINER
+          value: "TRUE"
+        image: docker.io/golang:1.22
+        imagePullPolicy: Always
+  # NOTE: The test jobs are for verifying the Makefile and hack/* scripts only
+  - name: test
+    branches:
+    - release-1.6
+    run_if_changed: "^(Makefile|hack/.*)$"
+    decorate: true
+    spec:
+      containers:
+      - args:
+        - test
+        command:
+        - make
+        image: docker.io/golang:1.22
+        imagePullPolicy: Always
+  - name: shellcheck
+    branches:
+    - release-1.6
+    run_if_changed: '((\.sh)|^Makefile)$'
+    decorate: true
+    spec:
+      containers:
+      - args:
+        - ./hack/shellcheck.sh
+        command:
+        - sh
+        env:
+        - name: IS_CONTAINER
+          value: "TRUE"
+        image: docker.io/koalaman/shellcheck-alpine:v0.10.0@sha256:5921d946dac740cbeec2fb1c898747b6105e585130cc7f0602eec9a10f7ddb63
+        imagePullPolicy: Always
+  - name: unit
+    branches:
+    - release-1.6
+    skip_if_only_changed: '(((^|/)OWNERS)|((^|/)OWNERS_ALIASES)|(\.md))$'
+    decorate: true
+    spec:
+      containers:
+      - args:
+        - ./hack/unit.sh
+        command:
+        - sh
+        env:
+        - name: IS_CONTAINER
+          value: "TRUE"
+        image: docker.io/golang:1.22
+  - name: generate
+    branches:
+    - release-1.6
+    skip_if_only_changed: '(((^|/)OWNERS)|((^|/)OWNERS_ALIASES)|(\.md))$'
+    decorate: true
+    spec:
+      containers:
+      - args:
+        - ./hack/codegen.sh
+        command:
+        - sh
+        env:
+        - name: IS_CONTAINER
+          value: "TRUE"
+        image: docker.io/golang:1.22
+        imagePullPolicy: Always
+  - name: manifestlint
+    branches:
+    - release-1.6
+    skip_if_only_changed: '(((^|/)OWNERS)|((^|/)OWNERS_ALIASES)|(\.md))$'
+    decorate: true
+    spec:
+      containers:
+      - args:
+        - ./hack/manifestlint.sh
+        command:
+        - sh
+        env:
+        - name: IS_CONTAINER
+          value: "TRUE"
+        - name: KUBECONFORM_PATH
+          value: "/"
+        image: ghcr.io/yannh/kubeconform:v0.6.2-alpine@sha256:49b5f6b320d30c1b8b72a7abdf02740ac9dc36a3ba23b934d1c02f7b37e6e740
+        imagePullPolicy: Always
   - name: markdownlint
     run_if_changed: '(\.md|markdownlint\.sh)$'
     branches:

--- a/prow/config/jobs/metal3-io/ip-address-manager-release-1.7.yaml
+++ b/prow/config/jobs/metal3-io/ip-address-manager-release-1.7.yaml
@@ -1,5 +1,116 @@
 presubmits:
   metal3-io/ip-address-manager:
+  - name: gomod
+    branches:
+    - release-1.7
+    skip_if_only_changed: '(((^|/)OWNERS)|((^|/)OWNERS_ALIASES)|(\.md))$'
+    decorate: true
+    spec:
+      containers:
+      - args:
+        - ./hack/gomod.sh
+        command:
+        - sh
+        env:
+        - name: IS_CONTAINER
+          value: "TRUE"
+        image: docker.io/golang:1.22
+        imagePullPolicy: Always
+  # NOTE: The test jobs are for verifying the Makefile and hack/* scripts only
+  - name: test
+    branches:
+    - release-1.7
+    run_if_changed: "^(Makefile|hack/.*)$"
+    decorate: true
+    spec:
+      containers:
+      - args:
+        - test
+        command:
+        - make
+        image: docker.io/golang:1.22
+        imagePullPolicy: Always
+  - name: markdownlint
+    branches:
+    - release-1.7
+    run_if_changed: '(\.md|markdownlint\.sh)$'
+    decorate: true
+    spec:
+      containers:
+      - args:
+        - ./hack/markdownlint.sh
+        command:
+        - sh
+        env:
+        - name: IS_CONTAINER
+          value: "TRUE"
+        image: docker.io/pipelinecomponents/markdownlint-cli2:0.12.0@sha256:a3977fba9814f10d33a1d69ae607dc808e7a6470b2ba03e84c17193c0791aac0
+        imagePullPolicy: Always
+  - name: shellcheck
+    branches:
+    - release-1.7
+    run_if_changed: '((\.sh)|^Makefile)$'
+    decorate: true
+    spec:
+      containers:
+      - args:
+        - ./hack/shellcheck.sh
+        command:
+        - sh
+        env:
+        - name: IS_CONTAINER
+          value: "TRUE"
+        image: docker.io/koalaman/shellcheck-alpine:v0.10.0@sha256:5921d946dac740cbeec2fb1c898747b6105e585130cc7f0602eec9a10f7ddb63
+        imagePullPolicy: Always
+  - name: unit
+    branches:
+    - release-1.7
+    skip_if_only_changed: '(((^|/)OWNERS)|((^|/)OWNERS_ALIASES)|(\.md))$'
+    decorate: true
+    spec:
+      containers:
+      - args:
+        - ./hack/unit.sh
+        command:
+        - sh
+        env:
+        - name: IS_CONTAINER
+          value: "TRUE"
+        image: docker.io/golang:1.22
+  - name: generate
+    branches:
+    - release-1.7
+    skip_if_only_changed: '(((^|/)OWNERS)|((^|/)OWNERS_ALIASES)|(\.md))$'
+    decorate: true
+    spec:
+      containers:
+      - args:
+        - ./hack/codegen.sh
+        command:
+        - sh
+        env:
+        - name: IS_CONTAINER
+          value: "TRUE"
+        image: docker.io/golang:1.22
+        imagePullPolicy: Always
+  - name: manifestlint
+    branches:
+    - release-1.7
+    skip_if_only_changed: '(((^|/)OWNERS)|((^|/)OWNERS_ALIASES)|(\.md))$'
+    decorate: true
+    spec:
+      containers:
+      - args:
+        - ./hack/manifestlint.sh
+        command:
+        - sh
+        env:
+        - name: IS_CONTAINER
+          value: "TRUE"
+        - name: KUBECONFORM_PATH
+          value: "/"
+        image: ghcr.io/yannh/kubeconform:v0.6.2-alpine@sha256:49b5f6b320d30c1b8b72a7abdf02740ac9dc36a3ba23b934d1c02f7b37e6e740
+        imagePullPolicy: Always
   - name: metal3-centos-e2e-basic-test-release-1-7
     branches:
     - release-1.7

--- a/prow/config/jobs/metal3-io/ip-address-manager-release-1.8.yaml
+++ b/prow/config/jobs/metal3-io/ip-address-manager-release-1.8.yaml
@@ -1,5 +1,116 @@
 presubmits:
   metal3-io/ip-address-manager:
+  - name: gomod
+    branches:
+    - release-1.8
+    skip_if_only_changed: '(((^|/)OWNERS)|((^|/)OWNERS_ALIASES)|(\.md))$'
+    decorate: true
+    spec:
+      containers:
+      - args:
+        - ./hack/gomod.sh
+        command:
+        - sh
+        env:
+        - name: IS_CONTAINER
+          value: "TRUE"
+        image: docker.io/golang:1.22
+        imagePullPolicy: Always
+  # NOTE: The test jobs are for verifying the Makefile and hack/* scripts only
+  - name: test
+    branches:
+    - release-1.8
+    run_if_changed: "^(Makefile|hack/.*)$"
+    decorate: true
+    spec:
+      containers:
+      - args:
+        - test
+        command:
+        - make
+        image: docker.io/golang:1.22
+        imagePullPolicy: Always
+  - name: markdownlint
+    branches:
+    - release-1.8
+    run_if_changed: '(\.md|markdownlint\.sh)$'
+    decorate: true
+    spec:
+      containers:
+      - args:
+        - ./hack/markdownlint.sh
+        command:
+        - sh
+        env:
+        - name: IS_CONTAINER
+          value: "TRUE"
+        image: docker.io/pipelinecomponents/markdownlint-cli2:0.12.0@sha256:a3977fba9814f10d33a1d69ae607dc808e7a6470b2ba03e84c17193c0791aac0
+        imagePullPolicy: Always
+  - name: shellcheck
+    branches:
+    - release-1.8
+    run_if_changed: '((\.sh)|^Makefile)$'
+    decorate: true
+    spec:
+      containers:
+      - args:
+        - ./hack/shellcheck.sh
+        command:
+        - sh
+        env:
+        - name: IS_CONTAINER
+          value: "TRUE"
+        image: docker.io/koalaman/shellcheck-alpine:v0.10.0@sha256:5921d946dac740cbeec2fb1c898747b6105e585130cc7f0602eec9a10f7ddb63
+        imagePullPolicy: Always
+  - name: unit
+    branches:
+    - release-1.8
+    skip_if_only_changed: '(((^|/)OWNERS)|((^|/)OWNERS_ALIASES)|(\.md))$'
+    decorate: true
+    spec:
+      containers:
+      - args:
+        - ./hack/unit.sh
+        command:
+        - sh
+        env:
+        - name: IS_CONTAINER
+          value: "TRUE"
+        image: docker.io/golang:1.22
+  - name: generate
+    branches:
+    - release-1.8
+    skip_if_only_changed: '(((^|/)OWNERS)|((^|/)OWNERS_ALIASES)|(\.md))$'
+    decorate: true
+    spec:
+      containers:
+      - args:
+        - ./hack/codegen.sh
+        command:
+        - sh
+        env:
+        - name: IS_CONTAINER
+          value: "TRUE"
+        image: docker.io/golang:1.22
+        imagePullPolicy: Always
+  - name: manifestlint
+    branches:
+    - release-1.8
+    skip_if_only_changed: '(((^|/)OWNERS)|((^|/)OWNERS_ALIASES)|(\.md))$'
+    decorate: true
+    spec:
+      containers:
+      - args:
+        - ./hack/manifestlint.sh
+        command:
+        - sh
+        env:
+        - name: IS_CONTAINER
+          value: "TRUE"
+        - name: KUBECONFORM_PATH
+          value: "/"
+        image: ghcr.io/yannh/kubeconform:v0.6.2-alpine@sha256:49b5f6b320d30c1b8b72a7abdf02740ac9dc36a3ba23b934d1c02f7b37e6e740
+        imagePullPolicy: Always
   - name: metal3-centos-e2e-basic-test-release-1-8
     branches:
     - release-1.8

--- a/prow/config/jobs/metal3-io/ip-address-manager.yaml
+++ b/prow/config/jobs/metal3-io/ip-address-manager.yaml
@@ -1,6 +1,8 @@
 presubmits:
   metal3-io/ip-address-manager:
   - name: gomod
+    branches:
+    - main
     skip_if_only_changed: '(((^|/)OWNERS)|((^|/)OWNERS_ALIASES)|(\.md))$'
     decorate: true
     spec:
@@ -16,6 +18,8 @@ presubmits:
         imagePullPolicy: Always
   # NOTE: The test jobs are for verifying the Makefile and hack/* scripts only
   - name: test
+    branches:
+    - main
     run_if_changed: "^(Makefile|hack/.*)$"
     decorate: true
     spec:
@@ -29,8 +33,6 @@ presubmits:
   - name: markdownlint
     branches:
     - main
-    - release-1.8
-    - release-1.7
     run_if_changed: '(\.md|markdownlint\.sh)$'
     decorate: true
     spec:
@@ -45,6 +47,8 @@ presubmits:
         image: docker.io/pipelinecomponents/markdownlint-cli2:0.12.0@sha256:a3977fba9814f10d33a1d69ae607dc808e7a6470b2ba03e84c17193c0791aac0
         imagePullPolicy: Always
   - name: shellcheck
+    branches:
+    - main
     run_if_changed: '((\.sh)|^Makefile)$'
     decorate: true
     spec:
@@ -59,6 +63,8 @@ presubmits:
         image: docker.io/koalaman/shellcheck-alpine:v0.10.0@sha256:5921d946dac740cbeec2fb1c898747b6105e585130cc7f0602eec9a10f7ddb63
         imagePullPolicy: Always
   - name: unit
+    branches:
+    - main
     skip_if_only_changed: '(((^|/)OWNERS)|((^|/)OWNERS_ALIASES)|(\.md))$'
     decorate: true
     spec:
@@ -72,6 +78,8 @@ presubmits:
           value: "TRUE"
         image: docker.io/golang:1.22
   - name: generate
+    branches:
+    - main
     skip_if_only_changed: '(((^|/)OWNERS)|((^|/)OWNERS_ALIASES)|(\.md))$'
     decorate: true
     spec:
@@ -86,6 +94,8 @@ presubmits:
         image: docker.io/golang:1.22
         imagePullPolicy: Always
   - name: manifestlint
+    branches:
+    - main
     skip_if_only_changed: '(((^|/)OWNERS)|((^|/)OWNERS_ALIASES)|(\.md))$'
     decorate: true
     spec:

--- a/prow/config/jobs/metal3-io/ironic-image-release-24.0.yaml
+++ b/prow/config/jobs/metal3-io/ironic-image-release-24.0.yaml
@@ -1,5 +1,37 @@
 presubmits:
   metal3-io/ironic-image:
+  - name: shellcheck
+    branches:
+    - release-24.0
+    run_if_changed: '((\.sh)|^Makefile)$'
+    decorate: true
+    spec:
+      containers:
+      - args:
+        - ./hack/shellcheck.sh
+        command:
+        - sh
+        env:
+        - name: IS_CONTAINER
+          value: "TRUE"
+        image: docker.io/koalaman/shellcheck-alpine:v0.10.0@sha256:5921d946dac740cbeec2fb1c898747b6105e585130cc7f0602eec9a10f7ddb63
+        imagePullPolicy: Always
+  - name: markdownlint
+    branches:
+    - release-24.0
+    run_if_changed: '(\.md|markdownlint\.sh)$'
+    decorate: true
+    spec:
+      containers:
+      - args:
+        - ./hack/markdownlint.sh
+        command:
+        - sh
+        env:
+        - name: IS_CONTAINER
+          value: "TRUE"
+        image: docker.io/pipelinecomponents/markdownlint-cli2:0.12.0@sha256:a3977fba9814f10d33a1d69ae607dc808e7a6470b2ba03e84c17193c0791aac0
+        imagePullPolicy: Always
   - name: metal3-centos-e2e-integration-test-release-1-6
     branches:
     - release-24.0

--- a/prow/config/jobs/metal3-io/ironic-image-release-24.1.yaml
+++ b/prow/config/jobs/metal3-io/ironic-image-release-24.1.yaml
@@ -1,5 +1,37 @@
 presubmits:
   metal3-io/ironic-image:
+  - name: shellcheck
+    branches:
+    - release-24.1
+    run_if_changed: '((\.sh)|^Makefile)$'
+    decorate: true
+    spec:
+      containers:
+      - args:
+        - ./hack/shellcheck.sh
+        command:
+        - sh
+        env:
+        - name: IS_CONTAINER
+          value: "TRUE"
+        image: docker.io/koalaman/shellcheck-alpine:v0.10.0@sha256:5921d946dac740cbeec2fb1c898747b6105e585130cc7f0602eec9a10f7ddb63
+        imagePullPolicy: Always
+  - name: markdownlint
+    branches:
+    - release-24.1
+    run_if_changed: '(\.md|markdownlint\.sh)$'
+    decorate: true
+    spec:
+      containers:
+      - args:
+        - ./hack/markdownlint.sh
+        command:
+        - sh
+        env:
+        - name: IS_CONTAINER
+          value: "TRUE"
+        image: docker.io/pipelinecomponents/markdownlint-cli2:0.12.0@sha256:a3977fba9814f10d33a1d69ae607dc808e7a6470b2ba03e84c17193c0791aac0
+        imagePullPolicy: Always
   - name: metal3-centos-e2e-integration-test-release-1-7
     branches:
     - release-24.1

--- a/prow/config/jobs/metal3-io/ironic-image-release-25.0.yaml
+++ b/prow/config/jobs/metal3-io/ironic-image-release-25.0.yaml
@@ -1,5 +1,37 @@
 presubmits:
   metal3-io/ironic-image:
+  - name: shellcheck
+    branches:
+    - release-25.0
+    run_if_changed: '((\.sh)|^Makefile)$'
+    decorate: true
+    spec:
+      containers:
+      - args:
+        - ./hack/shellcheck.sh
+        command:
+        - sh
+        env:
+        - name: IS_CONTAINER
+          value: "TRUE"
+        image: docker.io/koalaman/shellcheck-alpine:v0.10.0@sha256:5921d946dac740cbeec2fb1c898747b6105e585130cc7f0602eec9a10f7ddb63
+        imagePullPolicy: Always
+  - name: markdownlint
+    branches:
+    - release-25.0
+    run_if_changed: '(\.md|markdownlint\.sh)$'
+    decorate: true
+    spec:
+      containers:
+      - args:
+        - ./hack/markdownlint.sh
+        command:
+        - sh
+        env:
+        - name: IS_CONTAINER
+          value: "TRUE"
+        image: docker.io/pipelinecomponents/markdownlint-cli2:0.12.0@sha256:a3977fba9814f10d33a1d69ae607dc808e7a6470b2ba03e84c17193c0791aac0
+        imagePullPolicy: Always
   - name: metal3-centos-e2e-integration-test-release-1-8
     branches:
     - release-25.0

--- a/prow/config/jobs/metal3-io/ironic-image-release-26.0.yaml
+++ b/prow/config/jobs/metal3-io/ironic-image-release-26.0.yaml
@@ -1,5 +1,37 @@
 presubmits:
   metal3-io/ironic-image:
+  - name: shellcheck
+    branches:
+    - release-26.0
+    run_if_changed: '((\.sh)|^Makefile)$'
+    decorate: true
+    spec:
+      containers:
+      - args:
+        - ./hack/shellcheck.sh
+        command:
+        - sh
+        env:
+        - name: IS_CONTAINER
+          value: "TRUE"
+        image: docker.io/koalaman/shellcheck-alpine:v0.10.0@sha256:5921d946dac740cbeec2fb1c898747b6105e585130cc7f0602eec9a10f7ddb63
+        imagePullPolicy: Always
+  - name: markdownlint
+    branches:
+    - release-26.0
+    run_if_changed: '(\.md|markdownlint\.sh)$'
+    decorate: true
+    spec:
+      containers:
+      - args:
+        - ./hack/markdownlint.sh
+        command:
+        - sh
+        env:
+        - name: IS_CONTAINER
+          value: "TRUE"
+        image: docker.io/pipelinecomponents/markdownlint-cli2:0.12.0@sha256:a3977fba9814f10d33a1d69ae607dc808e7a6470b2ba03e84c17193c0791aac0
+        imagePullPolicy: Always
   - name: metal3-centos-e2e-integration-test-release-1-8
     branches:
     - release-26.0

--- a/prow/config/jobs/metal3-io/ironic-image.yaml
+++ b/prow/config/jobs/metal3-io/ironic-image.yaml
@@ -1,6 +1,8 @@
 presubmits:
   metal3-io/ironic-image:
   - name: shellcheck
+    branches:
+    - main
     run_if_changed: '((\.sh)|^Makefile)$'
     decorate: true
     spec:
@@ -15,6 +17,8 @@ presubmits:
         image: docker.io/koalaman/shellcheck-alpine:v0.10.0@sha256:5921d946dac740cbeec2fb1c898747b6105e585130cc7f0602eec9a10f7ddb63
         imagePullPolicy: Always
   - name: markdownlint
+    branches:
+    - main
     run_if_changed: '(\.md|markdownlint\.sh)$'
     decorate: true
     spec:


### PR DESCRIPTION
In the previous PR I kept "common" tests in the main file. This PR splits them up so that each release branch has all its own tests clearly defined in a separate file. Easier to keep track of at the cost of some duplication.