### PR TITLE
Evaluate when block before agent in CI image verification

### DIFF
--- a/jenkins/jobs/image_building.pipeline
+++ b/jenkins/jobs/image_building.pipeline
@@ -129,6 +129,9 @@ pipeline {
               timeout(time: 2, unit: 'HOURS')
             }
             when {
+              // IMPORTANT: We must evaluate the when block before the agent or we will get stuck
+              // since there is no stagig image available when IMAGE_TYPE is not "ci".
+              beforeAgent true
               expression { env.IMAGE_TYPE == 'ci' }
             }
             steps {


### PR DESCRIPTION
Docs: https://www.jenkins.io/doc/book/pipeline/syntax/#evaluating-when-before-entering-agent-in-a-stage

Without this, we end up blocked waiting for the agent to come up before the when block is evaluated. The agent never comes up since there is no image unless we are doing a CI image job.