### PR TITLE
remove centos e2e from required in 1.10 branch

### DIFF
--- a/prow/config/jobs/metal3-io/ip-address-manager-release-1.10.yaml
+++ b/prow/config/jobs/metal3-io/ip-address-manager-release-1.10.yaml
@@ -129,7 +129,7 @@ presubmits:
     - release-1.10
     agent: jenkins
     always_run: false
-    optional: false
+    optional: true
   - name: metal3-ubuntu-e2e-integration-test-release-1-10
     branches:
     - release-1.10


### PR DESCRIPTION
Remove centos e2e as required test from release-1.10 branch. We only run ubuntu suite in release branches.