### PR TITLE
Increase BMO optional tests timeout

### DIFF
--- a/jenkins/jobs/bmo_e2e_optional_tests.pipeline
+++ b/jenkins/jobs/bmo_e2e_optional_tests.pipeline
@@ -1,7 +1,7 @@
 import java.text.SimpleDateFormat
 
-// 2 hour
-def TIMEOUT = 7200
+// 3 hour
+def TIMEOUT = 10800
 
 // Set defaults for non-PR jobs
 def pullSha = (env.PULL_PULL_SHA) ?: "main"


### PR DESCRIPTION
BMO optional tests need more time to complete the jobs. It didn't have any other errors than timeout. So by increasing the time of tests would solve our issue.