### PR TITLE
:seedling: Fix how Github token is used in link checks workflow

### DIFF
--- a/.github/workflows/pr-link-check.yml
+++ b/.github/workflows/pr-link-check.yml
@@ -42,13 +42,11 @@ jobs:
       - name: Check links in changed files
         if: env.foundFiles == 'true'
         uses: lycheeverse/lychee-action@f796c8b7d468feb9b8c0a46da3fac0af6874d374 # v2.2.0
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
           failIfEmpty: false
           args: |
             --no-progress
-            --github-token
+            --github-token "${GITHUB_TOKEN}"
             $(cat changed-files.txt | tr '\n' ' ')
 
       - name: Provide helpful failure message

--- a/.github/workflows/scheduled-link-check.yml
+++ b/.github/workflows/scheduled-link-check.yml
@@ -25,14 +25,12 @@ jobs:
     - name: Link Checker
       id: linkcheck
       uses: lycheeverse/lychee-action@f796c8b7d468feb9b8c0a46da3fac0af6874d374 # v2.2.0
-      env:
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       with:
         args: |
           --user-agent "Mozilla/5.0 (Windows NT 6.1; Win64; x64; rv:135.0) Gecko/20100101 Firefox/135.0"
           --root-dir "$(pwd)/"
           --fallback-extensions "md"
-          --github-token
+          --github-token "${GITHUB_TOKEN}"
           "./**/*.md"
         output: /tmp/lychee_output.md
         fail: false


### PR DESCRIPTION
ix how Github token is used in link checks workflow