### PR TITLE
Don't clean the yum cache while building CentOS node image

### DIFF
--- a/jenkins/image_building/dib_elements/centos-node/pre-install.d/55-setup-repos
+++ b/jenkins/image_building/dib_elements/centos-node/pre-install.d/55-setup-repos
@@ -26,6 +26,4 @@ gpgcheck=1
 gpgkey=https://download.opensuse.org/repositories/isv:/cri-o:/stable:/${CRIO_MINOR_VERSION}/rpm/repodata/repomd.xml.key
 EOF
 
-sudo yum clean all
-sudo rm -rf /var/cache/yum
 sudo yum -y update


### PR DESCRIPTION
Had the add the clean cache steps since the repo was not found previously but now it is taking too much time to update the repos after the cleaned cache. Lets see if this is at all needed now.