### PR TITLE
remove old 1.8 tests from required for dev-env

### DIFF
--- a/prow/config/jobs/metal3-io/metal3-dev-env.yaml
+++ b/prow/config/jobs/metal3-io/metal3-dev-env.yaml
@@ -73,7 +73,7 @@ presubmits:
   - name: metal3-centos-e2e-integration-test-release-1-8
     agent: jenkins
     always_run: false
-    optional: false
+    optional: true
   - name: metal3-centos-e2e-integration-test-release-1-7
     agent: jenkins
     always_run: false


### PR DESCRIPTION
We have 1.9 and 1.8 both enabled now. 1.9 test is working, so remove old 1.8.