### PR TITLE
🌱 Move mboukhalfa to emeritus approvers

### DIFF
--- a/OWNERS
+++ b/OWNERS
@@ -11,6 +11,7 @@ emeritus_approvers:
 - fmuyassarov
 - furkatgofurov7
 - maelk
+- mboukhalfa
 - russellb
 
 emeritus_reviewers:

--- a/OWNERS_ALIASES
+++ b/OWNERS_ALIASES
@@ -4,7 +4,6 @@ aliases:
   project-infra-maintainers:
   - kashifest
   - lentzi90
-  - mboukhalfa
   - Sunnatillo
   - tuminoid
 


### PR DESCRIPTION
What this PR does / why we need it:
I can't commit to being an approver in this repo, so I am moving myself to emeritus approvers.