### PR TITLE
Bump IPAM prow jobs to use go v1.24

### DIFF
--- a/prow/config/jobs/metal3-io/ip-address-manager-release-1.10.yaml
+++ b/prow/config/jobs/metal3-io/ip-address-manager-release-1.10.yaml
@@ -14,7 +14,7 @@ presubmits:
         env:
         - name: IS_CONTAINER
           value: "TRUE"
-        image: docker.io/golang:1.23
+        image: docker.io/golang:1.24
         imagePullPolicy: Always
   # NOTE: The test jobs are for verifying the Makefile and hack/* scripts only
   - name: test
@@ -28,7 +28,7 @@ presubmits:
         - test
         command:
         - make
-        image: docker.io/golang:1.23
+        image: docker.io/golang:1.24
         imagePullPolicy: Always
   - name: markdownlint
     branches:
@@ -76,7 +76,7 @@ presubmits:
         env:
         - name: IS_CONTAINER
           value: "TRUE"
-        image: docker.io/golang:1.23
+        image: docker.io/golang:1.24
   - name: generate
     branches:
     - release-1.10
@@ -91,7 +91,7 @@ presubmits:
         env:
         - name: IS_CONTAINER
           value: "TRUE"
-        image: docker.io/golang:1.23
+        image: docker.io/golang:1.24
         imagePullPolicy: Always
   - name: manifestlint
     branches:

--- a/prow/config/jobs/metal3-io/ip-address-manager-release-1.9.yaml
+++ b/prow/config/jobs/metal3-io/ip-address-manager-release-1.9.yaml
@@ -14,7 +14,7 @@ presubmits:
         env:
         - name: IS_CONTAINER
           value: "TRUE"
-        image: docker.io/golang:1.23
+        image: docker.io/golang:1.24
         imagePullPolicy: Always
   # NOTE: The test jobs are for verifying the Makefile and hack/* scripts only
   - name: test
@@ -28,7 +28,7 @@ presubmits:
         - test
         command:
         - make
-        image: docker.io/golang:1.23
+        image: docker.io/golang:1.24
         imagePullPolicy: Always
   - name: markdownlint
     branches:
@@ -76,7 +76,7 @@ presubmits:
         env:
         - name: IS_CONTAINER
           value: "TRUE"
-        image: docker.io/golang:1.23
+        image: docker.io/golang:1.24
   - name: generate
     branches:
     - release-1.9
@@ -91,7 +91,7 @@ presubmits:
         env:
         - name: IS_CONTAINER
           value: "TRUE"
-        image: docker.io/golang:1.23
+        image: docker.io/golang:1.24
         imagePullPolicy: Always
   - name: manifestlint
     branches:

--- a/prow/config/jobs/metal3-io/ip-address-manager.yaml
+++ b/prow/config/jobs/metal3-io/ip-address-manager.yaml
@@ -14,7 +14,7 @@ presubmits:
         env:
         - name: IS_CONTAINER
           value: "TRUE"
-        image: docker.io/golang:1.23
+        image: docker.io/golang:1.24
         imagePullPolicy: Always
   # NOTE: The test jobs are for verifying the Makefile and hack/* scripts only
   - name: test
@@ -28,7 +28,7 @@ presubmits:
         - test
         command:
         - make
-        image: docker.io/golang:1.23
+        image: docker.io/golang:1.24
         imagePullPolicy: Always
   - name: markdownlint
     branches:
@@ -76,7 +76,7 @@ presubmits:
         env:
         - name: IS_CONTAINER
           value: "TRUE"
-        image: docker.io/golang:1.23
+        image: docker.io/golang:1.24
   - name: generate
     branches:
     - main
@@ -91,7 +91,7 @@ presubmits:
         env:
         - name: IS_CONTAINER
           value: "TRUE"
-        image: docker.io/golang:1.23
+        image: docker.io/golang:1.24
         imagePullPolicy: Always
   - name: manifestlint
     branches:


### PR DESCRIPTION
Bumps golang to v1.24 for prow jobs for following branches

- main
- release 1.10
- release 1.9