### PR TITLE
add release-1.9 triggers to other repos

### DIFF
--- a/jenkins/README.md
+++ b/jenkins/README.md
@@ -27,6 +27,10 @@ the commands below. The job result will be posted as a comment.
   v1beta1 and branch main on Ubuntu
 * **/test-centos-integration-main** run integration tests with CAPM3 API version
   v1beta1 and branch main on CentOS
+* **/test-ubuntu-integration-release-1-9** run integration tests with CAPM3 API
+  version v1beta1 and branch release-1.9 on Ubuntu
+* **/test-centos-integration-release-1-9** run integration tests with CAPM3 API
+  version v1beta1 and branch release-1.9 on CentOS
 * **/test-ubuntu-integration-release-1-8** run integration tests with CAPM3 API
   version v1beta1 and branch release-1.8 on Ubuntu
 * **/test-centos-integration-release-1-8** run integration tests with CAPM3 API

--- a/prow/config/jobs/metal3-io/ironic-ipa-downloader.yaml
+++ b/prow/config/jobs/metal3-io/ironic-ipa-downloader.yaml
@@ -33,6 +33,10 @@ presubmits:
     agent: jenkins
     always_run: false
     optional: false
+  - name: metal3-centos-e2e-integration-test-release-1-9
+    agent: jenkins
+    always_run: false
+    optional: true
   - name: metal3-centos-e2e-integration-test-release-1-8
     agent: jenkins
     always_run: false
@@ -46,6 +50,10 @@ presubmits:
     always_run: false
     optional: true
   - name: metal3-ubuntu-e2e-integration-test-main
+    agent: jenkins
+    always_run: false
+    optional: true
+  - name: metal3-ubuntu-e2e-integration-test-release-1-9
     agent: jenkins
     always_run: false
     optional: true

--- a/prow/config/jobs/metal3-io/mariadb-image.yaml
+++ b/prow/config/jobs/metal3-io/mariadb-image.yaml
@@ -34,6 +34,10 @@ presubmits:
     agent: jenkins
     always_run: false
     optional: true
+  - name: metal3-centos-e2e-integration-test-release-1-9
+    agent: jenkins
+    always_run: false
+    optional: true
   - name: metal3-centos-e2e-integration-test-release-1-8
     agent: jenkins
     always_run: false
@@ -50,6 +54,10 @@ presubmits:
     agent: jenkins
     always_run: false
     optional: false
+  - name: metal3-ubuntu-e2e-integration-test-release-1-9
+    agent: jenkins
+    always_run: false
+    optional: true
   - name: metal3-ubuntu-e2e-integration-test-release-1-8
     agent: jenkins
     always_run: false

--- a/prow/config/jobs/metal3-io/metal3-dev-env.yaml
+++ b/prow/config/jobs/metal3-io/metal3-dev-env.yaml
@@ -33,6 +33,10 @@ presubmits:
     agent: jenkins
     always_run: false
     optional: true
+  - name: metal3-centos-e2e-basic-test-release-1-9
+    agent: jenkins
+    always_run: false
+    optional: true
   - name: metal3-centos-e2e-basic-test-release-1-8
     agent: jenkins
     always_run: false
@@ -46,6 +50,10 @@ presubmits:
     always_run: false
     optional: true
   - name: metal3-ubuntu-e2e-basic-test-main
+    agent: jenkins
+    always_run: false
+    optional: true
+  - name: metal3-ubuntu-e2e-basic-test-release-1-9
     agent: jenkins
     always_run: false
     optional: true
@@ -66,6 +74,10 @@ presubmits:
     agent: jenkins
     always_run: false
     optional: true
+  - name: metal3-centos-e2e-integration-test-release-1-9
+    agent: jenkins
+    always_run: false
+    optional: false
   - name: metal3-centos-e2e-integration-test-release-1-8
     agent: jenkins
     always_run: false
@@ -79,6 +91,10 @@ presubmits:
     always_run: false
     optional: true
   - name: metal3-ubuntu-e2e-integration-test-main
+    agent: jenkins
+    always_run: false
+    optional: true
+  - name: metal3-ubuntu-e2e-integration-test-release-1-9
     agent: jenkins
     always_run: false
     optional: true
@@ -99,6 +115,10 @@ presubmits:
     agent: jenkins
     always_run: false
     optional: true
+  - name: metal3-centos-e2e-feature-test-release-1-9-pivoting
+    agent: jenkins
+    always_run: false
+    optional: true
   - name: metal3-centos-e2e-feature-test-release-1-8-pivoting
     agent: jenkins
     always_run: false
@@ -112,6 +132,10 @@ presubmits:
     always_run: false
     optional: true
   - name: metal3-centos-e2e-feature-test-main-remediation
+    agent: jenkins
+    always_run: false
+    optional: true
+  - name: metal3-centos-e2e-feature-test-release-1-9-remediation
     agent: jenkins
     always_run: false
     optional: true
@@ -131,6 +155,10 @@ presubmits:
     agent: jenkins
     always_run: false
     optional: true
+  - name: metal3-centos-e2e-feature-test-release-1-9-features
+    agent: jenkins
+    always_run: false
+    optional: true
   - name: metal3-centos-e2e-feature-test-release-1-8-features
     agent: jenkins
     always_run: false
@@ -144,6 +172,10 @@ presubmits:
     always_run: false
     optional: true
   - name: metal3-ubuntu-e2e-feature-test-main-pivoting
+    agent: jenkins
+    always_run: false
+    optional: true
+  - name: metal3-ubuntu-e2e-feature-test-release-1-9-pivoting
     agent: jenkins
     always_run: false
     optional: true
@@ -163,6 +195,10 @@ presubmits:
     agent: jenkins
     always_run: false
     optional: true
+  - name: metal3-ubuntu-e2e-feature-test-release-1-9-remediation
+    agent: jenkins
+    always_run: false
+    optional: true
   - name: metal3-ubuntu-e2e-feature-test-release-1-8-remediation
     agent: jenkins
     always_run: false
@@ -176,6 +212,10 @@ presubmits:
     always_run: false
     optional: true
   - name: metal3-ubuntu-e2e-feature-test-main-features
+    agent: jenkins
+    always_run: false
+    optional: true
+  - name: metal3-ubuntu-e2e-feature-test-release-1-9-features
     agent: jenkins
     always_run: false
     optional: true
@@ -196,6 +236,10 @@ presubmits:
     agent: jenkins
     always_run: false
     optional: true
+  - name: metal3-e2e-clusterctl-upgrade-test-release-1-9
+    agent: jenkins
+    always_run: false
+    optional: true
   - name: metal3-e2e-clusterctl-upgrade-test-release-1-8
     agent: jenkins
     always_run: false
@@ -210,6 +254,10 @@ presubmits:
     optional: true
   # name: {job_prefix}-e2e-{k8s_versions}-upgrade-test-{capm3_target_branch}
   - name: metal3-e2e-1-29-1-30-upgrade-test-main
+    agent: jenkins
+    always_run: false
+    optional: true
+  - name: metal3-e2e-1-29-1-30-upgrade-test-release-1-9
     agent: jenkins
     always_run: false
     optional: true
@@ -229,6 +277,10 @@ presubmits:
     agent: jenkins
     always_run: false
     optional: true
+  - name: metal3-dev-env-integration-test-centos-release-1-9
+    agent: jenkins
+    always_run: false
+    optional: true
   - name: metal3-dev-env-integration-test-centos-release-1-8
     agent: jenkins
     always_run: false
@@ -245,6 +297,10 @@ presubmits:
     agent: jenkins
     always_run: false
     optional: false
+  - name: metal3-dev-env-integration-test-ubuntu-release-1-9
+    agent: jenkins
+    always_run: false
+    optional: true
   - name: metal3-dev-env-integration-test-ubuntu-release-1-8
     agent: jenkins
     always_run: false

--- a/prow/config/plugins.yaml
+++ b/prow/config/plugins.yaml
@@ -171,22 +171,26 @@ triggers:
 
 milestone_applier:
   metal3-io/cluster-api-provider-metal3:
-    main: "CAPM3 - v1.9"
+    main: "CAPM3 - v1.10"
+    release-1.9: "CAPM3 - v1.9"
     release-1.8: "CAPM3 - v1.8"
     release-1.7: "CAPM3 - v1.7"
     release-1.6: "CAPM3 - v1.6"
   metal3-io/baremetal-operator:
-    main: "BMO - v0.9"
+    main: "BMO - v0.10"
+    release-0.9: "BMO - v0.9"
     release-0.8: "BMO - v0.8"
     release-0.6: "BMO - v0.6"
     release-0.5: "BMO - v0.5"
   metal3-io/ip-address-manager:
-    main: "IPAM - v1.9"
+    main: "IPAM - v1.10"
+    release-1.9: "IPAM - v1.9"
     release-1.8: "IPAM - v1.8"
     release-1.7: "IPAM - v1.7"
     release-1.6: "IPAM - v1.6"
   metal3-io/ironic-image:
-    main: "ironic-image - v27.0"
+    main: "ironic-image - v28.0"
+    release-27.0: "ironic-image - v27.0"
     release-26.0: "ironic-image - v26.0"
     release-25.0: "ironic-image - v25.0"
     release-24.1: "ironic-image - v24.1"


### PR DESCRIPTION
Add release-1.9 triggers to dev-env, ipa-downloader and mariadb-image.

Update README.md for the new triggers.

Update milestone applier config to use 1.9 branches and milestones correctly.