### PR TITLE
Add prow keywords for k8s pre-release testing

### DIFF
--- a/prow/config/jobs/metal3-io/baremetal-operator.yaml
+++ b/prow/config/jobs/metal3-io/baremetal-operator.yaml
@@ -199,3 +199,16 @@ presubmits:
     agent: jenkins
     always_run: false
     optional: true
+  # name: {job_prefix}-{image_os}-e2e-integration-k8s-pre-release-test-{capm3_target_branch}
+  - name: metal3-centos-e2e-integration-k8s-pre-release-test-main
+    branches:
+    - main
+    agent: jenkins
+    always_run: false
+    optional: true
+  - name: metal3-ubuntu-e2e-integration-k8s-pre-release-test-main
+    branches:
+    - main
+    agent: jenkins
+    always_run: false
+    optional: true

--- a/prow/config/jobs/metal3-io/cluster-api-provider-metal3.yaml
+++ b/prow/config/jobs/metal3-io/cluster-api-provider-metal3.yaml
@@ -230,3 +230,16 @@ presubmits:
     agent: jenkins
     always_run: false
     optional: true
+  # name: {job_prefix}-{image_os}-e2e-integration-k8s-pre-release-test-{capm3_target_branch}
+  - name: metal3-centos-e2e-integration-k8s-pre-release-test-main
+    branches:
+    - main
+    agent: jenkins
+    always_run: false
+    optional: true
+  - name: metal3-ubuntu-e2e-integration-k8s-pre-release-test-main
+    branches:
+    - main
+    agent: jenkins
+    always_run: false
+    optional: true

--- a/prow/config/jobs/metal3-io/ip-address-manager.yaml
+++ b/prow/config/jobs/metal3-io/ip-address-manager.yaml
@@ -188,3 +188,16 @@ presubmits:
     agent: jenkins
     always_run: false
     optional: true
+  # name: {job_prefix}-{image_os}-e2e-integration-k8s-pre-release-test-{capm3_target_branch}
+  - name: metal3-centos-e2e-integration-k8s-pre-release-test-main
+    branches:
+    - main
+    agent: jenkins
+    always_run: false
+    optional: true
+  - name: metal3-ubuntu-e2e-integration-k8s-pre-release-test-main
+    branches:
+    - main
+    agent: jenkins
+    always_run: false
+    optional: true

--- a/prow/config/jobs/metal3-io/metal3-dev-env.yaml
+++ b/prow/config/jobs/metal3-io/metal3-dev-env.yaml
@@ -275,3 +275,12 @@ presubmits:
     agent: jenkins
     always_run: false
     optional: true
+  # name: {job_prefix}-{image_os}-e2e-integration-k8s-pre-release-test-{capm3_target_branch}
+  - name: metal3-centos-e2e-integration-k8s-pre-release-test-main
+    agent: jenkins
+    always_run: false
+    optional: true
+  - name: metal3-ubuntu-e2e-integration-k8s-pre-release-test-main
+    agent: jenkins
+    always_run: false
+    optional: true

--- a/prow/config/jobs/metal3-io/project-infra.yaml
+++ b/prow/config/jobs/metal3-io/project-infra.yaml
@@ -322,12 +322,12 @@ presubmits:
     agent: jenkins
     always_run: false
     optional: true
-  # name: {job_prefix}-{image_os}-e2e-k8s-pre-release-test-{capm3_target_branch}
-  - name: metal3-centos-e2e-k8s-pre-release-test-main
+  # name: {job_prefix}-{image_os}-e2e-integration-k8s-pre-release-test-{capm3_target_branch}
+  - name: metal3-centos-e2e-integration-k8s-pre-release-test-main
     agent: jenkins
     always_run: false
     optional: true
-  - name: metal3-ubuntu-e2e-k8s-pre-release-test-main
+  - name: metal3-ubuntu-e2e-integration-k8s-pre-release-test-main
     agent: jenkins
     always_run: false
     optional: true


### PR DESCRIPTION
Add prow keywords for k8s pre-release testing for BMO, IPAM and CAPM3 and update the naming for project-infra.