### PR TITLE
Prow: Temporary autoscaler RBAC workaround

### DIFF
--- a/prow/cluster-resources/autoscaler.yaml
+++ b/prow/cluster-resources/autoscaler.yaml
@@ -175,3 +175,13 @@ rules:
   - list
   - update
   - watch
+# TODO (lentzi90): Remove this when the issue is solved
+# https://github.com/kubernetes/autoscaler/issues/6490
+- apiGroups:
+  - infrastructure.cluster.x-k8s.io
+  resources:
+  - openstackmachinetemplates
+  verbs:
+  - get
+  - list
+  - watch


### PR DESCRIPTION
There is a bug in the autoscaler that makes it get stuck on a permission
issue sometimes. It doesn't really need these permissions for our
use-case, but adding them should hopefully avoid it getting stuck.

See https://github.com/kubernetes/autoscaler/issues/6490

Fixes: #881 