### PR TITLE
Prow: Upgrade kubernetes, ingress, calico and more

### DIFF
--- a/prow/capo-cluster/infra-md.yaml
+++ b/prow/capo-cluster/infra-md.yaml
@@ -27,5 +27,5 @@ spec:
       infrastructureRef:
         apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
         kind: OpenStackMachineTemplate
-        name: prow-worker-v1-30-6-est
-      version: v1.30.6
+        name: prow-worker-v1-31-6
+      version: v1.31.6

--- a/prow/capo-cluster/kubeadmcontrolplane.yaml
+++ b/prow/capo-cluster/kubeadmcontrolplane.yaml
@@ -31,6 +31,6 @@ spec:
     infrastructureRef:
       apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
       kind: OpenStackMachineTemplate
-      name: prow-control-plane-v1-30-6-est
+      name: prow-control-plane-v1-31-6
   replicas: 1
-  version: v1.30.6
+  version: v1.31.6

--- a/prow/capo-cluster/machinedeployment.yaml
+++ b/prow/capo-cluster/machinedeployment.yaml
@@ -23,5 +23,5 @@ spec:
       infrastructureRef:
         apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
         kind: OpenStackMachineTemplate
-        name: prow-worker-v1-30-6-est
-      version: v1.30.6
+        name: prow-worker-v1-31-6
+      version: v1.31.6

--- a/prow/capo-cluster/openstackcluster.yaml
+++ b/prow/capo-cluster/openstackcluster.yaml
@@ -7,6 +7,8 @@ spec:
     enabled: true
     allowedCIDRs:
     - 10.6.0.0/24
+    # Jumphost
+    - 129.192.83.86/32
   externalNetwork:
     id: df26cc5b-b122-4506-b948-a213d2b0a7d8
   identityRef:
@@ -40,8 +42,8 @@ spec:
   bastion:
     enabled: true
     spec:
-      flavor: c1m2
+      flavor: c1m2-est
       image:
-        filter:
-          name: "Ubuntu-22.04-jammy"
+        # Ubuntu-24.04
+        id: 19e017ae-2759-479c-90ac-a400a3f64678
       sshKeyName: metal3ci

--- a/prow/capo-cluster/openstackmachinetemplates.yaml
+++ b/prow/capo-cluster/openstackmachinetemplates.yaml
@@ -1,78 +1,6 @@
 apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
 kind: OpenStackMachineTemplate
 metadata:
-  name: prow-control-plane-v1-29-4-new
-spec:
-  template:
-    spec:
-      flavor: c4m4
-      identityRef:
-        cloudName: prow
-        name: prow-cloud-config
-      image:
-        filter:
-          name: ubuntu-2204-kube-v1.29.4
-      rootVolume:
-        sizeGiB: 100
-      sshKeyName: metal3ci
----
-apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
-kind: OpenStackMachineTemplate
-metadata:
-  name: prow-worker-v1-29-4-new
-spec:
-  template:
-    spec:
-      flavor: c8m16avx2
-      identityRef:
-        cloudName: prow
-        name: prow-cloud-config
-      image:
-        filter:
-          name: ubuntu-2204-kube-v1.29.4
-      rootVolume:
-        sizeGiB: 100
-      sshKeyName: metal3ci
----
-apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
-kind: OpenStackMachineTemplate
-metadata:
-  name: prow-control-plane-v1-30-6
-spec:
-  template:
-    spec:
-      flavor: c4m4
-      identityRef:
-        cloudName: prow
-        name: prow-cloud-config
-      image:
-        filter:
-          name: ubuntu-2204-kube-v1.30.6
-      rootVolume:
-        sizeGiB: 100
-      sshKeyName: metal3ci
----
-apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
-kind: OpenStackMachineTemplate
-metadata:
-  name: prow-worker-v1-30-6
-spec:
-  template:
-    spec:
-      flavor: c8m16avx2
-      identityRef:
-        cloudName: prow
-        name: prow-cloud-config
-      image:
-        filter:
-          name: ubuntu-2204-kube-v1.30.6
-      rootVolume:
-        sizeGiB: 100
-      sshKeyName: metal3ci
----
-apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
-kind: OpenStackMachineTemplate
-metadata:
   name: prow-control-plane-v1-30-6-est
 spec:
   template:
@@ -100,4 +28,36 @@ spec:
       image:
         filter:
           name: ubuntu-2204-kube-v1.30.6
+      sshKeyName: metal3ci
+---
+apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+kind: OpenStackMachineTemplate
+metadata:
+  name: prow-control-plane-v1-31-6
+spec:
+  template:
+    spec:
+      flavor: c4m12-est
+      identityRef:
+        cloudName: prow
+        name: prow-cloud-config
+      image:
+        filter:
+          name: ubuntu-2404-kube-v1.31.6
+      sshKeyName: metal3ci
+---
+apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+kind: OpenStackMachineTemplate
+metadata:
+  name: prow-worker-v1-31-6
+spec:
+  template:
+    spec:
+      flavor: c8m24-est
+      identityRef:
+        cloudName: prow
+        name: prow-cloud-config
+      image:
+        filter:
+          name: ubuntu-2404-kube-v1.31.6
       sshKeyName: metal3ci

--- a/prow/cluster-resources/autoscaler.yaml
+++ b/prow/cluster-resources/autoscaler.yaml
@@ -18,7 +18,7 @@ spec:
         app: cluster-autoscaler
     spec:
       containers:
-      - image: registry.k8s.io/autoscaling/cluster-autoscaler:v1.30.2
+      - image: registry.k8s.io/autoscaling/cluster-autoscaler
         name: cluster-autoscaler
         command:
         - /cluster-autoscaler

--- a/prow/cluster-resources/kustomization.yaml
+++ b/prow/cluster-resources/kustomization.yaml
@@ -1,17 +1,23 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
-- https://raw.githubusercontent.com/projectcalico/calico/v3.28.2/manifests/calico.yaml
-- https://raw.githubusercontent.com/kubernetes/cloud-provider-openstack/v1.30.1/manifests/controller-manager/cloud-controller-manager-roles.yaml
-- https://raw.githubusercontent.com/kubernetes/cloud-provider-openstack/v1.30.1/manifests/controller-manager/cloud-controller-manager-role-bindings.yaml
-- https://raw.githubusercontent.com/kubernetes/cloud-provider-openstack/v1.30.1/manifests/controller-manager/openstack-cloud-controller-manager-ds.yaml
-- https://raw.githubusercontent.com/kubernetes/cloud-provider-openstack/v1.30.1/manifests/cinder-csi-plugin/cinder-csi-controllerplugin-rbac.yaml
-- https://raw.githubusercontent.com/kubernetes/cloud-provider-openstack/v1.30.1/manifests/cinder-csi-plugin/cinder-csi-controllerplugin.yaml
-- https://raw.githubusercontent.com/kubernetes/cloud-provider-openstack/v1.30.1/manifests/cinder-csi-plugin/cinder-csi-nodeplugin-rbac.yaml
-- https://raw.githubusercontent.com/kubernetes/cloud-provider-openstack/v1.30.1/manifests/cinder-csi-plugin/cinder-csi-nodeplugin.yaml
-- https://raw.githubusercontent.com/kubernetes/cloud-provider-openstack/v1.30.1/manifests/cinder-csi-plugin/csi-cinder-driver.yaml
+- https://raw.githubusercontent.com/projectcalico/calico/v3.29.2/manifests/calico.yaml
+# Check available versions at https://github.com/kubernetes/cloud-provider-openstack/releases
+- https://raw.githubusercontent.com/kubernetes/cloud-provider-openstack/v1.31.3/manifests/controller-manager/cloud-controller-manager-roles.yaml
+- https://raw.githubusercontent.com/kubernetes/cloud-provider-openstack/v1.31.3/manifests/controller-manager/cloud-controller-manager-role-bindings.yaml
+- https://raw.githubusercontent.com/kubernetes/cloud-provider-openstack/v1.31.3/manifests/controller-manager/openstack-cloud-controller-manager-ds.yaml
+- https://raw.githubusercontent.com/kubernetes/cloud-provider-openstack/v1.31.3/manifests/cinder-csi-plugin/cinder-csi-controllerplugin-rbac.yaml
+- https://raw.githubusercontent.com/kubernetes/cloud-provider-openstack/v1.31.3/manifests/cinder-csi-plugin/cinder-csi-controllerplugin.yaml
+- https://raw.githubusercontent.com/kubernetes/cloud-provider-openstack/v1.31.3/manifests/cinder-csi-plugin/cinder-csi-nodeplugin-rbac.yaml
+- https://raw.githubusercontent.com/kubernetes/cloud-provider-openstack/v1.31.3/manifests/cinder-csi-plugin/cinder-csi-nodeplugin.yaml
+- https://raw.githubusercontent.com/kubernetes/cloud-provider-openstack/v1.31.3/manifests/cinder-csi-plugin/csi-cinder-driver.yaml
 - autoscaler.yaml
 - coredns-pdb.yaml
+
+images:
+# Check available tags at https://github.com/kubernetes/autoscaler/tags
+- name: registry.k8s.io/autoscaling/cluster-autoscaler
+  newTag: v1.31.1
 
 generatorOptions:
   disableNameSuffixHash: true

--- a/prow/infra/add-args.yaml
+++ b/prow/infra/add-args.yaml
@@ -1,4 +1,0 @@
-# See https://github.com/kubernetes/ingress-nginx/issues/10572
-- op: add
-  path: /spec/template/spec/containers/0/args/-
-  value: --enable-annotation-validation=true

--- a/prow/infra/configmap-patch.yaml
+++ b/prow/infra/configmap-patch.yaml
@@ -1,8 +1,0 @@
-apiVersion: v1
-kind: ConfigMap
-metadata:
-  name: ingress-nginx-controller
-  namespace: ingress-nginx
-data:
-  # See https://kubernetes.github.io/ingress-nginx/user-guide/nginx-configuration/configmap/#strict-validate-path-type
-  strict-validate-path-type: "true"

--- a/prow/infra/kustomization.yaml
+++ b/prow/infra/kustomization.yaml
@@ -1,7 +1,7 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
-- https://github.com/kubernetes/ingress-nginx/deploy/static/provider/cloud?ref=controller-v1.10.4
+- https://github.com/kubernetes/ingress-nginx/deploy/static/provider/cloud?ref=controller-v1.12.0
 - cluster-issuer-http.yaml
 - storageclass.yaml
 - ingress-controller-pdb.yaml
@@ -15,12 +15,6 @@ patches:
     kind: Job
     namespace: ingress-nginx
 - path: ingress-controller-deployment-patch.yaml
-- path: configmap-patch.yaml
-- path: add-args.yaml
-  target:
-    kind: Deployment
-    namespace: ingress-nginx
-    name: ingress-nginx-controller
 # Run on infra nodes
 - path: toleration-node-selector-patch.yaml
   target:


### PR DESCRIPTION
See individual commit messages for more details.
This PR does the following:
- Upgrade ingress-nginx to v1.12.0
- Upgrade Calico
- Upgrade cloud-provider integrations and cluster-autoscaler
- Upgrade kubernetes to v1.31.6
- Upgrade nodes and bastion to Ubuntu 24.04

The changes are already applied.