### PR TITLE
Image build job with test

### DIFF
--- a/jenkins/image_building/build-image.sh
+++ b/jenkins/image_building/build-image.sh
@@ -19,9 +19,6 @@ cd "${REPO_ROOT}" || true
 export IMAGE_OS="${IMAGE_OS}"
 export IMAGE_TYPE="${IMAGE_TYPE}"
 
-# shellcheck disable=SC1091
-. "${current_dir}/upload-ci-image.sh"
-
 # Disable needrestart interactive mode
 sudo sed -i "s/^#\$nrconf{restart} = 'i';/\$nrconf{restart} = 'a';/" /etc/needrestart/needrestart.conf > /dev/null || true
 

--- a/jenkins/image_building/verify-ci-image.sh
+++ b/jenkins/image_building/verify-ci-image.sh
@@ -1,0 +1,31 @@
+#!/usr/bin/env bash
+
+set -eux
+
+# TODO: make a common script for this instead of having 2 almost identical scripts
+verify_ci_image() {
+    current_dir="$(dirname "$(readlink -f "${0}")")"
+
+    # So that no extra components are built later
+    export IMAGE_TESTING="true"
+
+    # Run "make clean" after test, so that next job can start from clean state
+    export CLEANUP_AFTERWARDS="${CLEANUP_AFTERWARDS:-false}"
+
+    # Similar config to periodic integration tests
+    export REPO_BRANCH="main"
+    export REPO_ORG="metal3-io"
+    export REPO_NAME="metal3-dev-env"
+    export UPDATED_REPO="metal3-io/metal3-dev-env"
+    export UPDATED_BRANCH="main"
+    export NUM_NODES=2
+
+    export IRONIC_INSTALL_TYPE="rpm"
+
+    "${current_dir}/../scripts/dynamic_worker_workflow/dev_env_integration_tests.sh"
+}
+
+# If the script was run directly (i.e. not sourced), run the verify_ci_image func
+if [[ "${BASH_SOURCE[0]}" == "${0}" ]]; then
+    verify_ci_image "$@"
+fi

--- a/jenkins/jobs/image_building.pipeline
+++ b/jenkins/jobs/image_building.pipeline
@@ -16,6 +16,12 @@ pipeline {
     BMORELEASEBRANCH = "${env.bmo_release_branch}"
     CAPI_VERSION = "${env.CAPI_VERSION}"
     CAPM3_VERSION = "${env.CAPM3_VERSION}"
+    OS_AUTH_URL = "https://xerces.ericsson.net:5000"
+    OS_PROJECT_ID = "b62dc8622f87407589de9f7dcec13d25"
+    OS_INTERFACE = "public"
+    OS_PROJECT_NAME = "EST_Metal3_CI"
+    OS_USER_DOMAIN_NAME = "xerces"
+    OS_IDENTITY_API_VERSION = 3
   }
   stages {
     stage('SCM') {
@@ -52,12 +58,12 @@ pipeline {
               ])
             }
           }
-          stage("Build CI image") {
+          stage("Build disk image") {
             options {
               timeout(time: 1, unit: 'HOURS')
             }
             steps {
-              echo "Building ${IMAGE_OS} CI image"
+              echo "Building ${IMAGE_OS} ${IMAGE_TYPE} image"
               script {
                 sh """
                 ./jenkins/image_building/build-image.sh
@@ -73,7 +79,7 @@ pipeline {
               expression { env.IMAGE_TYPE == 'node' }
             }
             steps {
-              echo "Testing new ${IMAGE_OS} CI image"
+              echo "Testing new ${IMAGE_OS} node image"
               script {
                 def imageName = readFile("image_name.txt").trim()
 
@@ -84,13 +90,50 @@ pipeline {
               }
             }
           }
+          stage("Upload the new CI image with -staging suffix") {
+            options {
+              timeout(time: 30, unit: 'MINUTES')
+            }
+            when {
+              expression { env.IMAGE_TYPE == 'ci' }
+            }
+            steps {
+              script {
+                def imageName = readFile("image_name.txt").trim()
+                withCredentials([
+                  usernamePassword(credentialsId: 'xerces-est-metal3ci', usernameVariable: 'OS_USERNAME', passwordVariable: 'OS_PASSWORD')
+                ]) {
+                  sh """
+                  ./jenkins/image_building/upload-ci-image.sh ${imageName} "metal3-ci-${IMAGE_OS}-staging"
+                  """
+                }
+              }
+            }
+          }
+          stage("Verify the new CI image") {
+            agent { label "metal3ci-staging" }
+            options {
+              timeout(time: 2, unit: 'HOURS')
+            }
+            when {
+              expression { env.IMAGE_TYPE == 'ci' }
+            }
+            steps {
+              echo "Testing new ${IMAGE_OS} CI image"
+              script {
+                sh """
+                ./jenkins/image_building/verify-ci-image.sh
+                """
+              }
+            }
+          }
           stage("Upload the new Image") {
             options {
               timeout(time: 30, unit: 'MINUTES')
             }
             steps {
               withCredentials([
-                usernamePassword(credentialsId: 'xerces-est-metal3ci', usernameVariable: 'OPENSTACK_USERNAME_XERCES', passwordVariable: 'OPENSTACK_PASSWORD_XERCES'),
+                usernamePassword(credentialsId: 'xerces-est-metal3ci', usernameVariable: 'OS_USERNAME', passwordVariable: 'OS_PASSWORD'),
                 usernamePassword(credentialsId: 'infra-nordix-artifactory-api-key', usernameVariable: 'RT_USER', passwordVariable: 'RT_TOKEN')
               ]) {
                 script {
@@ -102,8 +145,10 @@ pipeline {
                     ./jenkins/image_building/upload-node-image.sh ${imageName}
                     """
                   } else {
+                    // The CI image is already uploaded with a different name so we just need to rename it.
                     sh """
-                    ./jenkins/image_building/upload-ci-image.sh ${imageName}
+                    source ./jenkins/image_building/upload-ci-image.sh
+                    rename_image_common "metal3-ci-${IMAGE_OS}-staging"
                     """
                   }
                 }

--- a/jenkins/jobs/image_building.pipeline
+++ b/jenkins/jobs/image_building.pipeline
@@ -1,5 +1,7 @@
-ci_git_branch = "main"
-ci_git_url = "https://github.com/metal3-io/project-infra.git"
+script {
+  ci_git_branch = (env.PULL_PULL_SHA) ?: "main"
+  ci_git_url = "https://github.com/metal3-io/project-infra.git"
+}
 
 pipeline {
   agent none
@@ -35,14 +37,19 @@ pipeline {
               timeout(time: 5, unit: 'MINUTES')
             }
             steps {
-              checkout([$class: 'GitSCM',
-                       branches: [[name: ci_git_branch]],
-                       doGenerateSubmoduleConfigurations: false,
-                       extensions: [[$class: 'WipeWorkspace'],
-                       [$class: 'CleanCheckout'],
-                       [$class: 'CleanBeforeCheckout']],
-                       submoduleCfg: [],
-                       userRemoteConfigs: [[url: ci_git_url]]])
+              checkout([
+                $class: 'GitSCM',
+                branches: [[name: ci_git_branch]],
+                doGenerateSubmoduleConfigurations: false,
+                extensions: [
+                  [$class: 'WipeWorkspace'],
+                  [$class: 'CleanCheckout'],
+                  [$class: 'CleanBeforeCheckout'],
+                  [$class: 'PreBuildMerge', options: [mergeTarget: 'main']]
+                ],
+                submoduleCfg: [],
+                userRemoteConfigs: [[url: ci_git_url]]
+              ])
             }
           }
           stage("Build CI image") {

--- a/prow/config/jobs/metal3-io/project-infra.yaml
+++ b/prow/config/jobs/metal3-io/project-infra.yaml
@@ -245,3 +245,11 @@ presubmits:
     agent: jenkins
     always_run: false
     optional: true
+  - name: metal3-ci-image-building
+    agent: jenkins
+    always_run: false
+    optional: true
+  - name: metal3-node-image-building
+    agent: jenkins
+    always_run: false
+    optional: true


### PR DESCRIPTION
Related gerrit change: https://gerrit.nordix.org/c/infra/cicd/+/23399

Enable triggering image building jobs on PRs

Verify CI images by uploading them with a "-staging" suffix first, run a
basic integration test using this staging image before proceeding to make
it the latest.

Fixes: #985