### PR TITLE
Add Prow keywords for conformance tests

### DIFF
--- a/prow/config/jobs/metal3-io/cluster-api-provider-metal3.yaml
+++ b/prow/config/jobs/metal3-io/cluster-api-provider-metal3.yaml
@@ -223,3 +223,10 @@ presubmits:
     agent: jenkins
     always_run: false
     optional: true
+  # name: {job_prefix}-e2e-conformance-test-{capm3_target_branch}
+  - name: metal3-e2e-conformance-test-main
+    branches:
+    - main
+    agent: jenkins
+    always_run: false
+    optional: true

--- a/prow/config/jobs/metal3-io/metal3-dev-env.yaml
+++ b/prow/config/jobs/metal3-io/metal3-dev-env.yaml
@@ -270,3 +270,8 @@ presubmits:
     agent: jenkins
     always_run: false
     optional: true
+  # name: {job_prefix}-e2e-conformance-test-{capm3_target_branch}
+  - name: metal3-e2e-conformance-test-main
+    agent: jenkins
+    always_run: false
+    optional: true

--- a/prow/config/jobs/metal3-io/project-infra.yaml
+++ b/prow/config/jobs/metal3-io/project-infra.yaml
@@ -317,3 +317,8 @@ presubmits:
     agent: jenkins
     always_run: false
     optional: true
+  # name: {job_prefix}-e2e-conformance-test-{capm3_target_branch}
+  - name: metal3-e2e-conformance-test-main
+    agent: jenkins
+    always_run: false
+    optional: true


### PR DESCRIPTION
Add Prow keywords to run K8s conformance tests from PRs in CAPM3, metal3-dev-env and project-infra.