### PR TITLE
Link checker should ignore deleted files

### DIFF
--- a/.github/workflows/pr-link-check.yml
+++ b/.github/workflows/pr-link-check.yml
@@ -41,10 +41,10 @@ jobs:
       - name: Checkout base branch
         run: git checkout "upstream/${{ github.event.pull_request.base.ref }}"
 
-      - name: Get list of changed Markdown files
+      - name: Get list of changed Markdown files (without deletions)
         id: changed-files
         run: |
-          git diff --name-only "upstream/${{ github.event.pull_request.base.ref }}...${{ github.head_ref }}" -- "*.md" > changed-files.txt
+          git diff --name-only --diff-filter=d "upstream/${{ github.event.pull_request.base.ref }}...${{ github.head_ref }}" -- "*.md" > changed-files.txt
           cat changed-files.txt
           if [[ -s "changed-files.txt" ]]; then
             echo "Changed md files found"


### PR DESCRIPTION
Currently, it fails if any markdown file is deleted.

Signed-off-by: Dmitry Tantsur <dtantsur@protonmail.com>
