### PR TITLE
Prow: Upgrade k8s to v1.33.5

### DIFF
--- a/prow/README.md
+++ b/prow/README.md
@@ -132,10 +132,10 @@ image. Here is an example:
   "ssh_username": "ubuntu",
   "volume_type": "",
   "image_disk_format": "raw",
-  "kubernetes_deb_version": "1.32.5-1.1",
-  "kubernetes_rpm_version": "1.32.5",
-  "kubernetes_semver": "v1.32.5",
-  "kubernetes_series": "v1.32"
+  "kubernetes_deb_version": "1.33.5-1.1",
+  "kubernetes_rpm_version": "1.33.5",
+  "kubernetes_semver": "v1.33.5",
+  "kubernetes_series": "v1.33"
 }
 ```
 

--- a/prow/capo-cluster/infra-md.yaml
+++ b/prow/capo-cluster/infra-md.yaml
@@ -27,5 +27,5 @@ spec:
       infrastructureRef:
         apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
         kind: OpenStackMachineTemplate
-        name: prow-worker-v1-32-5
-      version: v1.32.5
+        name: prow-worker-v1-33-5
+      version: v1.33.5

--- a/prow/capo-cluster/kubeadmcontrolplane.yaml
+++ b/prow/capo-cluster/kubeadmcontrolplane.yaml
@@ -28,6 +28,6 @@ spec:
     infrastructureRef:
       apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
       kind: OpenStackMachineTemplate
-      name: prow-control-plane-v1-32-5
+      name: prow-control-plane-v1-33-5
   replicas: 1
-  version: v1.32.5
+  version: v1.33.5

--- a/prow/capo-cluster/machinedeployment.yaml
+++ b/prow/capo-cluster/machinedeployment.yaml
@@ -23,5 +23,5 @@ spec:
       infrastructureRef:
         apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
         kind: OpenStackMachineTemplate
-        name: prow-worker-v1-32-5
-      version: v1.32.5
+        name: prow-worker-v1-33-5
+      version: v1.33.5

--- a/prow/capo-cluster/openstackmachinetemplates.yaml
+++ b/prow/capo-cluster/openstackmachinetemplates.yaml
@@ -33,7 +33,7 @@ spec:
 apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
 kind: OpenStackMachineTemplate
 metadata:
-  name: prow-control-plane-v1-31-6
+  name: prow-control-plane-v1-33-5
 spec:
   template:
     spec:
@@ -43,45 +43,13 @@ spec:
         name: prow-cloud-config
       image:
         filter:
-          name: ubuntu-2404-kube-v1.31.6
-      sshKeyName: metal3ci
----
-apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
-kind: OpenStackMachineTemplate
-metadata:
-  name: prow-worker-v1-31-6
-spec:
-  template:
-    spec:
-      flavor: c8m24-est
-      identityRef:
-        cloudName: prow
-        name: prow-cloud-config
-      image:
-        filter:
-          name: ubuntu-2404-kube-v1.31.6
-      sshKeyName: metal3ci
----
-apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
-kind: OpenStackMachineTemplate
-metadata:
-  name: prow-control-plane-v1-31-6-rotated
-spec:
-  template:
-    spec:
-      flavor: c4m12-est
-      identityRef:
-        cloudName: prow
-        name: prow-cloud-config
-      image:
-        filter:
-          name: ubuntu-2404-kube-v1.31.6
+          name: ubuntu-2404-kube-v1.33.5
       sshKeyName: prow
 ---
 apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
 kind: OpenStackMachineTemplate
 metadata:
-  name: prow-worker-v1-31-6-rotated
+  name: prow-worker-v1-33-5
 spec:
   template:
     spec:
@@ -91,5 +59,5 @@ spec:
         name: prow-cloud-config
       image:
         filter:
-          name: ubuntu-2404-kube-v1.31.6
+          name: ubuntu-2404-kube-v1.33.5
       sshKeyName: prow

--- a/prow/cluster-resources/kustomization.yaml
+++ b/prow/cluster-resources/kustomization.yaml
@@ -3,21 +3,21 @@ kind: Kustomization
 resources:
 - https://raw.githubusercontent.com/projectcalico/calico/v3.30.1/manifests/calico.yaml
 # Check available versions at https://github.com/kubernetes/cloud-provider-openstack/releases
-- https://raw.githubusercontent.com/kubernetes/cloud-provider-openstack/v1.32.0/manifests/controller-manager/cloud-controller-manager-roles.yaml
-- https://raw.githubusercontent.com/kubernetes/cloud-provider-openstack/v1.32.0/manifests/controller-manager/cloud-controller-manager-role-bindings.yaml
-- https://raw.githubusercontent.com/kubernetes/cloud-provider-openstack/v1.32.0/manifests/controller-manager/openstack-cloud-controller-manager-ds.yaml
-- https://raw.githubusercontent.com/kubernetes/cloud-provider-openstack/v1.32.0/manifests/cinder-csi-plugin/cinder-csi-controllerplugin-rbac.yaml
-- https://raw.githubusercontent.com/kubernetes/cloud-provider-openstack/v1.32.0/manifests/cinder-csi-plugin/cinder-csi-controllerplugin.yaml
-- https://raw.githubusercontent.com/kubernetes/cloud-provider-openstack/v1.32.0/manifests/cinder-csi-plugin/cinder-csi-nodeplugin-rbac.yaml
-- https://raw.githubusercontent.com/kubernetes/cloud-provider-openstack/v1.32.0/manifests/cinder-csi-plugin/cinder-csi-nodeplugin.yaml
-- https://raw.githubusercontent.com/kubernetes/cloud-provider-openstack/v1.32.0/manifests/cinder-csi-plugin/csi-cinder-driver.yaml
+- https://raw.githubusercontent.com/kubernetes/cloud-provider-openstack/v1.33.1/manifests/controller-manager/cloud-controller-manager-roles.yaml
+- https://raw.githubusercontent.com/kubernetes/cloud-provider-openstack/v1.33.1/manifests/controller-manager/cloud-controller-manager-role-bindings.yaml
+- https://raw.githubusercontent.com/kubernetes/cloud-provider-openstack/v1.33.1/manifests/controller-manager/openstack-cloud-controller-manager-ds.yaml
+- https://raw.githubusercontent.com/kubernetes/cloud-provider-openstack/v1.33.1/manifests/cinder-csi-plugin/cinder-csi-controllerplugin-rbac.yaml
+- https://raw.githubusercontent.com/kubernetes/cloud-provider-openstack/v1.33.1/manifests/cinder-csi-plugin/cinder-csi-controllerplugin.yaml
+- https://raw.githubusercontent.com/kubernetes/cloud-provider-openstack/v1.33.1/manifests/cinder-csi-plugin/cinder-csi-nodeplugin-rbac.yaml
+- https://raw.githubusercontent.com/kubernetes/cloud-provider-openstack/v1.33.1/manifests/cinder-csi-plugin/cinder-csi-nodeplugin.yaml
+- https://raw.githubusercontent.com/kubernetes/cloud-provider-openstack/v1.33.1/manifests/cinder-csi-plugin/csi-cinder-driver.yaml
 - autoscaler.yaml
 - coredns-pdb.yaml
 
 images:
 # Check available tags at https://github.com/kubernetes/autoscaler/tags
 - name: registry.k8s.io/autoscaling/cluster-autoscaler
-  newTag: v1.32.1
+  newTag: v1.33.1
 
 generatorOptions:
   disableNameSuffixHash: true


### PR DESCRIPTION
Time to upgrade. K8s v1.34 has already been out for a while. We stick to one minor release behind.