### PR TITLE
Install and configure buildkit in ubuntu ci image

### DIFF
--- a/jenkins/image_building/dib_elements/ubuntu-ci/install.d/55-install
+++ b/jenkins/image_building/dib_elements/ubuntu-ci/install.d/55-install
@@ -34,11 +34,25 @@ sudo echo \
   $(lsb_release -cs) stable" | sudo tee /etc/apt/sources.list.d/docker.list
 
 sudo apt-get update
-sudo apt-get install docker-ce docker-ce-cli containerd.io jq -y
+sudo apt-get install docker-ce docker-ce-cli containerd.io docker-buildx-plugin docker-compose-plugin jq -y
 sudo groupadd docker || true
 sudo usermod -aG docker metal3ci || true
 sudo systemctl enable docker
+
+# Configure Docker daemon with BuildKit support
+sudo mkdir -p /etc/docker
+sudo tee /etc/docker/daemon.json <<EOF
+{
+  "features": {
+    "buildkit": true
+  }
+}
+EOF
+
 sudo systemctl restart docker
+
+# Set BuildKit as default for the metal3ci user
+sudo -u metal3ci bash -c 'echo "export DOCKER_BUILDKIT=1" >> /home/metal3ci/.bashrc'
 
 # Add metal3ci user to libvirt group
 sudo adduser metal3ci libvirt


### PR DESCRIPTION
This allows for more advanced options when building and running containers.

Closes https://github.com/metal3-io/ironic-image/issues/765