### PR TITLE
Prow: Use GCR for commenter and label_sync images

### DIFF
--- a/prow/config/generic-autobumper-config.yaml
+++ b/prow/config/generic-autobumper-config.yaml
@@ -6,10 +6,14 @@ remoteName: "project-infra"
 includedConfigPaths:
 - "prow"
 targetVersion: "latest"
+extraFiles:
+- "prow/Makefile"
 prefixes:
 - name: "k8s-prow images"
   prefix: "us-docker.pkg.dev/k8s-infra-prow/images/"
   repo: "https://github.com/metal3-io/project-infra"
   summarise: false
-extraFiles:
-- "prow/Makefile"
+- name: "test-infra images"
+  prefix: "gcr.io/k8s-staging-test-infra/"
+  repo: "https://github.com/metal3-io/project-infra"
+  summarise: false

--- a/prow/config/jobs/periodics.yaml
+++ b/prow/config/jobs/periodics.yaml
@@ -4,7 +4,7 @@ periodics:
   decorate: true
   spec:
     containers:
-    - image: us-docker.pkg.dev/k8s-infra-prow/images/commenter:v20240731-a5d9345e59
+    - image: gcr.io/k8s-staging-test-infra/commenter:v20240801-a5d9345e59
       command:
       - commenter
       args:
@@ -37,7 +37,7 @@ periodics:
   decorate: true
   spec:
     containers:
-    - image: us-docker.pkg.dev/k8s-infra-prow/images/commenter:v20240731-a5d9345e59
+    - image: gcr.io/k8s-staging-test-infra/commenter:v20240801-a5d9345e59
       command:
       - commenter
       args:

--- a/prow/manifests/overlays/metal3/external-plugins/labels_cronjob.yaml
+++ b/prow/manifests/overlays/metal3/external-plugins/labels_cronjob.yaml
@@ -28,7 +28,7 @@ spec:
         spec:
           containers:
           - name: label-sync
-            image: us-docker.pkg.dev/k8s-infra-prow/images/label_sync:v20240731-a5d9345e59
+            image: gcr.io/k8s-staging-test-infra/label_sync:v20240801-a5d9345e59
             args:
             - --config=/etc/config/labels.yaml
             - --confirm=true


### PR DESCRIPTION
These components are not maintained in the new prow repo and have apparently not been pushed to the same staging registry. Instead they are pushed to the test-infra staging registry in GCR.

This commit changes the registry for the commenter and label_sync jobs and updates the autobumper to detect these images as well. I also had to bump the tag of the images since they have not pushed old image to the same registry.