### PR TITLE
Add k8s repo for yum in centos node image

### DIFF
--- a/jenkins/image_building/dib_elements/centos-node/pre-install.d/55-setup-repos
+++ b/jenkins/image_building/dib_elements/centos-node/pre-install.d/55-setup-repos
@@ -16,4 +16,13 @@ gpgcheck=1
 gpgkey=https://download.opensuse.org/repositories/isv:/cri-o:/stable:/${CRIO_MINOR_VERSION}/rpm/repodata/repomd.xml.key
 EOF
 
+cat <<EOF | sudo tee /etc/yum.repos.d/kubernetes.repo
+[kubernetes]
+name=Kubernetes
+baseurl=https://pkgs.k8s.io/core:/stable:/${KUBERNETES_MINOR_VERSION}/rpm/
+enabled=1
+gpgcheck=1
+gpgkey=https://pkgs.k8s.io/core:/stable:/${KUBERNETES_MINOR_VERSION}/rpm/repodata/repomd.xml.key
+EOF
+
 sudo yum -y update


### PR DESCRIPTION
google hosted yum repo moved to pkgs.k8s.io repo while ago. 
