### PR TITLE
Prow: Bump calico, autoscaler and cloud-provider

### DIFF
--- a/prow/capo-cluster/machinedeployment.yaml
+++ b/prow/capo-cluster/machinedeployment.yaml
@@ -3,7 +3,7 @@ kind: MachineDeployment
 metadata:
   name: prow-md-0
   annotations:
-    cluster.x-k8s.io/cluster-api-autoscaler-node-group-min-size: "1"
+    cluster.x-k8s.io/cluster-api-autoscaler-node-group-min-size: "2"
     cluster.x-k8s.io/cluster-api-autoscaler-node-group-max-size: "5"
 spec:
   clusterName: prow

--- a/prow/cluster-resources/autoscaler.yaml
+++ b/prow/cluster-resources/autoscaler.yaml
@@ -18,7 +18,7 @@ spec:
         app: cluster-autoscaler
     spec:
       containers:
-      - image: registry.k8s.io/autoscaling/cluster-autoscaler:v1.29.0
+      - image: registry.k8s.io/autoscaling/cluster-autoscaler:v1.30.2
         name: cluster-autoscaler
         command:
         - /cluster-autoscaler

--- a/prow/cluster-resources/kustomization.yaml
+++ b/prow/cluster-resources/kustomization.yaml
@@ -1,15 +1,15 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
-- https://raw.githubusercontent.com/projectcalico/calico/v3.27.3/manifests/calico.yaml
-- https://raw.githubusercontent.com/kubernetes/cloud-provider-openstack/v1.29.0/manifests/controller-manager/cloud-controller-manager-roles.yaml
-- https://raw.githubusercontent.com/kubernetes/cloud-provider-openstack/v1.29.0/manifests/controller-manager/cloud-controller-manager-role-bindings.yaml
-- https://raw.githubusercontent.com/kubernetes/cloud-provider-openstack/v1.29.0/manifests/controller-manager/openstack-cloud-controller-manager-ds.yaml
-- https://raw.githubusercontent.com/kubernetes/cloud-provider-openstack/v1.29.0/manifests/cinder-csi-plugin/cinder-csi-controllerplugin-rbac.yaml
-- https://raw.githubusercontent.com/kubernetes/cloud-provider-openstack/v1.29.0/manifests/cinder-csi-plugin/cinder-csi-controllerplugin.yaml
-- https://raw.githubusercontent.com/kubernetes/cloud-provider-openstack/v1.29.0/manifests/cinder-csi-plugin/cinder-csi-nodeplugin-rbac.yaml
-- https://raw.githubusercontent.com/kubernetes/cloud-provider-openstack/v1.29.0/manifests/cinder-csi-plugin/cinder-csi-nodeplugin.yaml
-- https://raw.githubusercontent.com/kubernetes/cloud-provider-openstack/v1.29.0/manifests/cinder-csi-plugin/csi-cinder-driver.yaml
+- https://raw.githubusercontent.com/projectcalico/calico/v3.28.2/manifests/calico.yaml
+- https://raw.githubusercontent.com/kubernetes/cloud-provider-openstack/v1.30.1/manifests/controller-manager/cloud-controller-manager-roles.yaml
+- https://raw.githubusercontent.com/kubernetes/cloud-provider-openstack/v1.30.1/manifests/controller-manager/cloud-controller-manager-role-bindings.yaml
+- https://raw.githubusercontent.com/kubernetes/cloud-provider-openstack/v1.30.1/manifests/controller-manager/openstack-cloud-controller-manager-ds.yaml
+- https://raw.githubusercontent.com/kubernetes/cloud-provider-openstack/v1.30.1/manifests/cinder-csi-plugin/cinder-csi-controllerplugin-rbac.yaml
+- https://raw.githubusercontent.com/kubernetes/cloud-provider-openstack/v1.30.1/manifests/cinder-csi-plugin/cinder-csi-controllerplugin.yaml
+- https://raw.githubusercontent.com/kubernetes/cloud-provider-openstack/v1.30.1/manifests/cinder-csi-plugin/cinder-csi-nodeplugin-rbac.yaml
+- https://raw.githubusercontent.com/kubernetes/cloud-provider-openstack/v1.30.1/manifests/cinder-csi-plugin/cinder-csi-nodeplugin.yaml
+- https://raw.githubusercontent.com/kubernetes/cloud-provider-openstack/v1.30.1/manifests/cinder-csi-plugin/csi-cinder-driver.yaml
 - autoscaler.yaml
 - coredns-pdb.yaml
 


### PR DESCRIPTION
Also adjust minimum number of machines in the worker MD.
The cloud-provider and autoscaler bump should really have
happened together with the kubernetes bump but was forgotten.