### PR TITLE
Prow: Disable legacy cache option

### DIFF
--- a/prow/manifests/base/ghproxy.yaml
+++ b/prow/manifests/base/ghproxy.yaml
@@ -39,6 +39,7 @@ spec:
         - --cache-dir=/cache
         - --cache-sizeGB=99
         - --serve-metrics=true
+        - --legacy-disable-disk-cache-partitions-by-auth-header=false
         ports:
         - containerPort: 8888
         volumeMounts:


### PR DESCRIPTION
GHProxy has been logging warnings about a legacy option. This commit disables it. The log message suggests that smaller prow instances can set this flag to false unconditionally, so it should work well for us. This is what the warnings look like:

```
{"component":"ghproxy","file":"sigs.k8s.io/prow/cmd/ghproxy/ghproxy.go:173","func":"main.main","level":"warning","msg":"The deprecated `--legacy-disable-disk-cache-partitions-by-auth-header` flags value is `true`. If you are a bigger Prow setup, you should copy your existing cache directory to the directory mentioned in the `Not using a partitioned cache because legacyDisablePartitioningByAuthHeader is true` messages to warm up the partitioned-by-auth-header cache, then set the flag to false. If you are a smaller Prow setup or just started using ghproxy you can just unconditionally set it to `false`.","severity":"warning","time":"2025-04-01T10:44:52Z"}
```