### PR TITLE
align release-1.11 CAPM3,IPAM integration tests

### DIFF
--- a/prow/config/jobs/metal3-io/cluster-api-provider-metal3-release-1.11.yaml
+++ b/prow/config/jobs/metal3-io/cluster-api-provider-metal3-release-1.11.yaml
@@ -153,7 +153,7 @@ presubmits:
     - release-1.11
     agent: jenkins
     always_run: false
-    optional: false
+    optional: true
   # name: {job_prefix}-{image_os}-e2e-feature-test-{capm3_target_job}
   - name: metal3-centos-e2e-feature-test-release-1-11
     branches:

--- a/prow/config/jobs/metal3-io/ip-address-manager-release-1.11.yaml
+++ b/prow/config/jobs/metal3-io/ip-address-manager-release-1.11.yaml
@@ -129,13 +129,13 @@ presubmits:
     - release-1.11
     agent: jenkins
     always_run: false
-    optional: true
+    optional: false
   - name: metal3-ubuntu-e2e-integration-test-release-1-11
     branches:
     - release-1.11
     agent: jenkins
     always_run: false
-    optional: false
+    optional: true
   - name: metal3-centos-e2e-feature-test-release-1-11-pivoting
     branches:
     - release-1.11


### PR DESCRIPTION
With this change:

- CAPM3 and IPAM release-1.11 will require the same kind of mandatory integration tests
- Only the centos based integration test will be mandatory uniformly across the two branches

This change has no practical effect on GitHub because GitHub only reacts to webhook triggered mandatory jobs based on the status checks that a maintainer sets manually on the settings page (at least in our repos) so the optional flag I am setting here is just configured to avoid confusion.