### PR TITLE
update basic-checks baseimage when building it

### DIFF
--- a/.github/workflows/build-images-action.yml
+++ b/.github/workflows/build-images-action.yml
@@ -1,6 +1,7 @@
 name: build-images-action
 
 on:
+  repository_dispatch:
   push:
     branches:
     - 'main'

--- a/prow/container-images/basic-checks/Dockerfile
+++ b/prow/container-images/basic-checks/Dockerfile
@@ -3,5 +3,6 @@ FROM docker.io/golang:${GO_VERSION}
 
 # Install additional packages not present in regular golang image
 RUN apt-get update \
+    && apt-get -y upgrade \
     && apt-get install -y libvirt-dev \
     && apt-get clean


### PR DESCRIPTION
Update baseimage when we build the basic-checks image. While we usually bump to quite new version, we also have repository_dispatch trigger in the workflow, so we can rebuild the image in which case baseimage is old and should get updated.

Quay is reporting a lot of vulnerabilities for this image already.