### PR TITLE
Add CAPI md tests' setup and Prow keywords

### DIFF
--- a/jenkins/jobs/capm3-e2e-tests.pipeline
+++ b/jenkins/jobs/capm3-e2e-tests.pipeline
@@ -38,6 +38,9 @@ script {
   } else if ( "${GINKGO_FOCUS}" == 'k8s-conformance' ) {
     TIMEOUT = 7200 // 2h
     agent_label = "metal3ci-8c32gb-${IMAGE_OS}"
+  } else if ( "${GINKGO_FOCUS}" == 'capi-md-tests' ) {
+    TIMEOUT = 10800 // 3h
+    agent_label = "metal3ci-8c32gb-${IMAGE_OS}"
   } else {
     agent_label = "metal3ci-8c32gb-${IMAGE_OS}"
     BUILD_TAG = "${env.BUILD_TAG}-other-features"

--- a/prow/config/jobs/metal3-io/cluster-api-provider-metal3.yaml
+++ b/prow/config/jobs/metal3-io/cluster-api-provider-metal3.yaml
@@ -211,3 +211,15 @@ presubmits:
     agent: jenkins
     always_run: false
     optional: true
+  - name: metal3-ubuntu-e2e-capi-md-test-main
+    branches:
+    - main
+    agent: jenkins
+    always_run: false
+    optional: true
+  - name: metal3-centos-e2e-capi-md-test-main
+    branches:
+    - main
+    agent: jenkins
+    always_run: false
+    optional: true

--- a/prow/config/jobs/metal3-io/metal3-dev-env.yaml
+++ b/prow/config/jobs/metal3-io/metal3-dev-env.yaml
@@ -262,3 +262,11 @@ presubmits:
     agent: jenkins
     always_run: false
     optional: true
+  - name: metal3-ubuntu-e2e-capi-md-test-main
+    agent: jenkins
+    always_run: false
+    optional: true
+  - name: metal3-centos-e2e-capi-md-test-main
+    agent: jenkins
+    always_run: false
+    optional: true

--- a/prow/config/jobs/metal3-io/project-infra.yaml
+++ b/prow/config/jobs/metal3-io/project-infra.yaml
@@ -309,3 +309,11 @@ presubmits:
     agent: jenkins
     always_run: false
     optional: true
+  - name: metal3-ubuntu-e2e-capi-md-test-main
+    agent: jenkins
+    always_run: false
+    optional: true
+  - name: metal3-centos-e2e-capi-md-test-main
+    agent: jenkins
+    always_run: false
+    optional: true


### PR DESCRIPTION
Add timeout and agent_label to use with MachineDeployment tests adopted from CAPI. Add also Prow keywords to start the job from PRs.