### PR TITLE
Bump BMO prow jobs to use go v1.24

### DIFF
--- a/prow/config/jobs/metal3-io/baremetal-operator-release-0.10.yaml
+++ b/prow/config/jobs/metal3-io/baremetal-operator-release-0.10.yaml
@@ -14,7 +14,7 @@ presubmits:
         env:
         - name: IS_CONTAINER
           value: "TRUE"
-        image: quay.io/metal3-io/basic-checks:golang-1.23
+        image: quay.io/metal3-io/basic-checks:golang-1.24
         imagePullPolicy: Always
   - name: markdownlint
     branches:
@@ -70,7 +70,7 @@ presubmits:
           value: "http://localhost:6385/v1/"
         - name: IRONIC_INSPECTOR_ENDPOINT
           value: "http://localhost:5050/v1/"
-        image: quay.io/metal3-io/basic-checks:golang-1.23
+        image: quay.io/metal3-io/basic-checks:golang-1.24
         imagePullPolicy: Always
   # NOTE: The test jobs are for verifying Makefile and hack/* script changes only
   - name: test
@@ -84,7 +84,7 @@ presubmits:
         - test
         command:
         - make
-        image: quay.io/metal3-io/basic-checks:golang-1.23
+        image: quay.io/metal3-io/basic-checks:golang-1.24
         imagePullPolicy: Always
   - name: manifestlint
     branches:

--- a/prow/config/jobs/metal3-io/baremetal-operator-release-0.9.yaml
+++ b/prow/config/jobs/metal3-io/baremetal-operator-release-0.9.yaml
@@ -14,7 +14,7 @@ presubmits:
         env:
         - name: IS_CONTAINER
           value: "TRUE"
-        image: quay.io/metal3-io/basic-checks:golang-1.23
+        image: quay.io/metal3-io/basic-checks:golang-1.24
         imagePullPolicy: Always
   - name: markdownlint
     branches:
@@ -70,7 +70,7 @@ presubmits:
           value: "http://localhost:6385/v1/"
         - name: IRONIC_INSPECTOR_ENDPOINT
           value: "http://localhost:5050/v1/"
-        image: quay.io/metal3-io/basic-checks:golang-1.23
+        image: quay.io/metal3-io/basic-checks:golang-1.24
         imagePullPolicy: Always
   # NOTE: The test jobs are for verifying Makefile and hack/* script changes only
   - name: test
@@ -84,7 +84,7 @@ presubmits:
         - test
         command:
         - make
-        image: quay.io/metal3-io/basic-checks:golang-1.23
+        image: quay.io/metal3-io/basic-checks:golang-1.24
         imagePullPolicy: Always
   - name: manifestlint
     branches:

--- a/prow/config/jobs/metal3-io/baremetal-operator.yaml
+++ b/prow/config/jobs/metal3-io/baremetal-operator.yaml
@@ -14,7 +14,7 @@ presubmits:
         env:
         - name: IS_CONTAINER
           value: "TRUE"
-        image: quay.io/metal3-io/basic-checks:golang-1.23
+        image: quay.io/metal3-io/basic-checks:golang-1.24
         imagePullPolicy: Always
   - name: markdownlint
     branches:
@@ -70,7 +70,7 @@ presubmits:
           value: "http://localhost:6385/v1/"
         - name: IRONIC_INSPECTOR_ENDPOINT
           value: "http://localhost:5050/v1/"
-        image: quay.io/metal3-io/basic-checks:golang-1.23
+        image: quay.io/metal3-io/basic-checks:golang-1.24
         imagePullPolicy: Always
   # NOTE: The test jobs are for verifying Makefile and hack/* script changes only
   - name: test
@@ -84,7 +84,7 @@ presubmits:
         - test
         command:
         - make
-        image: quay.io/metal3-io/basic-checks:golang-1.23
+        image: quay.io/metal3-io/basic-checks:golang-1.24
         imagePullPolicy: Always
   - name: manifestlint
     branches:


### PR DESCRIPTION
Bumps golang to v1.24 for prow jobs for following branches

- main
- release 0.10
- release 0.9