### PR TITLE
🌱 Set USE_IRSO default true

### DIFF
--- a/jenkins/scripts/dynamic_worker_workflow/dev_env_integration_tests.sh
+++ b/jenkins/scripts/dynamic_worker_workflow/dev_env_integration_tests.sh
@@ -24,7 +24,7 @@ export TARGET_NODE_MEMORY="${TARGET_NODE_MEMORY:-4096}"
 export IRONIC_INSTALL_TYPE="${IRONIC_INSTALL_TYPE:-rpm}"
 export IRONIC_FROM_SOURCE="${IRONIC_FROM_SOURCE:-false}"
 export BUILD_IRONIC_IMAGE_LOCALLY=""
-export USE_IRSO="${USE_IRSO:-false}"
+export USE_IRSO="${USE_IRSO:-true}"
 
 if [[ "${IRONIC_INSTALL_TYPE}" == "source" ]]; then
     IRONIC_FROM_SOURCE="true"


### PR DESCRIPTION
USE_IRSO defaults to true
NOTE: Setting USE_IRSO to true only installs IRSO in the bootstrap-cluster in the target-cluster after pivot; it still uses deploy.sh script from bmo. 
