### PR TITLE
Prow: Add tolerations and nodeSelectors for CAPI related components and bump versions

### DIFF
--- a/prow/README.md
+++ b/prow/README.md
@@ -422,8 +422,10 @@ You may also have to create a keypair with the Metal3 CI ssh key.
 1. Make cluster self-hosted
 
    ```bash
-   clusterctl init --infrastructure=openstack:v0.11.1 --core=cluster-api:v1.8.5 \
-      --bootstrap=kubeadm:v1.8.5 --control-plane=kubeadm:v1.8.5
+   kubectl apply -k capi
+   # NOTE! You WILL need to apply the above multiple times before it is successful.
+   # This is because CRDs and webhooks must be in place before other
+   # resources can be added.
    unset KUBECONFIG
    clusterctl move --to-kubeconfig=capo-cluster/kubeconfig.yaml
    export KUBECONFIG=capo-cluster/kubeconfig.yaml

--- a/prow/capi/bootstrap.yaml
+++ b/prow/capi/bootstrap.yaml
@@ -4,7 +4,7 @@ metadata:
   name: kubeadm
   namespace: capi-kubeadm-bootstrap-system
 spec:
-  version: v1.8.5
+  version: v1.9.5
   deployment:
     nodeSelector:
       node-role.kubernetes.io/infra: ""

--- a/prow/capi/bootstrap.yaml
+++ b/prow/capi/bootstrap.yaml
@@ -5,6 +5,13 @@ metadata:
   namespace: capi-kubeadm-bootstrap-system
 spec:
   version: v1.8.5
+  deployment:
+    nodeSelector:
+      node-role.kubernetes.io/infra: ""
+    tolerations:
+    - key: node-role.kubernetes.io/infra
+      operator: Exists
+      effect: NoSchedule
 ---
 apiVersion: v1
 kind: Namespace

--- a/prow/capi/control-plane.yaml
+++ b/prow/capi/control-plane.yaml
@@ -4,7 +4,7 @@ metadata:
   name: kubeadm
   namespace: capi-kubeadm-control-plane-system
 spec:
-  version: v1.8.5
+  version: v1.9.5
   deployment:
     nodeSelector:
       node-role.kubernetes.io/infra: ""

--- a/prow/capi/control-plane.yaml
+++ b/prow/capi/control-plane.yaml
@@ -5,6 +5,13 @@ metadata:
   namespace: capi-kubeadm-control-plane-system
 spec:
   version: v1.8.5
+  deployment:
+    nodeSelector:
+      node-role.kubernetes.io/infra: ""
+    tolerations:
+    - key: node-role.kubernetes.io/infra
+      operator: Exists
+      effect: NoSchedule
 ---
 apiVersion: v1
 kind: Namespace

--- a/prow/capi/core.yaml
+++ b/prow/capi/core.yaml
@@ -4,7 +4,7 @@ metadata:
   name: cluster-api
   namespace: capi-system
 spec:
-  version: v1.8.5
+  version: v1.9.5
   deployment:
     nodeSelector:
       node-role.kubernetes.io/infra: ""

--- a/prow/capi/core.yaml
+++ b/prow/capi/core.yaml
@@ -5,6 +5,13 @@ metadata:
   namespace: capi-system
 spec:
   version: v1.8.5
+  deployment:
+    nodeSelector:
+      node-role.kubernetes.io/infra: ""
+    tolerations:
+    - key: node-role.kubernetes.io/infra
+      operator: Exists
+      effect: NoSchedule
 ---
 apiVersion: v1
 kind: Namespace

--- a/prow/capi/infrastructure.yaml
+++ b/prow/capi/infrastructure.yaml
@@ -4,7 +4,7 @@ metadata:
   name: openstack
   namespace: capo-system
 spec:
-  version: v0.11.1
+  version: v0.12.1
   deployment:
     nodeSelector:
       node-role.kubernetes.io/infra: ""

--- a/prow/capi/infrastructure.yaml
+++ b/prow/capi/infrastructure.yaml
@@ -5,6 +5,13 @@ metadata:
   namespace: capo-system
 spec:
   version: v0.11.1
+  deployment:
+    nodeSelector:
+      node-role.kubernetes.io/infra: ""
+    tolerations:
+    - key: node-role.kubernetes.io/infra
+      operator: Exists
+      effect: NoSchedule
 ---
 apiVersion: v1
 kind: Namespace

--- a/prow/capi/kustomization.yaml
+++ b/prow/capi/kustomization.yaml
@@ -1,9 +1,27 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
-- https://github.com/cert-manager/cert-manager/releases/download/v1.16.0/cert-manager.yaml
+- https://github.com/cert-manager/cert-manager/releases/download/v1.17.1/cert-manager.yaml
 - https://github.com/kubernetes-sigs/cluster-api-operator/releases/download/v0.14.0/operator-components.yaml
 - core.yaml
 - control-plane.yaml
 - bootstrap.yaml
 - infrastructure.yaml
+
+patches:
+# Cert-manager does not set any toleration so we have to first create
+# the array/map before we can add values to them...
+- patch: |-
+    - op: add
+      path: /spec/template/spec/tolerations
+      value: []
+  target:
+    kind: Deployment
+    name: cert-manager|cert-manager-cainjector|cert-manager-webhook
+    namespace: cert-manager
+# Add toleration and node selector to run on infra nodes
+- path: toleration-node-selector-patch.yaml
+  target:
+    kind: Deployment
+    name: cert-manager|cert-manager-cainjector|cert-manager-webhook
+    namespace: cert-manager

--- a/prow/capi/kustomization.yaml
+++ b/prow/capi/kustomization.yaml
@@ -3,6 +3,8 @@ kind: Kustomization
 resources:
 - https://github.com/cert-manager/cert-manager/releases/download/v1.17.1/cert-manager.yaml
 - https://github.com/kubernetes-sigs/cluster-api-operator/releases/download/v0.17.0/operator-components.yaml
+# ORC is needed for CAPO
+- https://github.com/k-orc/openstack-resource-controller/releases/download/v1.0.1/install.yaml
 - core.yaml
 - control-plane.yaml
 - bootstrap.yaml
@@ -28,6 +30,18 @@ patches:
     kind: Deployment
     name: capi-operator-controller-manager
     namespace: capi-operator-system
+# ORC does not set either
+- patch: |-
+    - op: add
+      path: /spec/template/spec/nodeSelector
+      value: {}
+    - op: add
+      path: /spec/template/spec/tolerations
+      value: []
+  target:
+    kind: Deployment
+    name: orc-controller-manager
+    namespace: orc-system
 # Add toleration and node selector to run on infra nodes
 - path: toleration-node-selector-patch.yaml
   target:
@@ -39,3 +53,8 @@ patches:
     kind: Deployment
     name: capi-operator-controller-manager
     namespace: capi-operator-system
+- path: toleration-node-selector-patch.yaml
+  target:
+    kind: Deployment
+    name: orc-controller-manager
+    namespace: orc-system

--- a/prow/capi/kustomization.yaml
+++ b/prow/capi/kustomization.yaml
@@ -2,7 +2,7 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
 - https://github.com/cert-manager/cert-manager/releases/download/v1.17.1/cert-manager.yaml
-- https://github.com/kubernetes-sigs/cluster-api-operator/releases/download/v0.14.0/operator-components.yaml
+- https://github.com/kubernetes-sigs/cluster-api-operator/releases/download/v0.17.0/operator-components.yaml
 - core.yaml
 - control-plane.yaml
 - bootstrap.yaml
@@ -19,9 +19,23 @@ patches:
     kind: Deployment
     name: cert-manager|cert-manager-cainjector|cert-manager-webhook
     namespace: cert-manager
+# CAPI operator does not set any nodeSelector
+- patch: |-
+    - op: add
+      path: /spec/template/spec/nodeSelector
+      value: {}
+  target:
+    kind: Deployment
+    name: capi-operator-controller-manager
+    namespace: capi-operator-system
 # Add toleration and node selector to run on infra nodes
 - path: toleration-node-selector-patch.yaml
   target:
     kind: Deployment
     name: cert-manager|cert-manager-cainjector|cert-manager-webhook
     namespace: cert-manager
+- path: toleration-node-selector-patch.yaml
+  target:
+    kind: Deployment
+    name: capi-operator-controller-manager
+    namespace: capi-operator-system

--- a/prow/capi/toleration-node-selector-patch.yaml
+++ b/prow/capi/toleration-node-selector-patch.yaml
@@ -1,0 +1,13 @@
+- op: add
+  path: /spec/template/spec/tolerations/-
+  value:
+    key: node-role.kubernetes.io/infra
+    operator: Exists
+    effect: NoSchedule
+# We add the node selector for node-role.kubernetes.io/infra=""
+# The key has to be included in the path or it would overwrite any existing nodeSelectors.
+# We have to write the "/" as "~1" since it is the separator in the path field.
+# See https://datatracker.ietf.org/doc/html/rfc6901#section-3
+- op: add
+  path: /spec/template/spec/nodeSelector/node-role.kubernetes.io~1infra
+  value: ""


### PR DESCRIPTION
Make sure that all CAPI related components run on the infra nodes by adding tolerations and nodeSelectors to them.
Bump cert-manager and CAPI operator versions and update README to always use the operator way of deploying CAPI providers.
Bump CAPI core, KBT and KCP to v1.9.5 and CAPO to v0.12.1.
CAPO has a new external dependency, ORC, so this is also added, plus tolerations and nodeSelector for it.

Changes are already applied in the cluster.