### PR TITLE
Add OpenSUSE leap image to image building job

### DIFF
--- a/jenkins/jobs/image_building.pipeline
+++ b/jenkins/jobs/image_building.pipeline
@@ -39,7 +39,7 @@ pipeline {
         axes {
           axis {
             name 'IMAGE_OS'
-            values 'ubuntu', 'centos'
+            values 'ubuntu', 'centos', "opensuse-leap"
           }
         }
         environment {


### PR DESCRIPTION
Start building opensuse images in the CI. At least node image is required to test opensuse in the CI.