### PR TITLE
Prow: Switch to staging registry

### DIFF
--- a/prow/Makefile
+++ b/prow/Makefile
@@ -5,8 +5,9 @@ export CONTAINER_RUNTIME ?= docker
 validate:
 	$(CONTAINER_RUNTIME) run --rm \
 		--volume "${PWD}:/workdir:ro,z" \
-		--entrypoint /checkconfig \
-		gcr.io/k8s-prow/checkconfig:v20231011-33fbc60185 \
-		--config-path /workdir/manifests/overlays/metal3/config.yaml \
-		--plugin-config /workdir/manifests/overlays/metal3/plugins.yaml \
+		--entrypoint /ko-app/checkconfig \
+		us-docker.pkg.dev/k8s-infra-prow/images/checkconfig:v20240730-12bb925b4 \
+		--config-path /workdir/config/config.yaml \
+		--job-config-path /workdir/config/jobs \
+		--plugin-config /workdir/config/plugins.yaml \
 		--strict

--- a/prow/config/config.yaml
+++ b/prow/config/config.yaml
@@ -22,10 +22,10 @@ plank:
         path_strategy: explicit
       s3_credentials_secret: s3-credentials
       utility_images:
-        clonerefs: gcr.io/k8s-prow/clonerefs:v20240730-12bb925b4
-        entrypoint: gcr.io/k8s-prow/entrypoint:v20240730-12bb925b4
-        initupload: gcr.io/k8s-prow/initupload:v20240730-12bb925b4
-        sidecar: gcr.io/k8s-prow/sidecar:v20240730-12bb925b4
+        clonerefs: us-docker.pkg.dev/k8s-infra-prow/images/clonerefs:v20240730-12bb925b4
+        entrypoint: us-docker.pkg.dev/k8s-infra-prow/images/entrypoint:v20240730-12bb925b4
+        initupload: us-docker.pkg.dev/k8s-infra-prow/images/initupload:v20240730-12bb925b4
+        sidecar: us-docker.pkg.dev/k8s-infra-prow/images/sidecar:v20240730-12bb925b4
       resources:
         clonerefs:
           requests:

--- a/prow/config/generic-autobumper-config.yaml
+++ b/prow/config/generic-autobumper-config.yaml
@@ -8,6 +8,6 @@ includedConfigPaths:
 targetVersion: "latest"
 prefixes:
 - name: "k8s-prow images"
-  prefix: "gcr.io/k8s-prow/"
+  prefix: "us-docker.pkg.dev/k8s-infra-prow/images/"
   repo: "https://github.com/metal3-io/project-infra"
   summarise: false

--- a/prow/config/jobs/metal3-io/project-infra.yaml
+++ b/prow/config/jobs/metal3-io/project-infra.yaml
@@ -5,7 +5,7 @@ presubmits:
     decorate: true
     spec:
       containers:
-      - image: gcr.io/k8s-prow/checkconfig:v20240730-12bb925b4
+      - image: us-docker.pkg.dev/k8s-infra-prow/images/checkconfig:v20240730-12bb925b4
         command:
         - checkconfig
         args:

--- a/prow/config/jobs/periodics.yaml
+++ b/prow/config/jobs/periodics.yaml
@@ -4,7 +4,7 @@ periodics:
   decorate: true
   spec:
     containers:
-    - image: gcr.io/k8s-prow/commenter:v20240731-a5d9345e59
+    - image: us-docker.pkg.dev/k8s-infra-prow/images/commenter:v20240731-a5d9345e59
       command:
       - commenter
       args:
@@ -37,7 +37,7 @@ periodics:
   decorate: true
   spec:
     containers:
-    - image: gcr.io/k8s-prow/commenter:v20240731-a5d9345e59
+    - image: us-docker.pkg.dev/k8s-infra-prow/images/commenter:v20240731-a5d9345e59
       command:
       - commenter
       args:
@@ -71,7 +71,7 @@ periodics:
     base_ref: main
   spec:
     containers:
-    - image: gcr.io/k8s-prow/generic-autobumper:v20240730-12bb925b4
+    - image: us-docker.pkg.dev/k8s-infra-prow/images/generic-autobumper:v20240730-12bb925b4
       command:
       - generic-autobumper
       args:

--- a/prow/manifests/base/crier.yaml
+++ b/prow/manifests/base/crier.yaml
@@ -19,7 +19,7 @@ spec:
       terminationGracePeriodSeconds: 30
       containers:
       - name: crier
-        image: gcr.io/k8s-prow/crier:v20240730-12bb925b4
+        image: us-docker.pkg.dev/k8s-infra-prow/images/crier:v20240730-12bb925b4
         args:
         - --blob-storage-workers=10
         - --config-path=/etc/config/config.yaml

--- a/prow/manifests/base/deck.yaml
+++ b/prow/manifests/base/deck.yaml
@@ -24,7 +24,7 @@ spec:
       terminationGracePeriodSeconds: 30
       containers:
       - name: deck
-        image: gcr.io/k8s-prow/deck:v20240730-12bb925b4
+        image: us-docker.pkg.dev/k8s-infra-prow/images/deck:v20240730-12bb925b4
         args:
         - --config-path=/etc/config/config.yaml
         - --job-config-path=/etc/job-config

--- a/prow/manifests/base/ghproxy.yaml
+++ b/prow/manifests/base/ghproxy.yaml
@@ -34,7 +34,7 @@ spec:
     spec:
       containers:
       - name: ghproxy
-        image: gcr.io/k8s-prow/ghproxy:v20240730-12bb925b4
+        image: us-docker.pkg.dev/k8s-infra-prow/images/ghproxy:v20240730-12bb925b4
         args:
         - --cache-dir=/cache
         - --cache-sizeGB=99

--- a/prow/manifests/base/hook.yaml
+++ b/prow/manifests/base/hook.yaml
@@ -24,7 +24,7 @@ spec:
       terminationGracePeriodSeconds: 180
       containers:
       - name: hook
-        image: gcr.io/k8s-prow/hook:v20240730-12bb925b4
+        image: us-docker.pkg.dev/k8s-infra-prow/images/hook:v20240730-12bb925b4
         imagePullPolicy: Always
         args:
         - --dry-run=false

--- a/prow/manifests/base/horologium.yaml
+++ b/prow/manifests/base/horologium.yaml
@@ -21,7 +21,7 @@ spec:
       terminationGracePeriodSeconds: 30
       containers:
       - name: horologium
-        image: gcr.io/k8s-prow/horologium:v20240730-12bb925b4
+        image: us-docker.pkg.dev/k8s-infra-prow/images/horologium:v20240730-12bb925b4
         args:
         - --dry-run=false
         - --config-path=/etc/config/config.yaml

--- a/prow/manifests/base/prow-controller-manager.yaml
+++ b/prow/manifests/base/prow-controller-manager.yaml
@@ -26,7 +26,7 @@ spec:
         - --github-endpoint=https://api.github.com
         - --enable-controller=plank
         - --github-token-path=/etc/github/token
-        image: gcr.io/k8s-prow/prow-controller-manager:v20240730-12bb925b4
+        image: us-docker.pkg.dev/k8s-infra-prow/images/prow-controller-manager:v20240730-12bb925b4
         volumeMounts:
         - name: github-token
           mountPath: /etc/github

--- a/prow/manifests/base/sinker.yaml
+++ b/prow/manifests/base/sinker.yaml
@@ -18,7 +18,7 @@ spec:
       serviceAccountName: "sinker"
       containers:
       - name: sinker
-        image: gcr.io/k8s-prow/sinker:v20240730-12bb925b4
+        image: us-docker.pkg.dev/k8s-infra-prow/images/sinker:v20240730-12bb925b4
         args:
         - --config-path=/etc/config/config.yaml
         - --dry-run=false

--- a/prow/manifests/base/statusreconciler.yaml
+++ b/prow/manifests/base/statusreconciler.yaml
@@ -19,7 +19,7 @@ spec:
       terminationGracePeriodSeconds: 180
       containers:
       - name: statusreconciler
-        image: gcr.io/k8s-prow/status-reconciler:v20240730-12bb925b4
+        image: us-docker.pkg.dev/k8s-infra-prow/images/status-reconciler:v20240730-12bb925b4
         args:
         - --dry-run=false
         - --continue-on-error=true

--- a/prow/manifests/base/tide.yaml
+++ b/prow/manifests/base/tide.yaml
@@ -20,7 +20,7 @@ spec:
       serviceAccountName: "tide"
       containers:
       - name: tide
-        image: gcr.io/k8s-prow/tide:v20240730-12bb925b4
+        image: us-docker.pkg.dev/k8s-infra-prow/images/tide:v20240730-12bb925b4
         args:
         - --dry-run=false
         - --config-path=/etc/config/config.yaml

--- a/prow/manifests/overlays/metal3/external-plugins/cherrypicker_deployment.yaml
+++ b/prow/manifests/overlays/metal3/external-plugins/cherrypicker_deployment.yaml
@@ -39,7 +39,7 @@ spec:
       terminationGracePeriodSeconds: 180
       containers:
       - name: cherrypicker
-        image: gcr.io/k8s-prow/cherrypicker:v20240730-12bb925b4
+        image: us-docker.pkg.dev/k8s-infra-prow/images/cherrypicker:v20240730-12bb925b4
         imagePullPolicy: Always
         args:
         - --github-token-path=/etc/github/token

--- a/prow/manifests/overlays/metal3/external-plugins/jenkins-operator.yaml
+++ b/prow/manifests/overlays/metal3/external-plugins/jenkins-operator.yaml
@@ -36,7 +36,7 @@ spec:
       serviceAccountName: jenkins-operator
       containers:
       - name: jenkins-operator
-        image: gcr.io/k8s-prow/jenkins-operator:v20240730-12bb925b4
+        image: us-docker.pkg.dev/k8s-infra-prow/images/jenkins-operator:v20240730-12bb925b4
         args:
         - --config-path=/etc/config/config.yaml
         - --job-config-path=/etc/job-config

--- a/prow/manifests/overlays/metal3/external-plugins/labels_cronjob.yaml
+++ b/prow/manifests/overlays/metal3/external-plugins/labels_cronjob.yaml
@@ -28,7 +28,7 @@ spec:
         spec:
           containers:
           - name: label-sync
-            image: gcr.io/k8s-prow/label_sync:v20240731-a5d9345e59
+            image: us-docker.pkg.dev/k8s-infra-prow/images/label_sync:v20240731-a5d9345e59
             args:
             - --config=/etc/config/labels.yaml
             - --confirm=true

--- a/prow/manifests/overlays/metal3/external-plugins/needs-rebase_deployment.yaml
+++ b/prow/manifests/overlays/metal3/external-plugins/needs-rebase_deployment.yaml
@@ -32,7 +32,7 @@ spec:
       terminationGracePeriodSeconds: 180
       containers:
       - name: needs-rebase
-        image: gcr.io/k8s-prow/needs-rebase:v20240730-12bb925b4
+        image: us-docker.pkg.dev/k8s-infra-prow/images/needs-rebase:v20240730-12bb925b4
         imagePullPolicy: Always
         args:
         - --dry-run=false


### PR DESCRIPTION
The GCR is about to be shut down. Prow already stopped publishing images there but have not transitioned to registry.k8s.io yet. Because of this we are switching to use the staging registry instead, which is the same that the k/k prow is also using.

Related to #871 (doesn't fix, since the issue is for migrating to registry.k8s.io)