### PR TITLE
Remove keepalived local build from bmo e2e

### DIFF
--- a/jenkins/scripts/dynamic_worker_workflow/test_env.sh
+++ b/jenkins/scripts/dynamic_worker_workflow/test_env.sh
@@ -25,7 +25,6 @@ elif [[ "${REPO_NAME}" == "baremetal-operator" ]]; then
     export BMOBRANCH="${UPDATED_BRANCH}"
     export BMOPATH="${HOME}/tested_repo"
     export BUILD_BMO_LOCALLY="true"
-    export IRONIC_KEEPALIVED_LOCAL_IMAGE="${BMOPATH}/resources/keepalived-docker"
 
 elif [[ "${REPO_NAME}" == "ip-address-manager" ]]; then
     export IPAMREPO="${UPDATED_REPO}"

--- a/jenkins/scripts/integration_test_env.sh
+++ b/jenkins/scripts/integration_test_env.sh
@@ -23,7 +23,6 @@ elif [[ "${REPO_NAME}" == "baremetal-operator" ]]; then
     export BMOBRANCH="${UPDATED_BRANCH}"
     export BMOPATH="/home/${USER}/tested_repo"
     export BUILD_BMO_LOCALLY="true"
-    export IRONIC_KEEPALIVED_LOCAL_IMAGE="${BMOPATH}/resources/keepalived-docker"
 
 elif [[ "${REPO_NAME}" == "ip-address-manager" ]]; then
     export IPAMREPO="${UPDATED_REPO}"


### PR DESCRIPTION
This PR:
- removes the keepalived local image path from e2e integration test as
  it is no longer required after keepalived was moved to utility-images repo.
- removes the keepalied local image path from the dynamic workflow
  test env shell script for the above mentioned reason
