### PR TITLE
Rename EPHEMERAL to BOOTSTRAP

### DIFF
--- a/jenkins/jobs/bml_integration_tests.pipeline
+++ b/jenkins/jobs/bml_integration_tests.pipeline
@@ -44,7 +44,7 @@ pipeline {
     CONTROL_PLANE_MACHINE_COUNT = 1
     CAPI_VERSION = "${CAPI_VERSION}"
     CAPM3_VERSION = "${CAPM3_VERSION}"
-    EPHEMERAL_CLUSTER = "minikube"
+    BOOTSTRAP_CLUSTER = "minikube"
     EXTERNAL_VLAN_ID = "3"
   }
   stages {

--- a/jenkins/scripts/bare_metal_lab/bml_cleanup.sh
+++ b/jenkins/scripts/bare_metal_lab/bml_cleanup.sh
@@ -9,7 +9,7 @@ set -eu
 #  cleanup_bml.sh
 #
 export EXTERNAL_VLAN_ID="${EXTERNAL_VLAN_ID:-3}"
-export EPHEMERAL_CLUSTER="${EPHEMERAL_CLUSTER:-"minikube"}"
+export BOOTSTRAP_CLUSTER="${BOOTSTRAP_CLUSTER:-"minikube"}"
 export CAPI_VERSION="${CAPI_VERSION:-v1beta2}"
 export CAPM3_VERSION="${CAPM3_VERSION:-v1beta1}"
 export CAPM3RELEASEBRANCH="${CAPM3RELEASEBRANCH:-main}"

--- a/jenkins/scripts/bare_metal_lab/bml_integration_test.sh
+++ b/jenkins/scripts/bare_metal_lab/bml_integration_test.sh
@@ -36,7 +36,7 @@ fi
 # In the bare metal lab, the external network has vlan id 3
 export EXTERNAL_VLAN_ID="${EXTERNAL_VLAN_ID:-"3"}"
 
-export EPHEMERAL_CLUSTER="${EPHEMERAL_CLUSTER:-"minikube"}"
+export BOOTSTRAP_CLUSTER="${BOOTSTRAP_CLUSTER:-"minikube"}"
 export CAPI_VERSION="${CAPI_VERSION:-v1beta2}"
 export CAPM3_VERSION="${CAPM3_VERSION:-v1beta1}"
 export CAPM3RELEASEBRANCH="${CAPM3RELEASEBRANCH:-main}"

--- a/jenkins/scripts/dynamic_worker_workflow/dev_env_integration_tests.sh
+++ b/jenkins/scripts/dynamic_worker_workflow/dev_env_integration_tests.sh
@@ -45,9 +45,9 @@ export FORCE_REPO_UPDATE=false
 if [[ "${IMAGE_OS}" == "ubuntu" ]]; then
     #Must match with fetch_logs.sh
     export CONTAINER_RUNTIME="docker"
-    export EPHEMERAL_CLUSTER="kind"
+    export BOOTSTRAP_CLUSTER="kind"
 else
-    export EPHEMERAL_CLUSTER="minikube"
+    export BOOTSTRAP_CLUSTER="minikube"
 fi
 
 # Clone the source repository

--- a/jenkins/scripts/dynamic_worker_workflow/e2e_tests.sh
+++ b/jenkins/scripts/dynamic_worker_workflow/e2e_tests.sh
@@ -65,9 +65,9 @@ export FORCE_REPO_UPDATE=false
 if [[ "${IMAGE_OS}" == "ubuntu" ]]; then
     #Must match with fetch_logs.sh
     export CONTAINER_RUNTIME="docker"
-    export EPHEMERAL_CLUSTER="kind"
+    export BOOTSTRAP_CLUSTER="kind"
 else
-    export EPHEMERAL_CLUSTER="minikube"
+    export BOOTSTRAP_CLUSTER="minikube"
 fi
 
 # Clone the source repository

--- a/jenkins/scripts/dynamic_worker_workflow/fetch_logs.sh
+++ b/jenkins/scripts/dynamic_worker_workflow/fetch_logs.sh
@@ -112,9 +112,9 @@ mkdir -p "${LOGS_DIR}/manifests"
 if [[ -d "/tmp/manifests" ]]; then
     cp -r /tmp/manifests/* "${LOGS_DIR}/manifests"
 else
-    # There will be no manifest directory in case of filure in ephemeral cluster
+    # There will be no manifest directory in case of filure in bootstrap cluster
     # We are collecting those manifest for debugging
-    fetch_manifests "manifests/ephemeral_cluster" "/home/metal3ci/.kube/config"
+    fetch_manifests "manifests/bootstrap_cluster" "/home/metal3ci/.kube/config"
 fi
 
 # Fetch k8s logs

--- a/jenkins/scripts/dynamic_worker_workflow/run_clean.sh
+++ b/jenkins/scripts/dynamic_worker_workflow/run_clean.sh
@@ -4,9 +4,9 @@ set -eux
 
 if [[ "${IMAGE_OS}" == "ubuntu" ]]; then
     export CONTAINER_RUNTIME="docker"
-    export EPHEMERAL_CLUSTER="kind"
+    export BOOTSTRAP_CLUSTER="kind"
 else
-    export EPHEMERAL_CLUSTER="minikube"
+    export BOOTSTRAP_CLUSTER="minikube"
 fi
 
 if [[ "${REPO_NAME}" == "metal3-dev-env" ]] ||


### PR DESCRIPTION
We have been discussing to update Ephemeral cluster name to Bootstrap cluster instances. This PR will unify all the variables from EPHEMERAL_CLUSTER to BOOTSTRAP_CLUSTER. 
