### PR TITLE
Prow: Use CAPI Operator

### DIFF
--- a/.cspell-config.json
+++ b/.cspell-config.json
@@ -40,6 +40,7 @@
     "kubeadmcontrolplane",
     "kubeconfig",
     "kubelet",
+    "kustomization",
     "kustomizations",
     "loadbalancer",
     "machinedeployment",

--- a/prow/README.md
+++ b/prow/README.md
@@ -77,8 +77,10 @@ You will need the following CLI tools in order to deploy and/or manage Prow:
 
 ### Folders and components
 
-There are four folders with kustomizations (`capo-cluster`, `cluster-resources`,
-`infra` and `manifests`). The `capo-cluster` folder contains everything needed for
+There are five folders with kustomizations (`capi`, `capo-cluster`,
+`cluster-resources`, `infra` and `manifests`). The `capi` folder contains a
+kustomization for cert-manager, the cluster API operator as well as the provider
+components we use. The `capo-cluster` folder contains everything needed for
 creating the Kubernetes cluster itself. In `cluster-resources`, you will find
 things the cluster needs to integrate with the cloud, i.e. the external
 cloud-provider for OpenStack and CSI plugin for Cinder. It also has the CNI
@@ -365,8 +367,10 @@ You may also have to create a keypair with the Metal3 CI ssh key.
 
    ```bash
    kind create cluster
-   clusterctl init --infrastructure=openstack:v0.11.1 --core=cluster-api:v1.8.5 \
-      --bootstrap=kubeadm:v1.8.5 --control-plane=kubeadm:v1.8.5
+   kubectl apply -k capi
+   # NOTE! You WILL need to apply multiple times before it is successful.
+   # This is because CRDs and webhooks must be in place before other
+   # resources can be added.
    ```
 
 1. Create cluster.

--- a/prow/capi/bootstrap.yaml
+++ b/prow/capi/bootstrap.yaml
@@ -1,0 +1,12 @@
+apiVersion: operator.cluster.x-k8s.io/v1alpha2
+kind: BootstrapProvider
+metadata:
+  name: kubeadm
+  namespace: capi-kubeadm-bootstrap-system
+spec:
+  version: v1.8.5
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: capi-kubeadm-bootstrap-system

--- a/prow/capi/control-plane.yaml
+++ b/prow/capi/control-plane.yaml
@@ -1,0 +1,12 @@
+apiVersion: operator.cluster.x-k8s.io/v1alpha2
+kind: ControlPlaneProvider
+metadata:
+  name: kubeadm
+  namespace: capi-kubeadm-control-plane-system
+spec:
+  version: v1.8.5
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: capi-kubeadm-control-plane-system

--- a/prow/capi/core.yaml
+++ b/prow/capi/core.yaml
@@ -1,0 +1,12 @@
+apiVersion: operator.cluster.x-k8s.io/v1alpha2
+kind: CoreProvider
+metadata:
+  name: cluster-api
+  namespace: capi-system
+spec:
+  version: v1.8.5
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: capi-system

--- a/prow/capi/infrastructure.yaml
+++ b/prow/capi/infrastructure.yaml
@@ -1,0 +1,12 @@
+apiVersion: operator.cluster.x-k8s.io/v1alpha2
+kind: InfrastructureProvider
+metadata:
+  name: openstack
+  namespace: capo-system
+spec:
+  version: v0.11.1
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: capo-system

--- a/prow/capi/kustomization.yaml
+++ b/prow/capi/kustomization.yaml
@@ -1,0 +1,8 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+- https://github.com/cert-manager/cert-manager/releases/download/v1.16.0/cert-manager.yaml
+- https://github.com/kubernetes-sigs/cluster-api-operator/releases/download/v0.14.0/operator-components.yaml
+- core.yaml
+- bootstrap.yaml
+- infrastructure.yaml


### PR DESCRIPTION
We have so far been relying on imperative commands to manage the lifecycle of CAPI/CAPO and cert-manager. This commit introduces the CAPI Operator with manifests to declaratively manage these components instead.

Fixes: #907