### PR TITLE
:seedling: Add pull bmo e2e optional to prow

### DIFF
--- a/jenkins/jobs/bmo_e2e_optional_tests.pipeline
+++ b/jenkins/jobs/bmo_e2e_optional_tests.pipeline
@@ -1,0 +1,89 @@
+import java.text.SimpleDateFormat
+
+// 2 hour
+def TIMEOUT = 7200
+
+// Set defaults for non-PR jobs
+def pullSha = (env.PULL_PULL_SHA) ?: "main"
+def pullBase = (env.PULL_BASE_REF) ?: "main"
+def repoUrl = "https://github.com/metal3-io/baremetal-operator.git"
+// Fetch the base branch and the pullSha, nothing else
+def refspec = '+refs/heads/' + pullBase + ':refs/remotes/origin/' + pullBase + ' ' + pullSha
+
+pipeline {
+  environment {
+    GINKGO_FOCUS="${GINKGO_FOCUS}"
+  }
+  agent none
+  stages {
+    stage("Run Baremetal Operator optional e2e tests") {
+      matrix {
+        agent { label "metal3ci-8c16gb-ubuntu" }
+        // Skip redfish on PRs, test all for periodic jobs
+        when {
+          anyOf {
+            expression { env.BMC_PROTOCOL != "redfish" }
+            triggeredBy 'TimerTrigger'
+          }
+        }
+        axes {
+          axis {
+            name 'BMC_PROTOCOL'
+            values 'ipmi', 'redfish', 'redfish-virtualmedia'
+          }
+        }
+        environment {
+          BMC_PROTOCOL = "${BMC_PROTOCOL}"
+        }
+        stages {
+          stage("Checkout source code") {
+            steps {
+              checkout scmGit(
+                  branches: [[name: pullSha]],
+                  userRemoteConfigs: [[url: repoUrl, credentialsId: "metal3-jenkins-github-username-token", refspec: refspec]],
+                  extensions: [[$class: "WipeWorkspace"],
+                  [$class: "CleanCheckout"],
+                  [$class: "CleanBeforeCheckout"],
+                  [$class: "PreBuildMerge", options: [mergeTarget: pullBase, mergeRemote: "origin"]],
+                  [$class: "UserIdentity", name: "Test", email: "test@test.test"],
+                  cloneOption(honorRefspec: true)],
+                  submoduleCfg: [],)
+              script {
+                CURRENT_START_TIME = System.currentTimeMillis()
+              }
+            }
+          }
+          stage("Run Baremetal Operator optional e2e tests") {
+            options {
+              timeout(time: TIMEOUT, unit: "SECONDS")
+              ansiColor("xterm")
+            }
+            steps {
+              withCredentials([string(credentialsId: "metal3-clusterctl-github-token", variable: "GITHUB_TOKEN")]) {
+                timestamps {
+                  sh "./hack/ci-e2e.sh"
+                }
+              }
+            }
+            post {
+              always {
+                script {
+                  CURRENT_END_TIME = System.currentTimeMillis()
+                  if ((((CURRENT_END_TIME - CURRENT_START_TIME)/1000) - TIMEOUT) > 0) {
+                      echo "Failed due to timeout"
+                      currentBuild.result = "FAILURE"
+                  }
+                }
+                archiveArtifacts "artifacts*.tar.gz"
+                timestamps {
+                  /* Clean up */
+                  sh "make clean-e2e"
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/prow/config/jobs/metal3-io/baremetal-operator-release-0.8.yaml
+++ b/prow/config/jobs/metal3-io/baremetal-operator-release-0.8.yaml
@@ -188,3 +188,9 @@ presubmits:
     agent: jenkins
     always_run: false
     optional: true
+  - name: metal3-bmo-e2e-test-optional-pull
+    branches:
+    - release-0.8
+    agent: jenkins
+    always_run: false
+    optional: true

--- a/prow/config/jobs/metal3-io/baremetal-operator-release-0.9.yaml
+++ b/prow/config/jobs/metal3-io/baremetal-operator-release-0.9.yaml
@@ -188,3 +188,9 @@ presubmits:
     agent: jenkins
     always_run: false
     optional: true
+  - name: metal3-bmo-e2e-test-optional-pull
+    branches:
+    - release-0.9
+    agent: jenkins
+    always_run: false
+    optional: true

--- a/prow/config/jobs/metal3-io/baremetal-operator.yaml
+++ b/prow/config/jobs/metal3-io/baremetal-operator.yaml
@@ -193,3 +193,9 @@ presubmits:
     agent: jenkins
     always_run: false
     optional: true
+  - name: metal3-bmo-e2e-test-optional-pull
+    branches:
+    - main
+    agent: jenkins
+    always_run: false
+    optional: true


### PR DESCRIPTION
Optional BMO e2e tests have been running as periodic jobs by Github agents, adding only the pull jobs so that they can be triggered on PRs as well.