### PR TITLE
Add reusable workflow for scheduled OSV scan

### DIFF
--- a/.github/workflows/scheduled-osv-scan.yml
+++ b/.github/workflows/scheduled-osv-scan.yml
@@ -1,0 +1,84 @@
+# runs vulnerability scans and add them to Github Security tab
+
+name: OSV-Scanner Scheduled
+
+on:
+  workflow_call:
+    inputs:
+      repository-name:
+        description: 'Name of the repository being scanned'
+        required: true
+        type: string
+      scan-args:
+        description: 'Additional OSV scanner arguments'
+        required: false
+        type: string
+        default: |-
+          --config ./config.toml
+          --recursive
+          ./
+    secrets:
+      SLACK_WEBHOOK:
+        description: 'Slack webhook URL for notifications'
+        required: true
+
+permissions:
+  actions: read
+  contents: read
+  security-events: write # for uploading SARIF files
+
+jobs:
+  set-go-version:
+    name: Set up Go version
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+    - name: Calculate go version
+      id: vars
+      run: echo "go_version=$(make go-version)" >> "${GITHUB_OUTPUT}"
+    - name: Create config.toml
+      run: echo "GoVersionOverride = \"${{ steps.vars.outputs.go_version }}\"" > config.toml
+    - name: Upload config.toml
+      uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
+      with:
+        name: calculated-go-version
+        path: ./config.toml
+
+  scan-scheduled:
+    name: Run OSV Scanner
+    needs: set-go-version
+    uses: "google/osv-scanner-action/.github/workflows/osv-scanner-reusable.yml@90b209d0ea55cea1da9fc0c4e65782cc6acb6e2e" # v2.2.2
+    with:
+      download-artifact: calculated-go-version
+      fail-on-vuln: false
+      scan-args: ${{ inputs.scan-args }}
+
+  check-and-notify:
+    name: Check vulnerabilities and notify
+    needs: [set-go-version, scan-scheduled]
+    runs-on: ubuntu-latest
+    if: ${{ always() }}
+    steps:
+      - uses: actions/download-artifact@634f93cb2916e3fdff6788551b99b062d0335ce0 # v5.0.0
+        with:
+          name: SARIF file
+      - name: Check for vulnerabilities in SARIF
+        id: check
+        run: |
+          HAS_VULN=$(jq '[.runs[].results[]] | length > 0' results.sarif)
+          echo "has_vulnerabilities=$HAS_VULN" >> $GITHUB_OUTPUT
+      - name: Slack Notification on Vulnerability or Failure
+        if: ${{ steps.check.outputs.has_vulnerabilities == 'true' || contains(needs.*.result, 'failure') }}
+        uses: rtCamp/action-slack-notify@e31e87e03dd19038e411e38ae27cbad084a90661 # 2.3.3
+        env:
+          SLACK_TITLE: "OSV-Scanner failed or detected vulnerabilities in ${{ inputs.repository-name }}"
+          SLACK_COLOR: "#FF0000"
+          SLACK_MESSAGE: "OSV-Scanner failed or detected vulnerabilities in ${{ inputs.repository-name }}"
+          SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK }}
+          SLACK_CHANNEL: metal3-github-actions-notify
+          SLACK_USERNAME: metal3-github-actions-notify
+      - name: Fail if vulnerabilities found or previous job failed
+        if: ${{ steps.check.outputs.has_vulnerabilities == 'true' || contains(needs.*.result, 'failure') }}
+        run: |
+          echo "Vulnerabilities found or previous job failed"
+          exit 1


### PR DESCRIPTION
Add new reusable workflow for running scheduled OSV scans in Metal3 repositories.

The workflow
- sets up Go version defined in the project's Makefile
- runs the reusable OSV scanner workflow with given scan arguments
- checks results and reports on Slack if there are any vulnerabilities found or failures occured on the workflow

Use the reusable OSV scanner workflow instead of actions (scan, report) directly, as recommended ([code](https://github.com/google/osv-scanner-action/blob/main/osv-scanner-action/action.yml#L15), [documentation](https://google.github.io/osv-scanner/github-action/#scheduled-scans)). Reusing the workflow means that the other steps around the scanning have to be in separate jobs.