### PR TITLE
add support for ironic-image release-30.0 branch

### DIFF
--- a/prow/config/jobs/metal3-io/ironic-image-release-30.0.yaml
+++ b/prow/config/jobs/metal3-io/ironic-image-release-30.0.yaml
@@ -1,0 +1,59 @@
+presubmits:
+  metal3-io/ironic-image:
+  - name: shellcheck
+    branches:
+    - release-30.0
+    run_if_changed: '((\.sh)|^Makefile)$'
+    decorate: true
+    spec:
+      containers:
+      - args:
+        - ./hack/shellcheck.sh
+        command:
+        - sh
+        env:
+        - name: IS_CONTAINER
+          value: "TRUE"
+        image: docker.io/koalaman/shellcheck-alpine:v0.10.0@sha256:5921d946dac740cbeec2fb1c898747b6105e585130cc7f0602eec9a10f7ddb63
+        imagePullPolicy: Always
+  - name: markdownlint
+    branches:
+    - release-30.0
+    run_if_changed: '(\.md|markdownlint\.sh)$'
+    decorate: true
+    spec:
+      containers:
+      - args:
+        - ./hack/markdownlint.sh
+        command:
+        - sh
+        env:
+        - name: IS_CONTAINER
+          value: "TRUE"
+        image: docker.io/pipelinecomponents/markdownlint-cli2:0.12.0@sha256:a3977fba9814f10d33a1d69ae607dc808e7a6470b2ba03e84c17193c0791aac0
+        imagePullPolicy: Always
+  # name: {job_prefix}-{image_os}-e2e-integration-test-{capm3_target_branch}
+  - name: metal3-centos-e2e-integration-test-main
+    branches:
+    - release-30.0
+    agent: jenkins
+    always_run: false
+    optional: false
+  - name: metal3-ubuntu-e2e-integration-test-main
+    branches:
+    - release-30.0
+    agent: jenkins
+    always_run: false
+    optional: false
+  - name: metal3-dev-env-integration-test-centos-main
+    branches:
+    - release-30.0
+    agent: jenkins
+    always_run: false
+    optional: true
+  - name: metal3-dev-env-integration-test-ubuntu-main
+    branches:
+    - release-30.0
+    agent: jenkins
+    always_run: false
+    optional: true

--- a/prow/config/plugins.yaml
+++ b/prow/config/plugins.yaml
@@ -186,7 +186,8 @@ milestone_applier:
     release-1.9: "IPAM - v1.9"
     release-1.8: "IPAM - v1.8"
   metal3-io/ironic-image:
-    main: "ironic-image - v30.0"
+    main: "ironic-image - v31.0"
+    release-30.0: "ironic-image - v30.0"
     release-29.0: "ironic-image - v29.0"
     release-28.0: "ironic-image - v28.0"
     release-27.0: "ironic-image - v27.0"


### PR DESCRIPTION
Add CI support for ironic-image release-30.0 branch. It will be tested versus CAPM3 main, until CAPM3 v1.11 minor is out, and then changed to be tested versus that.