### PR TITLE
Update KCT and KCP with new cloud-init structure

### DIFF
--- a/prow/capo-cluster/infra-kct.yaml
+++ b/prow/capo-cluster/infra-kct.yaml
@@ -9,10 +9,10 @@ spec:
         nodeRegistration:
           kubeletExtraArgs:
             cloud-provider: external
-            provider-id: "openstack:///'{{ instance_id }}'"
+            provider-id: "openstack:///'{{ v1.instance_id }}'"
             kube-reserved: cpu=200m,memory=100Mi
             system-reserved: cpu=100m,memory=100Mi
-          name: '{{ local_hostname }}'
+          name: '{{ v1.local_hostname }}'
           taints:
           - key: node-role.kubernetes.io/infra
             effect: NoSchedule

--- a/prow/capo-cluster/kubeadmconfigtemplate.yaml
+++ b/prow/capo-cluster/kubeadmconfigtemplate.yaml
@@ -9,7 +9,7 @@ spec:
         nodeRegistration:
           kubeletExtraArgs:
             cloud-provider: external
-            provider-id: "openstack:///'{{ instance_id }}'"
+            provider-id: "openstack:///'{{ v1.instance_id }}'"
             kube-reserved: cpu=200m,memory=100Mi
             system-reserved: cpu=100m,memory=100Mi
-          name: '{{ local_hostname }}'
+          name: '{{ v1.local_hostname }}'

--- a/prow/capo-cluster/kubeadmcontrolplane.yaml
+++ b/prow/capo-cluster/kubeadmcontrolplane.yaml
@@ -15,18 +15,18 @@ spec:
       nodeRegistration:
         kubeletExtraArgs:
           cloud-provider: external
-          provider-id: "openstack:///'{{ instance_id }}'"
+          provider-id: "openstack:///'{{ v1.instance_id }}'"
           kube-reserved: cpu=200m,memory=100Mi
           system-reserved: cpu=100m,memory=100Mi
-        name: '{{ local_hostname }}'
+        name: '{{ v1.local_hostname }}'
     joinConfiguration:
       nodeRegistration:
         kubeletExtraArgs:
           cloud-provider: external
-          provider-id: "openstack:///'{{ instance_id }}'"
+          provider-id: "openstack:///'{{ v1.instance_id }}'"
           kube-reserved: cpu=200m,memory=100Mi
           system-reserved: cpu=100m,memory=100Mi
-        name: '{{ local_hostname }}'
+        name: '{{ v1.local_hostname }}'
   machineTemplate:
     infrastructureRef:
       apiVersion: infrastructure.cluster.x-k8s.io/v1beta1


### PR DESCRIPTION
There has been a change in the data received by the metadata service in xerces. This made the templated values in the KCP and KCT invalid. This commit updates the templates with the new cloud-init structure.

The "v1" keys that we are using now should be stable. They are documented here: https://cloudinit.readthedocs.io/en/latest/explanation/instancedata.html#standardised-instance-data-json-v1-keys