### PR TITLE
prow-test-dumper: handle completely missing branch protection case

### DIFF
--- a/hack/prow_test_dumper.py
+++ b/hack/prow_test_dumper.py
@@ -67,6 +67,11 @@ def get_github_branch_protection(owner: str, repo: str, branch: str, token: str)
                 status_checks = settings["required_status_checks"]
                 if status_checks:
                     return status_checks.get("contexts", [])
+    except requests.exceptions.HTTPError as ex:
+        if response.status_code == 404:
+            # branch protection is not configured at all
+            return []
+        sys.exit(f"Error: {str(ex)}")
     except requests.exceptions.RequestException as ex:
         sys.exit(f"Error: {str(ex)}")
     return []


### PR DESCRIPTION
In case a branch is not having any branch protection (it is not defined at all, or matching any branch protection wildcards), we just exited before. Now, it will return empty set, so we correctly get notified that tests are missing, and also the processing continues to further jobs defined.