### PR TITLE
Install podman in basic-checks container

### DIFF
--- a/prow/container-images/basic-checks/Dockerfile
+++ b/prow/container-images/basic-checks/Dockerfile
@@ -4,5 +4,5 @@ FROM docker.io/golang:${GO_VERSION}
 # Install additional packages not present in regular golang image
 RUN apt-get update \
     && apt-get -y upgrade \
-    && apt-get install -y libvirt-dev \
+    && apt-get install -y libvirt-dev podman \
     && apt-get clean


### PR DESCRIPTION
Install podman in basic-checks container
This is needed for https://github.com/metal3-io/baremetal-operator/pull/2605/, which fixes https://github.com/metal3-io/baremetal-operator/issues/2509 