### PR TITLE
Prow: Require manually triggered jobs

### DIFF
--- a/prow/config/config.yaml
+++ b/prow/config/config.yaml
@@ -89,7 +89,7 @@ tide:
 # This is what controls which github status checks (or CI jobs) must
 # be passing for a PR to merge.
 #
-# Docs: https://github.com/kubernetes/test-infra/tree/master/prow/cmd/branchprotector
+# Docs: https://docs.prow.k8s.io/docs/components/optional/branchprotector/
 #
 branch-protection:
   orgs:
@@ -103,6 +103,8 @@ branch-protection:
       # To turn this off for a given job, set "optional: true"
       # in the job definition.
       protect: true
+  # IF we trigger optional jobs, make sure they pass before we merge
+  require_manually_triggered_jobs: true
 
 deck:
   spyglass:


### PR DESCRIPTION
If we trigger optional jobs on a PR, this makes sure that prow won't merge it unless they actually pass. Otherwise, prow will happily ignore these jobs and merge as long as the required jobs have passed.