### PR TITLE
Prow: Add Makefile to autobumper

### DIFF
--- a/prow/config/generic-autobumper-config.yaml
+++ b/prow/config/generic-autobumper-config.yaml
@@ -11,3 +11,5 @@ prefixes:
   prefix: "gcr.io/k8s-prow/"
   repo: "https://github.com/metal3-io/project-infra"
   summarise: false
+extraFiles:
+- "prow/Makefile"


### PR DESCRIPTION
The autobumper is not checking Makefiles unless explicitly configured to do so. I have tested this with a dry-run locally.