### PR TITLE
Add Prow keywords for K8s pre-release testing

### DIFF
--- a/prow/config/jobs/metal3-io/project-infra.yaml
+++ b/prow/config/jobs/metal3-io/project-infra.yaml
@@ -322,3 +322,12 @@ presubmits:
     agent: jenkins
     always_run: false
     optional: true
+  # name: {job_prefix}-{image_os}-e2e-k8s-pre-release-test-{capm3_target_branch}
+  - name: metal3-centos-e2e-k8s-pre-release-test-main
+    agent: jenkins
+    always_run: false
+    optional: true
+  - name: metal3-ubuntu-e2e-k8s-pre-release-test-main
+    agent: jenkins
+    always_run: false
+    optional: true


### PR DESCRIPTION
Add Prow keywords for testing with k8s' pre-release versions. Only for project-infra for now because the pipeline (see https://github.com/metal3-io/project-infra/pull/1060) is still in progress.