### PR TITLE
WIP: add a build test for ironic-image

### DIFF
--- a/prow/config/jobs/metal3-io/ironic-image.yaml
+++ b/prow/config/jobs/metal3-io/ironic-image.yaml
@@ -32,6 +32,23 @@ presubmits:
           value: "TRUE"
         image: docker.io/pipelinecomponents/markdownlint-cli2:0.12.0@sha256:a3977fba9814f10d33a1d69ae607dc808e7a6470b2ba03e84c17193c0791aac0
         imagePullPolicy: Always
+  - name: build
+    branches:
+    - main
+    decorate: true
+    spec:
+      containers:
+      - args:
+        - -c
+        - "dnf install -y make; make build"
+        command:
+        - sh
+        image: quay.io/podman/stable:v5.5.2-immutable # TODO: add sha256
+        securityContext:
+          privileged: true
+        env:
+        - name: CONTAINER_RUNTIME
+          value: "podman"
   # name: {job_prefix}-{image_os}-e2e-integration-test-{capm3_target_branch}
   - name: metal3-centos-e2e-integration-test-main
     branches:


### PR DESCRIPTION
Test both CS9 and CS10 build in ironic-image.

TODO:
- [ ] finalize the choosing the base container and pinning it (do we really need one?)
- [ ] should we introduce build.sh in ironic-image to clean up this
- [ ] add relevant release branches to test it too

Ref: needs https://github.com/metal3-io/ironic-image/pull/747 merged on affected branches.
