### PR TITLE
:bug: fix incorrect PR title handling

### DIFF
--- a/.github/workflows/pr-verifier.yaml
+++ b/.github/workflows/pr-verifier.yaml
@@ -12,13 +12,14 @@ jobs:
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
 
       - name: Validate PR Title
+        env:
+          PR_TITLE: ${{ github.event.pull_request.title }}
         run: |
-          WIP_REGEX="^\W?WIP\W"
-          TAG_REGEX="^\[[[:alnum:]\._-]*\]"
-          PR_TITLE="${{ github.event.pull_request.title }}"
+          WIP_REGEX='^\W?WIP\W'
+          TAG_REGEX='^\[[[:alnum:]\._-]*\]'
 
           # Trim WIP and tags from title
-          trimmed_title=$(echo "$PR_TITLE" | sed -E "s/$WIP_REGEX//" | sed -E "s/$TAG_REGEX//" | xargs)
+          trimmed_title=$(echo "${PR_TITLE}" | sed -E "s/${WIP_REGEX}//" | sed -E "s/${TAG_REGEX}//" | xargs)
 
           # Normalize common emojis in text form to actual emojis
           trimmed_title=$(echo "$trimmed_title" | sed -E "s/:warning:/⚠/g")
@@ -29,7 +30,7 @@ jobs:
           trimmed_title=$(echo "$trimmed_title" | sed -E "s/:seedling:/🌱/g")
 
           # Check PR type prefix
-          if [[ "$trimmed_title" =~ ^(⚠|✨|🐛|📖|🚀|🌱) ]]; then
+          if [[ "${trimmed_title}" =~ ^(⚠|✨|🐛|📖|🚀|🌱) ]]; then
               echo "PR title is valid: $trimmed_title"
           else
               echo "Error: No matching PR type indicator found in title."
@@ -44,7 +45,7 @@ jobs:
           fi
 
           # Check that PR title does not contain Issue or PR number
-          if [[ "$trimmed_title" =~ \#[0-9]+ ]]; then
+          if [[ "${trimmed_title}" =~ \#[0-9]+ ]]; then
               echo "Error: PR title should not contain issue or PR number."
               echo "Issue numbers belong in the PR body as either \"Fixes #XYZ\" (if it closes the issue or PR), or something like \"Related to #XYZ\" (if it's just related)."
               exit 1


### PR DESCRIPTION
This commit:
  - Changes the PR title in the PR verifier script to be a constant string in the BASH context.