### PR TITLE
Remove unnecessary git credentials

### DIFF
--- a/jenkins/jobs/bml_integration_tests.pipeline
+++ b/jenkins/jobs/bml_integration_tests.pipeline
@@ -1,7 +1,5 @@
 import java.text.SimpleDateFormat
 
-ci_git_credential_id = "metal3-jenkins-github-username-token"
-
 // 3 hours
 def TIMEOUT = 10800
 
@@ -65,9 +63,7 @@ pipeline {
               [$class: 'CleanBeforeCheckout']
               ],
           submoduleCfg: [],
-          userRemoteConfigs: [
-              [credentialsId: ci_git_credential_id,url: ci_git_url, refspec: refspec]
-              ]
+          userRemoteConfigs: [[url: ci_git_url, refspec: refspec]]
           ])
         script {
           CURRENT_START_TIME = System.currentTimeMillis()

--- a/jenkins/jobs/bmo_e2e_optional_tests.pipeline
+++ b/jenkins/jobs/bmo_e2e_optional_tests.pipeline
@@ -40,7 +40,7 @@ pipeline {
             steps {
               checkout scmGit(
                   branches: [[name: pullSha]],
-                  userRemoteConfigs: [[url: repoUrl, credentialsId: "metal3-jenkins-github-username-token", refspec: refspec]],
+                  userRemoteConfigs: [[url: repoUrl, refspec: refspec]],
                   extensions: [[$class: "WipeWorkspace"],
                   [$class: "CleanCheckout"],
                   [$class: "CleanBeforeCheckout"],

--- a/jenkins/jobs/capm3-e2e-tests.pipeline
+++ b/jenkins/jobs/capm3-e2e-tests.pipeline
@@ -1,6 +1,3 @@
-
-ci_git_credential_id = 'metal3-jenkins-github-username-token'
-
 // 3 hours
 int TIMEOUT = 10800
 
@@ -92,9 +89,7 @@ pipeline {
                       [$class: 'CleanBeforeCheckout']
                       ],
                   submoduleCfg: [],
-                  userRemoteConfigs: [
-                      [credentialsId: ci_git_credential_id,url: ci_git_url, refspec: refspec]
-                      ]
+                  userRemoteConfigs: [[url: ci_git_url, refspec: refspec]]
                   ])
                 withCredentials([string(credentialsId: 'metal3-clusterctl-github-token', variable: 'GITHUB_TOKEN')]) {
                     ansiColor('xterm') {

--- a/jenkins/jobs/clean_resources.pipeline
+++ b/jenkins/jobs/clean_resources.pipeline
@@ -1,6 +1,5 @@
 import java.text.SimpleDateFormat
 
-ci_git_credential_id = "metal3-jenkins-github-username-token"
 def TIMEOUT = 1800
 
 script {
@@ -47,8 +46,7 @@ pipeline {
                  [$class: 'CleanCheckout'],
                  [$class: 'CleanBeforeCheckout']],
                  submoduleCfg: [],
-                 userRemoteConfigs: [[credentialsId: ci_git_credential_id,
-                 url: ci_git_url,  refspec: refspec]]])
+                 userRemoteConfigs: [[url: ci_git_url,  refspec: refspec]]])
       }
     }
     stage('Clean old integration test vms') {

--- a/jenkins/jobs/dev_env_integration_tests.pipeline
+++ b/jenkins/jobs/dev_env_integration_tests.pipeline
@@ -1,7 +1,5 @@
 import java.text.SimpleDateFormat
 
-ci_git_credential_id = "metal3-jenkins-github-username-token"
-
 // 3 hours
 def TIMEOUT = 10800
 
@@ -69,12 +67,7 @@ pipeline {
           [$class: 'CleanBeforeCheckout']
         ],
         submoduleCfg: [],
-        userRemoteConfigs: [
-          [credentialsId: ci_git_credential_id,
-          url: ci_git_url,
-          refspec: refspec
-          ]
-        ]
+        userRemoteConfigs: [[url: ci_git_url, refspec: refspec]]
         ])
 
        withCredentials([string(credentialsId: 'metal3-clusterctl-github-token', variable: 'GITHUB_TOKEN')]) {

--- a/jenkins/jobs/dynamic_fullstack_building.pipeline
+++ b/jenkins/jobs/dynamic_fullstack_building.pipeline
@@ -1,8 +1,5 @@
 import java.text.SimpleDateFormat
 
-// Token for retrieving the GitHub credentials from the Jenkis key storage
-ci_git_credential_id = 'metal3-jenkins-github-username-token'
-
 // 3 hours
 def TIMEOUT = 10800
 
@@ -66,9 +63,7 @@ pipeline {
               [$class: 'CleanBeforeCheckout']
               ],
           submoduleCfg: [],
-          userRemoteConfigs: [
-              [credentialsId: ci_git_credential_id,url: ci_git_url, refspec: refspec]
-              ]
+          userRemoteConfigs: [[url: ci_git_url, refspec: refspec]]
           ])
         /* Pass all the credentials */
         withCredentials([usernamePassword(credentialsId: 'infra-nordix-artifactory-api-key', usernameVariable: 'RT_USER', passwordVariable: 'RT_TOKEN')]) {

--- a/jenkins/jobs/e2e_features_test.pipeline
+++ b/jenkins/jobs/e2e_features_test.pipeline
@@ -1,7 +1,5 @@
 import java.text.SimpleDateFormat
 
-ci_git_credential_id = "metal3-jenkins-github-username-token"
-
 // default 3h for other non-pivot feature tests
 def TIMEOUT = 10800
 
@@ -77,11 +75,7 @@ pipeline {
           [$class: 'CleanBeforeCheckout']
         ],
         submoduleCfg: [],
-        userRemoteConfigs: [
-          [credentialsId: ci_git_credential_id,
-          url: ci_git_url,
-          refspec: refspec
-          ]
+        userRemoteConfigs: [[url: ci_git_url, refspec: refspec]
         ]
         ])
         withCredentials([string(credentialsId: 'metal3-clusterctl-github-token', variable: 'GITHUB_TOKEN')]) {

--- a/jenkins/jobs/image_building.pipeline
+++ b/jenkins/jobs/image_building.pipeline
@@ -1,4 +1,3 @@
-ci_git_credential_id = "metal3-jenkins-github-username-token"
 ci_git_branch = "main"
 ci_git_url = "https://github.com/metal3-io/project-infra.git"
 
@@ -43,8 +42,7 @@ pipeline {
                        [$class: 'CleanCheckout'],
                        [$class: 'CleanBeforeCheckout']],
                        submoduleCfg: [],
-                       userRemoteConfigs: [[credentialsId: ci_git_credential_id,
-                       url: ci_git_url]]])
+                       userRemoteConfigs: [[url: ci_git_url]]])
             }
           }
           stage("Build CI image") {


### PR DESCRIPTION
We have been using username/password for checking out all repos. This is not necessary for public repos and doesn't seem to make any difference. The password has been changed without impacting any of the jobs... so this commit removes the use of these credentials.