### PR TITLE
Prow: Use flavors with local disk

### DIFF
--- a/prow/capo-cluster/infra-md.yaml
+++ b/prow/capo-cluster/infra-md.yaml
@@ -27,5 +27,5 @@ spec:
       infrastructureRef:
         apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
         kind: OpenStackMachineTemplate
-        name: prow-worker-v1-30-6
+        name: prow-worker-v1-30-6-est
       version: v1.30.6

--- a/prow/capo-cluster/kubeadmcontrolplane.yaml
+++ b/prow/capo-cluster/kubeadmcontrolplane.yaml
@@ -31,6 +31,6 @@ spec:
     infrastructureRef:
       apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
       kind: OpenStackMachineTemplate
-      name: prow-control-plane-v1-30-6
+      name: prow-control-plane-v1-30-6-est
   replicas: 1
   version: v1.30.6

--- a/prow/capo-cluster/machinedeployment.yaml
+++ b/prow/capo-cluster/machinedeployment.yaml
@@ -23,5 +23,5 @@ spec:
       infrastructureRef:
         apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
         kind: OpenStackMachineTemplate
-        name: prow-worker-v1-30-6
+        name: prow-worker-v1-30-6-est
       version: v1.30.6

--- a/prow/capo-cluster/openstackmachinetemplates.yaml
+++ b/prow/capo-cluster/openstackmachinetemplates.yaml
@@ -69,3 +69,35 @@ spec:
       rootVolume:
         sizeGiB: 100
       sshKeyName: metal3ci
+---
+apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+kind: OpenStackMachineTemplate
+metadata:
+  name: prow-control-plane-v1-30-6-est
+spec:
+  template:
+    spec:
+      flavor: c4m12-est
+      identityRef:
+        cloudName: prow
+        name: prow-cloud-config
+      image:
+        filter:
+          name: ubuntu-2204-kube-v1.30.6
+      sshKeyName: metal3ci
+---
+apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+kind: OpenStackMachineTemplate
+metadata:
+  name: prow-worker-v1-30-6-est
+spec:
+  template:
+    spec:
+      flavor: c8m24-est
+      identityRef:
+        cloudName: prow
+        name: prow-cloud-config
+      image:
+        filter:
+          name: ubuntu-2204-kube-v1.30.6
+      sshKeyName: metal3ci


### PR DESCRIPTION
To improve performance and reduce the risk of network issues due to volumes mounted over network, we switch to flavors with local disk. Root volumes are no longer needed.

Fixes: #922