### PR TITLE
bump basic-checks image to 1.23.8

### DIFF
--- a/prow/container-images/basic-checks/Dockerfile
+++ b/prow/container-images/basic-checks/Dockerfile
@@ -1,4 +1,4 @@
-ARG GO_VERSION=1.23.7@sha256:1acb493b9f9dfdfe705042ce09e8ded908ce4fb342405ecf3ca61ce7f3b168c7
+ARG GO_VERSION=1.23.8@sha256:a5339982f2e78b38b26ebbee35139854e184a4e90e1516f9f636371e720b727b
 FROM docker.io/golang:${GO_VERSION}
 
 # Install additional packages not present in regular golang image


### PR DESCRIPTION
Bump basic-checks image to 1.23.8 as some PRs need it in BMO, such as https://github.com/metal3-io/baremetal-operator/pull/2433.