### PR TITLE
add runmariadb script as a shellcheck trigger for mariadb-image

### DIFF
--- a/prow/config/jobs/metal3-io/mariadb-image.yaml
+++ b/prow/config/jobs/metal3-io/mariadb-image.yaml
@@ -1,7 +1,7 @@
 presubmits:
   metal3-io/mariadb-image:
   - name: shellcheck
-    run_if_changed: '((\.sh)|^Makefile)$'
+    run_if_changed: '((\.sh)|^Makefile|^runmariadb)$'
     decorate: true
     spec:
       containers:


### PR DESCRIPTION
Runmariadb script is not a trigger for shellcheck prow job in mariadb-image. Add it.

Another PR is made to mariadb-image to fix the actual shellcheck script.