### PR TITLE
Update CRIO installation link from k8s addons to CRI'o own subproject

### DIFF
--- a/jenkins/image_building/dib_elements/centos-node/pre-install.d/55-setup-repos
+++ b/jenkins/image_building/dib_elements/centos-node/pre-install.d/55-setup-repos
@@ -20,10 +20,12 @@ EOF
 cat <<EOF | tee /etc/yum.repos.d/cri-o.repo
 [cri-o]
 name=CRI-O
-baseurl=https://pkgs.k8s.io/addons:/cri-o:/stable:/$CRIO_MINOR_VERSION/rpm/
+baseurl=https://download.opensuse.org/repositories/isv:/cri-o:/stable:/${CRIO_MINOR_VERSION}/rpm/
 enabled=1
 gpgcheck=1
-gpgkey=https://pkgs.k8s.io/addons:/cri-o:/stable:/$CRIO_MINOR_VERSION/rpm/repodata/repomd.xml.key
+gpgkey=https://download.opensuse.org/repositories/isv:/cri-o:/stable:/${CRIO_MINOR_VERSION}/rpm/repodata/repomd.xml.key
 EOF
 
+sudo yum clean all
+sudo rm -rf /var/cache/yum
 sudo yum -y update

--- a/jenkins/image_building/dib_elements/ubuntu-node/pre-install.d/55-setup-repos
+++ b/jenkins/image_building/dib_elements/ubuntu-node/pre-install.d/55-setup-repos
@@ -7,8 +7,8 @@ export CRIO_MINOR_VERSION=${CRIO_VERSION%.*}
 
 curl -fsSL "https://pkgs.k8s.io/core:/stable:/${KUBERNETES_MINOR_VERSION}/deb/Release.key" | gpg --dearmor -o /etc/apt/keyrings/kubernetes-apt-keyring.gpg
 echo "deb [signed-by=/etc/apt/keyrings/kubernetes-apt-keyring.gpg] https://pkgs.k8s.io/core:/stable:/${KUBERNETES_MINOR_VERSION}/deb/ /" | tee /etc/apt/sources.list.d/kubernetes.list
-curl -fsSL "https://download.opensuse.org/repositories/isv:/kubernetes:/addons:/cri-o:/stable:/${CRIO_MINOR_VERSION}/deb/Release.key" | gpg --dearmor -o /etc/apt/keyrings/cri-o-apt-keyring.gpg
-echo "deb [signed-by=/etc/apt/keyrings/cri-o-apt-keyring.gpg] https://download.opensuse.org/repositories/isv:/kubernetes:/addons:/cri-o:/stable:/${CRIO_MINOR_VERSION}/deb/ /" | tee /etc/apt/sources.list.d/cri-o.list
+curl -fsSL "https://download.opensuse.org/repositories/isv:/cri-o:/stable:/${CRIO_MINOR_VERSION}/deb/Release.key" | gpg --dearmor -o /etc/apt/keyrings/cri-o-apt-keyring.gpg
+echo "deb [signed-by=/etc/apt/keyrings/cri-o-apt-keyring.gpg] https://download.opensuse.org/repositories/isv:/cri-o:/stable:/${CRIO_MINOR_VERSION}/deb/ /" | tee /etc/apt/sources.list.d/cri-o.list
 
 sudo apt-get update
 sudo apt-get dist-upgrade -f -y


### PR DESCRIPTION
CRI-O has moved from being a k8s add on project to its own subproject. Hence new patch installations would fail if we dont point towards the correct stable repositories to download release binaries.
Signed-off-by: Kashif Khan <kashif.khan@est.tech>