### PR TITLE
Add RootDeviceHint on bmhs in BML tests

### DIFF
--- a/jenkins/scripts/bare_metal_lab/default_vars/vars.yaml
+++ b/jenkins/scripts/bare_metal_lab/default_vars/vars.yaml
@@ -11,24 +11,38 @@ metal3_dev_env_branch: "{{ lookup('env', 'BML_METAL3_DEV_ENV_BRANCH') }}"
 pr_id: "{{ lookup('env', 'PR_ID') }}"
 serial_log_location: "/tmp/BMLlog"
 bare_metal_hosts:
-  # - id: "02"
-  #   mac: b4:b5:2f:6d:59:b0
-  #   ip: "192.168.1.11"
   - id: "03"
     mac: b4:b5:2f:6d:89:d8
     ip: "192.168.1.24"
+    rootDeviceHint: "/dev/disk/by-path/pci-0000:03:00.0-scsi-0:1:0:1"
   # - id: "04"
   #   mac: 80:c1:6e:7a:e8:10
   #   ip: "192.168.1.13"
+  #   rootDeviceHint: "/dev/disk/by-path/pci-0000:03:00.0-scsi-0:1:0:0"
   - id: "05"
     mac: 80:c1:6e:7a:5a:a8
     ip: "192.168.1.14"
+    rootDeviceHint: "/dev/disk/by-path/pci-0000:03:00.0-scsi-0:1:0:0"
   # - id: "06"
   #   mac: b4:b5:2f:6d:68:10
   #   ip: "192.168.1.15"
+  #   rootDeviceHint: "/dev/disk/by-path/pci-0000:03:00.0-scsi-0:1:0:0"
   # - id: "07"
   #   mac: b4:b5:2f:6d:a9:d8
   #   ip: "192.168.1.16"
+  #   rootDeviceHint: "/dev/disk/by-path/pci-0000:03:00.0-scsi-0:1:0:0"
+  # - id: "14"
+  #   mac: 6c:3b:e5:b5:03:c8
+  #   ip: "192.168.1.32"
+  #   rootDeviceHint: "/dev/disk/by-path/pci-0000:03:00.0-scsi-0:1:0:0"
+  # - id: "15"
+  #   mac: 10:60:4b:b4:be:00
+  #   ip: "192.168.1.37"
+  #   rootDeviceHint: "/dev/disk/by-path/pci-0000:03:00.0-scsi-0:1:0:0"
+  # - id: "16"
+  #   mac: b4:b5:2f:6f:01:40
+  #   ip: "192.168.1.33"
+  #   rootDeviceHint: "/dev/disk/by-path/pci-0000:03:00.0-scsi-0:1:0:0"
 
 EPHEMERAL_CLUSTER: "minikube"
 EXTERNAL_VLAN_ID: 3

--- a/jenkins/scripts/bare_metal_lab/templates/bmhosts_crs.yaml.j2
+++ b/jenkins/scripts/bare_metal_lab/templates/bmhosts_crs.yaml.j2
@@ -21,4 +21,6 @@ spec:
     address: ilo4://{{ bmh.ip }}
     credentialsName: bml-ilo-login-secret-{{ bmh.id }}
     disableCertificateVerification: true
+  rootDeviceHints:
+    deviceName: {{ bmh.rootDeviceHint }}
 {% endfor %}


### PR DESCRIPTION
When we changed RAID config to 0 in bml it started causing an issue. Sometimes After provisioning server cannot find OS in the disk. After we realized boot checks only first disk, and sometimes disk is written to second disk. To solve the issue we are adding rootDeviceHint to bmhs to make sure OS will always be written to first disk.

PR also removes server 2 info as it used as provisioning host