### PR TITLE
remove dracut from the IPA rootfs

### DIFF
--- a/jenkins/scripts/dynamic_worker_workflow/build_ipa.sh
+++ b/jenkins/scripts/dynamic_worker_workflow/build_ipa.sh
@@ -66,7 +66,7 @@ METADATA_PATH="/tmp/metadata.txt"
 
 sudo rm -rf "${IPA_BUILD_WORKSPACE}"
 # Update apt packages
-sudo apt-get update -y 
+sudo apt-get update -y
 
 # Install required packages
 sudo apt-get install --yes python3-pip python3-virtualenv qemu-utils

--- a/jenkins/scripts/dynamic_worker_workflow/ipa_builder_elements/ipa-cleanup-dracut/finalise.d/99-delete-dracut
+++ b/jenkins/scripts/dynamic_worker_workflow/ipa_builder_elements/ipa-cleanup-dracut/finalise.d/99-delete-dracut
@@ -5,4 +5,4 @@ if [[ "${DIB_DEBUG_TRACE:-1}" -gt 0 ]]; then
 fi
 set -eu
 
-sudo rm -rf "$TARGET_ROOT/var/tmp/dracut"*
+sudo dnf remove -y dracut


### PR DESCRIPTION
this PR:
  - removes the dracut packages from the rootfs

The size of the IPA image is slowly but steadily growing, and in order to minimize the size of the image some packages could be removed.

Although dracut is used at some point in the DIB build process there  is no point leaving it in the root file system after the IPA build process is finished. IPA user space does not rely on dracut, systemd can handle everything on it's own.