### PR TITLE
bump golang to 1.24 for IRSO

### DIFF
--- a/prow/config/jobs/metal3-io/ironic-standalone-operator.yaml
+++ b/prow/config/jobs/metal3-io/ironic-standalone-operator.yaml
@@ -14,7 +14,7 @@ presubmits:
         env:
         - name: IS_CONTAINER
           value: "TRUE"
-        image: docker.io/golang:1.23
+        image: docker.io/golang:1.24
         imagePullPolicy: Always
   - name: markdownlint
     run_if_changed: '(\.md|markdownlint\.sh)$'


### PR DESCRIPTION
IRSO needs golang 1.24 for mariadb-operator, so we need to bump it here as well. Other repos will follow when 1.10 cycle etc are done.

/cc @dtantsur @lentzi90 