### PR TITLE
Prow: Upgrade Kubernetes and CAPI/CAPO

### DIFF
--- a/prow/README.md
+++ b/prow/README.md
@@ -127,10 +127,10 @@ image. Here is an example:
   "floating_ip_network": "internet",
   "ssh_username": "ubuntu",
   "volume_type": "",
-  "kubernetes_deb_version": "1.29.4-2.1",
-  "kubernetes_rpm_version": "1.29.4",
-  "kubernetes_semver": "v1.29.4",
-  "kubernetes_series": "v1.29"
+  "kubernetes_deb_version": "1.30.6-1.1",
+  "kubernetes_rpm_version": "1.30.6",
+  "kubernetes_semver": "v1.30.6",
+  "kubernetes_series": "v1.30"
 }
 ```
 
@@ -365,8 +365,8 @@ You may also have to create a keypair with the Metal3 CI ssh key.
 
    ```bash
    kind create cluster
-   clusterctl init --infrastructure=openstack:v0.10.0 --core=cluster-api:v1.7.1 \
-      --bootstrap=kubeadm:v1.7.1 --control-plane=kubeadm:v1.7.1
+   clusterctl init --infrastructure=openstack:v0.11.1 --core=cluster-api:v1.8.5 \
+      --bootstrap=kubeadm:v1.8.5 --control-plane=kubeadm:v1.8.5
    ```
 
 1. Create cluster.
@@ -414,8 +414,8 @@ You may also have to create a keypair with the Metal3 CI ssh key.
 1. Make cluster self-hosted
 
    ```bash
-   clusterctl init --infrastructure=openstack:v0.10.0 --core=cluster-api:v1.7.1 \
-      --bootstrap=kubeadm:v1.7.1 --control-plane=kubeadm:v1.7.1
+   clusterctl init --infrastructure=openstack:v0.11.1 --core=cluster-api:v1.8.5 \
+      --bootstrap=kubeadm:v1.8.5 --control-plane=kubeadm:v1.8.5
    unset KUBECONFIG
    clusterctl move --to-kubeconfig=capo-cluster/kubeconfig.yaml
    export KUBECONFIG=capo-cluster/kubeconfig.yaml

--- a/prow/capo-cluster/infra-md.yaml
+++ b/prow/capo-cluster/infra-md.yaml
@@ -5,6 +5,10 @@ metadata:
 spec:
   clusterName: prow
   replicas: 1
+  strategy:
+    type: RollingUpdate
+    rollingUpdate:
+      maxUnavailable: 0
   selector:
     matchLabels: null
   template:
@@ -23,5 +27,5 @@ spec:
       infrastructureRef:
         apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
         kind: OpenStackMachineTemplate
-        name: prow-worker-v1-29-4-new
-      version: v1.29.4
+        name: prow-worker-v1-30-6
+      version: v1.30.6

--- a/prow/capo-cluster/kubeadmcontrolplane.yaml
+++ b/prow/capo-cluster/kubeadmcontrolplane.yaml
@@ -31,6 +31,6 @@ spec:
     infrastructureRef:
       apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
       kind: OpenStackMachineTemplate
-      name: prow-control-plane-v1-29-4-new
+      name: prow-control-plane-v1-30-6
   replicas: 1
-  version: v1.29.4
+  version: v1.30.6

--- a/prow/capo-cluster/machinedeployment.yaml
+++ b/prow/capo-cluster/machinedeployment.yaml
@@ -23,5 +23,5 @@ spec:
       infrastructureRef:
         apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
         kind: OpenStackMachineTemplate
-        name: prow-worker-v1-29-4-new
-      version: v1.29.4
+        name: prow-worker-v1-30-6
+      version: v1.30.6

--- a/prow/capo-cluster/openstackmachinetemplates.yaml
+++ b/prow/capo-cluster/openstackmachinetemplates.yaml
@@ -33,3 +33,39 @@ spec:
       rootVolume:
         sizeGiB: 100
       sshKeyName: metal3ci
+---
+apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+kind: OpenStackMachineTemplate
+metadata:
+  name: prow-control-plane-v1-30-6
+spec:
+  template:
+    spec:
+      flavor: c4m4
+      identityRef:
+        cloudName: prow
+        name: prow-cloud-config
+      image:
+        filter:
+          name: ubuntu-2204-kube-v1.30.6
+      rootVolume:
+        sizeGiB: 100
+      sshKeyName: metal3ci
+---
+apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+kind: OpenStackMachineTemplate
+metadata:
+  name: prow-worker-v1-30-6
+spec:
+  template:
+    spec:
+      flavor: c8m16avx2
+      identityRef:
+        cloudName: prow
+        name: prow-cloud-config
+      image:
+        filter:
+          name: ubuntu-2204-kube-v1.30.6
+      rootVolume:
+        sizeGiB: 100
+      sshKeyName: metal3ci


### PR DESCRIPTION
This upgrades Kubernetes to v1.30.6, CAPI to v1.8.5 and CAPO to v0.11.1.