### PR TITLE
add blunderbuss to Nordix repos

### DIFF
--- a/prow/config/plugins.yaml
+++ b/prow/config/plugins.yaml
@@ -10,6 +10,7 @@ plugins:
     plugins:
     - approve
     - assign
+    - blunderbuss
     - cat
     - dog
     - heart


### PR DESCRIPTION
Nordix support repos could use blunderbuss as well.