### PR TITLE
bump basic-checks image to golang:1.24.3

### DIFF
--- a/.github/workflows/build-images-action.yml
+++ b/.github/workflows/build-images-action.yml
@@ -20,7 +20,7 @@ jobs:
     uses: ./.github/workflows/container-image-build.yml
     with:
       image-name: 'basic-checks'
-      image-tag: 'golang-1.23'
+      image-tag: 'golang-1.24'
       dockerfile-directory: 'prow/container-images/basic-checks'
       pushImage: true
     secrets:

--- a/prow/container-images/basic-checks/Dockerfile
+++ b/prow/container-images/basic-checks/Dockerfile
@@ -1,4 +1,4 @@
-ARG GO_VERSION=1.23.8@sha256:a5339982f2e78b38b26ebbee35139854e184a4e90e1516f9f636371e720b727b
+ARG GO_VERSION=1.24.3@sha256:4c0a1814a7c6c65ece28b3bfea14ee3cf83b5e80b81418453f0e9d5255a5d7b8
 FROM docker.io/golang:${GO_VERSION}
 
 # Install additional packages not present in regular golang image


### PR DESCRIPTION
Bump basic-checks image to golang:1.24.3 to support bumping golang in BMO later. This new image is not used by anyone or changing anything, until BMO and its prow jobs are bumped to Go 1.24. This is just pre-building the image, so it doesn't explode when we do.