### PR TITLE
Tweak PR link check args

### DIFF
--- a/.github/workflows/pr-link-check.yml
+++ b/.github/workflows/pr-link-check.yml
@@ -60,7 +60,9 @@ jobs:
         with:
           failIfEmpty: false
           args: |
-            --no-progress
+            --user-agent "Mozilla/5.0 (Windows NT 6.1; Win64; x64; rv:135.0) Gecko/20100101 Firefox/135.0"
+            --root-dir "$(pwd)/"
+            --fallback-extensions "md"
             --github-token "${GITHUB_TOKEN}"
             $(cat changed-files.txt | tr '\n' ' ')
 


### PR DESCRIPTION
Tweak PR link check args. In this PR I set the values to be the same as are in scheduled workflow. 

Set user agent to help being detected as a bot: `--user-agent "Mozilla/5.0 (Windows NT 6.1; Win64; x64; rv:135.0) Gecko/20100101 Firefox/135.0"`
Make sure relative paths work by setting root directory:   `--root-dir "$(pwd)/"`
Github, mdbook and such recognize paths with out file extensions, set a fallback so that links with out file extensions are handled correctly:   `--fallback-extensions "md"`