### PR TITLE
move provisioning cluster to jenkins agent in bml

### DIFF
--- a/jenkins/scripts/bare_metal_lab/tasks/deploy-tasks.yaml
+++ b/jenkins/scripts/bare_metal_lab/tasks/deploy-tasks.yaml
@@ -47,17 +47,6 @@
     cmd: "brctl addif provisioning eno1"
   become: true
 
-- name: Deploy bmhosts
-  template:
-    src: "templates/bmhosts_crs.yaml.j2"
-    dest: "/opt/metal3-dev-env/bmhosts_crs.yaml"
-
-- name: Apply bmhosts manifest
-  shell:
-    cmd: kubectl apply -f ./bmhosts_crs.yaml -n metal3
-    chdir: "/opt/metal3-dev-env/"
-  tags: kubectl_apply
-
 - name: Set VLAN 3 interface to be up
   shell:
     cmd: "ip link set up dev bmext"
@@ -79,6 +68,17 @@
   become: true
   when: brctl_grep_bmext.rc != 0
   tags: bmext
+
+- name: Deploy bmhosts
+  template:
+    src: "templates/bmhosts_crs.yaml.j2"
+    dest: "/opt/metal3-dev-env/bmhosts_crs.yaml"
+
+- name: Apply bmhosts manifest
+  shell:
+    cmd: kubectl apply -f ./bmhosts_crs.yaml -n metal3
+    chdir: "/opt/metal3-dev-env/"
+  tags: kubectl_apply
 
 - name: Wait until all BMHs become available .
   kubernetes.core.k8s_info:

--- a/jenkins/scripts/bml_cleanup.sh
+++ b/jenkins/scripts/bml_cleanup.sh
@@ -8,24 +8,9 @@ set -eu
 # Usage:
 #  cleanup_bml.sh
 #
+
+CI_DIR="$(dirname "$(readlink -f "${0}")")"
+
 echo "Cleaning up the lab"
-# Execute remote script
-# shellcheck disable=SC2029
 
-TEST_EXECUTER_IP="192.168.1.3"
-
-ssh \
-    -o StrictHostKeyChecking=no \
-    -o UserKnownHostsFile=/dev/null \
-    -o ServerAliveInterval=15 \
-    -o ServerAliveCountMax=10 \
-    -o SendEnv="BML_ILO_USERNAME" \
-    -o SendEnv="BML_ILO_PASSWORD" \
-    -o SendEnv="GITHUB_TOKEN" \
-    -o SendEnv="REPO_NAME" \
-    -o SendEnv="BML_METAL3_DEV_ENV_REPO" \
-    -o SendEnv="BML_METAL3_DEV_ENV_BRANCH" \
-    -o SendEnv="PR_ID" \
-    -i "${METAL3_CI_USER_KEY}" \
-    "${METAL3_CI_USER}"@"${TEST_EXECUTER_IP}" \
-    ANSIBLE_FORCE_COLOR=true ansible-playbook -v /tmp/bare_metal_lab/cleanup-lab.yaml --skip-tags "clone"
+ANSIBLE_FORCE_COLOR=true ansible-playbook -v "${CI_DIR}"/bare_metal_lab/cleanup-lab.yaml --skip-tags "clone"

--- a/jenkins/scripts/files/run_clean.sh
+++ b/jenkins/scripts/files/run_clean.sh
@@ -15,8 +15,8 @@ else
     export EPHEMERAL_CLUSTER="minikube"
 fi
 if [[ "${REPO_NAME}" == "metal3-dev-env" ]]; then
-    pushd tested_repo
+    pushd "${HOME}/tested_repo"
 else
-    pushd metal3
+    pushd "${HOME}/metal3"
 fi
 make clean

--- a/jenkins/scripts/files/run_integration_tests.sh
+++ b/jenkins/scripts/files/run_integration_tests.sh
@@ -2,11 +2,7 @@
 
 set -eux
 
-VARS_FILE="${1:?}"
-export GITHUB_TOKEN="${2:?}"
-
-# shellcheck disable=SC1090
-source "${VARS_FILE}"
+export GITHUB_TOKEN="${1:?}"
 
 export CAPI_VERSION
 export CAPM3_VERSION
@@ -37,9 +33,9 @@ fi
 # In the bare metal lab, we have already cloned metal3-dev-env and we run integration tests
 # so no need to clone other repos.
 if [[ "${REPO_NAME}" == "metal3-dev-env" ]]; then
-    cd tested_repo
+    cd "${HOME}/tested_repo"
 else
-    cd metal3
+    cd "${HOME}/metal3"
 fi
 
 # See bare metal lab infrastructure documentation:


### PR DESCRIPTION
This PR moves provisioning cluster (minikube) from bare metal server to virtual machine that serves as jenkins agent