### PR TITLE
run cleaning lingering dnsmaq processes as root

### DIFF
--- a/jenkins/scripts/bare_metal_lab/tasks/cleanup-tasks.yaml
+++ b/jenkins/scripts/bare_metal_lab/tasks/cleanup-tasks.yaml
@@ -148,3 +148,5 @@
   ignore_errors: true
   changed_when: false
   register: pkill_result
+  become: true
+  become_user: root


### PR DESCRIPTION
pkill -f "dnsmasq.*libvirt" need root to run properly