### PR TITLE
Prow: Update docs

### DIFF
--- a/prow/README.md
+++ b/prow/README.md
@@ -285,7 +285,7 @@ Now you are ready to create the files.
    {
       "region": "RegionOne",
       "access_key": "${S3_ACCESS_KEY}",
-      "endpoint": "xerces.ericsson.net:7480",
+      "endpoint": "https://xerces.ericsson.net:7480",
       "insecure": false,
       "s3_force_path_style": true,
       "secret_key": "${S3_SECRET_KEY}"


### PR DESCRIPTION
There has been a change upstream that makes it necessary to specify the protocol (http or https) for the s3 endpoint.