### PR TITLE
Revert "Prow: Require manually triggered jobs"

### DIFF
--- a/prow/config/config.yaml
+++ b/prow/config/config.yaml
@@ -89,7 +89,7 @@ tide:
 # This is what controls which github status checks (or CI jobs) must
 # be passing for a PR to merge.
 #
-# Docs: https://docs.prow.k8s.io/docs/components/optional/branchprotector/
+# Docs: https://github.com/kubernetes/test-infra/tree/master/prow/cmd/branchprotector
 #
 branch-protection:
   orgs:
@@ -103,8 +103,6 @@ branch-protection:
       # To turn this off for a given job, set "optional: true"
       # in the job definition.
       protect: true
-  # IF we trigger optional jobs, make sure they pass before we merge
-  require_manually_triggered_jobs: true
 
 deck:
   spyglass:


### PR DESCRIPTION
This reverts commit ad608465e1b35624000c998d46163def0d958334.

This does not do what we wanted it to do, let's revert it. It just acts as double branch protection, possibly causing it to re-run the contexts for no reason.