### PR TITLE
Prow: Fix missing control-plane provider

### DIFF
--- a/prow/capi/kustomization.yaml
+++ b/prow/capi/kustomization.yaml
@@ -4,5 +4,6 @@ resources:
 - https://github.com/cert-manager/cert-manager/releases/download/v1.16.0/cert-manager.yaml
 - https://github.com/kubernetes-sigs/cluster-api-operator/releases/download/v0.14.0/operator-components.yaml
 - core.yaml
+- control-plane.yaml
 - bootstrap.yaml
 - infrastructure.yaml


### PR DESCRIPTION
I embarrassingly missed to add the control-plane in the kustomization in https://github.com/metal3-io/project-infra/pull/917 :facepalm: 
Good thing I double checked after applying.