### PR TITLE
Prow: Bump kubernetes, calico and ingress-nginx

### DIFF
--- a/prow/README.md
+++ b/prow/README.md
@@ -125,16 +125,17 @@ image. Here is an example:
 
 ```json
 {
-  "source_image": "54f49763-5f17-475e-9ad2-67dc8cd9a9ff",
+  "source_image": "19e017ae-2759-479c-90ac-a400a3f64678",
   "networks": "29fd620e-8145-43a2-8140-5cec6a69f344",
-  "flavor": "c4m4",
+  "flavor": "c4m12-est",
   "floating_ip_network": "internet",
   "ssh_username": "ubuntu",
   "volume_type": "",
-  "kubernetes_deb_version": "1.30.6-1.1",
-  "kubernetes_rpm_version": "1.30.6",
-  "kubernetes_semver": "v1.30.6",
-  "kubernetes_series": "v1.30"
+  "image_disk_format": "raw",
+  "kubernetes_deb_version": "1.32.5-1.1",
+  "kubernetes_rpm_version": "1.32.5",
+  "kubernetes_semver": "v1.32.5",
+  "kubernetes_series": "v1.32"
 }
 ```
 
@@ -142,7 +143,7 @@ Then build the image like this:
 
 ```bash
 cd images/capi
-PACKER_VAR_FILES=var_file.json make build-openstack-ubuntu-2204
+PACKER_VAR_FILES=var_file.json make build-openstack-ubuntu-2404
 ```
 
 ## Create credentials

--- a/prow/capo-cluster/infra-md.yaml
+++ b/prow/capo-cluster/infra-md.yaml
@@ -27,5 +27,5 @@ spec:
       infrastructureRef:
         apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
         kind: OpenStackMachineTemplate
-        name: prow-worker-v1-31-6-rotated
-      version: v1.31.6
+        name: prow-worker-v1-32-5
+      version: v1.32.5

--- a/prow/capo-cluster/kubeadmcontrolplane.yaml
+++ b/prow/capo-cluster/kubeadmcontrolplane.yaml
@@ -5,9 +5,6 @@ metadata:
 spec:
   kubeadmConfigSpec:
     clusterConfiguration:
-      apiServer:
-        extraArgs:
-          cloud-provider: external
       controllerManager:
         extraArgs:
           cloud-provider: external
@@ -31,6 +28,6 @@ spec:
     infrastructureRef:
       apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
       kind: OpenStackMachineTemplate
-      name: prow-control-plane-v1-31-6-rotated
+      name: prow-control-plane-v1-32-5
   replicas: 1
-  version: v1.31.6
+  version: v1.32.5

--- a/prow/capo-cluster/machinedeployment.yaml
+++ b/prow/capo-cluster/machinedeployment.yaml
@@ -23,5 +23,5 @@ spec:
       infrastructureRef:
         apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
         kind: OpenStackMachineTemplate
-        name: prow-worker-v1-31-6-rotated
-      version: v1.31.6
+        name: prow-worker-v1-32-5
+      version: v1.32.5

--- a/prow/capo-cluster/openstackmachinetemplates.yaml
+++ b/prow/capo-cluster/openstackmachinetemplates.yaml
@@ -1,7 +1,7 @@
 apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
 kind: OpenStackMachineTemplate
 metadata:
-  name: prow-control-plane-v1-30-6-est
+  name: prow-control-plane-v1-32-5
 spec:
   template:
     spec:
@@ -11,13 +11,13 @@ spec:
         name: prow-cloud-config
       image:
         filter:
-          name: ubuntu-2204-kube-v1.30.6
-      sshKeyName: metal3ci
+          name: ubuntu-2404-kube-v1.32.5
+      sshKeyName: prow
 ---
 apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
 kind: OpenStackMachineTemplate
 metadata:
-  name: prow-worker-v1-30-6-est
+  name: prow-worker-v1-32-5
 spec:
   template:
     spec:
@@ -27,8 +27,8 @@ spec:
         name: prow-cloud-config
       image:
         filter:
-          name: ubuntu-2204-kube-v1.30.6
-      sshKeyName: metal3ci
+          name: ubuntu-2404-kube-v1.32.5
+      sshKeyName: prow
 ---
 apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
 kind: OpenStackMachineTemplate

--- a/prow/cluster-resources/kustomization.yaml
+++ b/prow/cluster-resources/kustomization.yaml
@@ -3,21 +3,21 @@ kind: Kustomization
 resources:
 - https://raw.githubusercontent.com/projectcalico/calico/v3.30.1/manifests/calico.yaml
 # Check available versions at https://github.com/kubernetes/cloud-provider-openstack/releases
-- https://raw.githubusercontent.com/kubernetes/cloud-provider-openstack/v1.31.3/manifests/controller-manager/cloud-controller-manager-roles.yaml
-- https://raw.githubusercontent.com/kubernetes/cloud-provider-openstack/v1.31.3/manifests/controller-manager/cloud-controller-manager-role-bindings.yaml
-- https://raw.githubusercontent.com/kubernetes/cloud-provider-openstack/v1.31.3/manifests/controller-manager/openstack-cloud-controller-manager-ds.yaml
-- https://raw.githubusercontent.com/kubernetes/cloud-provider-openstack/v1.31.3/manifests/cinder-csi-plugin/cinder-csi-controllerplugin-rbac.yaml
-- https://raw.githubusercontent.com/kubernetes/cloud-provider-openstack/v1.31.3/manifests/cinder-csi-plugin/cinder-csi-controllerplugin.yaml
-- https://raw.githubusercontent.com/kubernetes/cloud-provider-openstack/v1.31.3/manifests/cinder-csi-plugin/cinder-csi-nodeplugin-rbac.yaml
-- https://raw.githubusercontent.com/kubernetes/cloud-provider-openstack/v1.31.3/manifests/cinder-csi-plugin/cinder-csi-nodeplugin.yaml
-- https://raw.githubusercontent.com/kubernetes/cloud-provider-openstack/v1.31.3/manifests/cinder-csi-plugin/csi-cinder-driver.yaml
+- https://raw.githubusercontent.com/kubernetes/cloud-provider-openstack/v1.32.0/manifests/controller-manager/cloud-controller-manager-roles.yaml
+- https://raw.githubusercontent.com/kubernetes/cloud-provider-openstack/v1.32.0/manifests/controller-manager/cloud-controller-manager-role-bindings.yaml
+- https://raw.githubusercontent.com/kubernetes/cloud-provider-openstack/v1.32.0/manifests/controller-manager/openstack-cloud-controller-manager-ds.yaml
+- https://raw.githubusercontent.com/kubernetes/cloud-provider-openstack/v1.32.0/manifests/cinder-csi-plugin/cinder-csi-controllerplugin-rbac.yaml
+- https://raw.githubusercontent.com/kubernetes/cloud-provider-openstack/v1.32.0/manifests/cinder-csi-plugin/cinder-csi-controllerplugin.yaml
+- https://raw.githubusercontent.com/kubernetes/cloud-provider-openstack/v1.32.0/manifests/cinder-csi-plugin/cinder-csi-nodeplugin-rbac.yaml
+- https://raw.githubusercontent.com/kubernetes/cloud-provider-openstack/v1.32.0/manifests/cinder-csi-plugin/cinder-csi-nodeplugin.yaml
+- https://raw.githubusercontent.com/kubernetes/cloud-provider-openstack/v1.32.0/manifests/cinder-csi-plugin/csi-cinder-driver.yaml
 - autoscaler.yaml
 - coredns-pdb.yaml
 
 images:
 # Check available tags at https://github.com/kubernetes/autoscaler/tags
 - name: registry.k8s.io/autoscaling/cluster-autoscaler
-  newTag: v1.31.1
+  newTag: v1.32.1
 
 generatorOptions:
   disableNameSuffixHash: true

--- a/prow/cluster-resources/kustomization.yaml
+++ b/prow/cluster-resources/kustomization.yaml
@@ -1,7 +1,7 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
-- https://raw.githubusercontent.com/projectcalico/calico/v3.29.2/manifests/calico.yaml
+- https://raw.githubusercontent.com/projectcalico/calico/v3.30.1/manifests/calico.yaml
 # Check available versions at https://github.com/kubernetes/cloud-provider-openstack/releases
 - https://raw.githubusercontent.com/kubernetes/cloud-provider-openstack/v1.31.3/manifests/controller-manager/cloud-controller-manager-roles.yaml
 - https://raw.githubusercontent.com/kubernetes/cloud-provider-openstack/v1.31.3/manifests/controller-manager/cloud-controller-manager-role-bindings.yaml

--- a/prow/infra/kustomization.yaml
+++ b/prow/infra/kustomization.yaml
@@ -1,7 +1,7 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
-- https://github.com/kubernetes/ingress-nginx/deploy/static/provider/cloud?ref=controller-v1.12.1
+- https://github.com/kubernetes/ingress-nginx/deploy/static/provider/cloud?ref=controller-v1.12.3
 - cluster-issuer-http.yaml
 - storageclass.yaml
 - ingress-controller-pdb.yaml


### PR DESCRIPTION
- Kubernetes v1.32.5, autoscaler and cloud provider also bumped to v1.32
- Calico bumped to v3.30.1
- Ingress-nginx v1.12.3

The `cloud-provider` flag no longer exists in the API server, so this has been removed.