### PR TITLE
Fix image building refspec and upload

### DIFF
--- a/jenkins/jobs/image_building.pipeline
+++ b/jenkins/jobs/image_building.pipeline
@@ -1,9 +1,17 @@
 script {
   ci_git_branch = (env.PULL_PULL_SHA) ?: "main"
+  ci_git_base = (env.PULL_BASE_REF) ?: "main"
   ci_git_url = "https://github.com/metal3-io/project-infra.git"
+  refspec = '+refs/heads/' + ci_git_base + ':refs/remotes/origin/' + ci_git_base + ' ' + ci_git_branch
 }
 
 pipeline {
+  options {
+    // We verify the CI images by uploading and testing them as jenkins agents.
+    // If multiple jobs would run in parallel, they may overwrite each others image
+    // and/or delete them before the test is finished.
+    disableConcurrentBuilds()
+  }
   agent none
   environment {
     IMAGE_TYPE = "${env.IMAGE_TYPE}"
@@ -50,11 +58,10 @@ pipeline {
                 extensions: [
                   [$class: 'WipeWorkspace'],
                   [$class: 'CleanCheckout'],
-                  [$class: 'CleanBeforeCheckout'],
-                  [$class: 'PreBuildMerge', options: [mergeTarget: 'main']]
+                  [$class: 'CleanBeforeCheckout']
                 ],
                 submoduleCfg: [],
-                userRemoteConfigs: [[url: ci_git_url]]
+                userRemoteConfigs: [[url: ci_git_url, refspec: refspec]]
               ])
             }
           }
@@ -68,6 +75,32 @@ pipeline {
                 sh """
                 ./jenkins/image_building/build-image.sh
                 """
+              }
+            }
+          }
+          stage("Upload the new CI image with -staging suffix") {
+            options {
+              timeout(time: 30, unit: 'MINUTES')
+            }
+            when {
+              expression { env.IMAGE_TYPE == 'ci' }
+            }
+            steps {
+              // NOTE: We delete any existing *-staging images before uploading the new one.
+              // This is important because the images cannot be separated from the older "latest" images
+              // if they are renamed to their "original" names (which they would be when the next image is uploaded).
+              script {
+                def imageName = readFile("image_name.txt").trim()
+                withCredentials([
+                  usernamePassword(credentialsId: 'xerces-est-metal3ci', usernameVariable: 'OS_USERNAME', passwordVariable: 'OS_PASSWORD')
+                ]) {
+                  sh """#!/bin/bash
+                  source ./jenkins/image_building/upload-ci-image.sh
+                  install_openstack_client
+                  delete_if_exists "metal3-ci-${IMAGE_OS}-staging"
+                  upload_ci_image_xerces ${imageName} "metal3-ci-${IMAGE_OS}-staging"
+                  """
+                }
               }
             }
           }
@@ -90,28 +123,8 @@ pipeline {
               }
             }
           }
-          stage("Upload the new CI image with -staging suffix") {
-            options {
-              timeout(time: 30, unit: 'MINUTES')
-            }
-            when {
-              expression { env.IMAGE_TYPE == 'ci' }
-            }
-            steps {
-              script {
-                def imageName = readFile("image_name.txt").trim()
-                withCredentials([
-                  usernamePassword(credentialsId: 'xerces-est-metal3ci', usernameVariable: 'OS_USERNAME', passwordVariable: 'OS_PASSWORD')
-                ]) {
-                  sh """
-                  ./jenkins/image_building/upload-ci-image.sh ${imageName} "metal3-ci-${IMAGE_OS}-staging"
-                  """
-                }
-              }
-            }
-          }
           stage("Verify the new CI image") {
-            agent { label "metal3ci-staging" }
+            agent { label "metal3ci-${IMAGE_OS}-staging" }
             options {
               timeout(time: 2, unit: 'HOURS')
             }
@@ -131,6 +144,10 @@ pipeline {
             options {
               timeout(time: 30, unit: 'MINUTES')
             }
+            when {
+              // Don't upload from PR tests
+              expression { ci_git_branch == 'main' }
+            }
             steps {
               withCredentials([
                 usernamePassword(credentialsId: 'xerces-est-metal3ci', usernameVariable: 'OS_USERNAME', passwordVariable: 'OS_PASSWORD'),
@@ -146,9 +163,11 @@ pipeline {
                     """
                   } else {
                     // The CI image is already uploaded with a different name so we just need to rename it.
-                    sh """
+                    // Also clean up old images (keeping the last 5)
+                    sh """#!/bin/bash
                     source ./jenkins/image_building/upload-ci-image.sh
                     rename_image_common "metal3-ci-${IMAGE_OS}-staging"
+                    delete_old_images
                     """
                   }
                 }


### PR DESCRIPTION
When triggering jobs on PRs, we need to include the PR commit(s) in the
refspec. Otherwise we cannot checkout the relevant code. Pre-build-merge
is also removed to keep the behavior similar to other jobs.
This commit also avoids uploading images from PR tests and making them "latest".
It also fixes the labels for the CI image verification step so that the
label is separate for ubuntu and centos images.

Last but not least, this tweaks the logic for image retention.
CI images are uploaded as metal3-ci-<os>-staging for verification.
In periodic jobs, the staging images are then renamed to *-latest after
successful verification. This is not done in PR jobs.

Any existing *-staging images are deleted before uploading a new.
Otherwise we risk mixing them up with the previously used CI images and
fill the retention queue with staging images instead of the real
"production" images because the logic of the upload script is to rename
them back to their "original" name when there are conflicts.

See https://github.com/metal3-io/project-infra/pull/984#issuecomment-2825135017