### PR TITLE
🌱 Fixing agent creation timeout issue

### DIFF
--- a/jenkins/jobs/capm3-e2e-tests.pipeline
+++ b/jenkins/jobs/capm3-e2e-tests.pipeline
@@ -37,7 +37,7 @@ script {
 }
 
 pipeline {
-    agent none
+    agent { label agent_label }
     environment {
         REPO_ORG = "${env.REPO_OWNER}"
         REPO_NAME = "${env.REPO_NAME}"
@@ -62,7 +62,6 @@ pipeline {
 
     stages {
         stage('e2e test') {
-            agent { label agent_label }
             options {
                 timeout(time: TIMEOUT, unit: 'SECONDS')
             }


### PR DESCRIPTION
This PR moves agent creation outside the stage, ensuring it doesn't time out. This change reduces timeout failures in tests, especially when the infrastructure is slow. Additionally, it aligns the agent creation process with other pipeline scripts for consistency.