### PR TITLE
update IRSO milestones

### DIFF
--- a/prow/config/plugins.yaml
+++ b/prow/config/plugins.yaml
@@ -192,4 +192,5 @@ milestone_applier:
     release-27.0: "ironic-image - v27.0"
     release-26.0: "ironic-image - v26.0"
   metal3-io/ironic-standalone-operator:
-    main: "IrSO - v0.2"
+    main: "IrSO - v0.5"
+    release-0.4: "IrSO - v0.4"


### PR DESCRIPTION
Update IRSO milestones (which have been completely wrong since 0.2 ...)

/hold
This can be merged only after 0.4 branch is created.