### PR TITLE
bump kubeconform/manifestlint to v0.6.7

### DIFF
--- a/prow/config/jobs/metal3-io/baremetal-operator.yaml
+++ b/prow/config/jobs/metal3-io/baremetal-operator.yaml
@@ -102,7 +102,7 @@ presubmits:
           value: "TRUE"
         - name: KUBECONFORM_PATH
           value: "/"
-        image: ghcr.io/yannh/kubeconform:v0.6.2-alpine@sha256:49b5f6b320d30c1b8b72a7abdf02740ac9dc36a3ba23b934d1c02f7b37e6e740
+        image: ghcr.io/yannh/kubeconform:v0.6.7-alpine@sha256:824e0c248809e4b2da2a768b16b107cf17ada88a89ec6aa6050e566ba93ebbc6
         imagePullPolicy: Always
   # name: {job_prefix}-{image_os}-e2e-basic-test-{capm3_target_branch}
   - name: metal3-centos-e2e-basic-test-main

--- a/prow/config/jobs/metal3-io/cluster-api-provider-metal3.yaml
+++ b/prow/config/jobs/metal3-io/cluster-api-provider-metal3.yaml
@@ -110,7 +110,7 @@ presubmits:
           value: "TRUE"
         - name: KUBECONFORM_PATH
           value: "/"
-        image: ghcr.io/yannh/kubeconform:v0.6.2-alpine@sha256:49b5f6b320d30c1b8b72a7abdf02740ac9dc36a3ba23b934d1c02f7b37e6e740
+        image: ghcr.io/yannh/kubeconform:v0.6.7-alpine@sha256:824e0c248809e4b2da2a768b16b107cf17ada88a89ec6aa6050e566ba93ebbc6
         imagePullPolicy: Always
   - name: build
     branches:

--- a/prow/config/jobs/metal3-io/ip-address-manager.yaml
+++ b/prow/config/jobs/metal3-io/ip-address-manager.yaml
@@ -109,7 +109,7 @@ presubmits:
           value: "TRUE"
         - name: KUBECONFORM_PATH
           value: "/"
-        image: ghcr.io/yannh/kubeconform:v0.6.2-alpine@sha256:49b5f6b320d30c1b8b72a7abdf02740ac9dc36a3ba23b934d1c02f7b37e6e740
+        image: ghcr.io/yannh/kubeconform:v0.6.7-alpine@sha256:824e0c248809e4b2da2a768b16b107cf17ada88a89ec6aa6050e566ba93ebbc6
         imagePullPolicy: Always
   # name: {job_prefix}-{image_os}-e2e-basic-test-{capm3_target_branch}
   - name: metal3-centos-e2e-basic-test-main

--- a/prow/config/jobs/metal3-io/ironic-standalone-operator.yaml
+++ b/prow/config/jobs/metal3-io/ironic-standalone-operator.yaml
@@ -30,3 +30,21 @@ presubmits:
           value: "TRUE"
         image: docker.io/pipelinecomponents/markdownlint-cli2:0.12.0@sha256:a3977fba9814f10d33a1d69ae607dc808e7a6470b2ba03e84c17193c0791aac0
         imagePullPolicy: Always
+  - name: manifestlint
+    branches:
+    - main
+    skip_if_only_changed: '(((^|/)OWNERS)|((^|/)OWNERS_ALIASES)|(\.md))$'
+    decorate: true
+    spec:
+      containers:
+      - args:
+        - ./hack/manifestlint.sh
+        command:
+        - sh
+        env:
+        - name: IS_CONTAINER
+          value: "TRUE"
+        - name: KUBECONFORM_PATH
+          value: "/"
+        image: ghcr.io/yannh/kubeconform:v0.6.7-alpine@sha256:824e0c248809e4b2da2a768b16b107cf17ada88a89ec6aa6050e566ba93ebbc6
+        imagePullPolicy: Always


### PR DESCRIPTION
Bump kubeconform in manifestlint job to v0.6.7.

Add missing IRSO manifestlint prow job. The script is already in IRSO repo but prow job was missing.

There are no failures in target repos due to bump, will not backport the bump to release branches.