### PR TITLE
Use nordix artifactory proxy to download IPA

### DIFF
--- a/jenkins/scripts/dynamic_worker_workflow/test_env.sh
+++ b/jenkins/scripts/dynamic_worker_workflow/test_env.sh
@@ -66,3 +66,6 @@ export CAPM3BRANCH="${CAPM3BRANCH:-${CAPM3RELEASEBRANCH}}"
 # Container image registry value to override the default value in m3-dev-env
 export CONTAINER_REGISTRY=${CONTAINER_REGISTRY:-"registry.nordix.org/quay-io-proxy"}
 export DOCKER_HUB_PROXY=${DOCKER_HUB_PROXY:-"registry.nordix.org/docker-hub-proxy"}
+
+# Proxy IPA's base URI value to override the default value in m3-dev-env
+export IPA_BASEURI="https://artifactory.nordix.org/artifactory/openstack-remote-cache/ironic-python-agent/dib"

--- a/jenkins/scripts/integration_test_env.sh
+++ b/jenkins/scripts/integration_test_env.sh
@@ -64,3 +64,6 @@ CAPM3BRANCH="${CAPM3BRANCH:-${CAPM3RELEASEBRANCH}}"
 # Container image registry value to override the default value in m3-dev-env
 export CONTAINER_REGISTRY=${CONTAINER_REGISTRY:-"registry.nordix.org/quay-io-proxy"}
 export DOCKER_HUB_PROXY=${DOCKER_HUB_PROXY:-"registry.nordix.org/docker-hub-proxy"}
+
+# Proxy IPA's base URI value to override the default value in m3-dev-env
+export IPA_BASEURI="https://artifactory.nordix.org/artifactory/openstack-remote-cache/ironic-python-agent/dib"


### PR DESCRIPTION
Lately, we have seen a lot of delay, flakes and failures while downloading IPA from opendev upstream. Now we have setup a proxy in Nordix rtfactory to proxy the IPA from upstream and use it in our tests in a faster way when cached.