### PR TITLE
:seedling: Set scalability test timeout to 6h

### DIFF
--- a/jenkins/jobs/capm3-e2e-tests.pipeline
+++ b/jenkins/jobs/capm3-e2e-tests.pipeline
@@ -27,7 +27,7 @@ script {
   } else if ( "${GINKGO_FOCUS}" == 'k8s-upgrade' ) {
     agent_label = "metal3ci-8c24gb-${IMAGE_OS}"
     TIMEOUT=14400 // 4h
-  } else if ( "${env.EPHEMERAL_TEST}" == 'true' ) {
+  } else if ( "${env.EPHEMERAL_TEST}" == 'true' || "${GINKGO_FOCUS}" == "scalability" ) {
     TIMEOUT=21600 // 6h
     agent_label = "metal3ci-8c32gb-${IMAGE_OS}"
   } else {


### PR DESCRIPTION
As we want to test more clusters in scalability, the default 3h is not enough. For now let's set it to 6h, but the timeout could be extended even further in the future.