### PR TITLE
🌱 Update Centos10 image

### DIFF
--- a/jenkins/image_building/build-image.sh
+++ b/jenkins/image_building/build-image.sh
@@ -70,7 +70,7 @@ if [[ "${IMAGE_OS}" == "ubuntu" ]]; then
 elif [[ "${IMAGE_OS}" == "centos" ]]; then
   numeric_release=10
   # Setting upstrem Centos 10 stream image
-  centos_upstream_img="CentOS-Stream-GenericCloud-10-20250915.0.x86_64.qcow2"
+  centos_upstream_img="CentOS-Stream-GenericCloud-10-20251027.0.x86_64.qcow2"
 
   if [[ ! -f "${REPO_ROOT}/${centos_upstream_img}" ]]; then
     wget -O "${REPO_ROOT}/${centos_upstream_img}" "https://cloud.centos.org/centos/10-stream/x86_64/images/${centos_upstream_img}"


### PR DESCRIPTION
metal3-periodic-node-image-building is failing to
```
+ centos_upstream_img=CentOS-Stream-GenericCloud-10-20250915.0.x86_64.qcow2

+ [[ ! -f /home/metal3ci/workspace/metal3-periodic-node-image-building/CentOS-Stream-GenericCloud-10-20250915.0.x86_64.qcow2 ]]

+ wget -O /home/metal3ci/workspace/metal3-periodic-node-image-building/CentOS-Stream-GenericCloud-10-20250915.0.x86_64.qcow2 https://cloud.centos.org/centos/10-stream/x86_64/images/CentOS-Stream-GenericCloud-10-20250915.0.x86_64.qcow2

--2025-10-29 05:02:10--  https://cloud.centos.org/centos/10-stream/x86_64/images/CentOS-Stream-GenericCloud-10-20250915.0.x86_64.qcow2

Resolving cloud.centos.org (cloud.centos.org)... 65.9.46.103, 65.9.46.51, 65.9.46.70, ...

Connecting to cloud.centos.org (cloud.centos.org)|65.9.46.103|:443... connected.

HTTP request sent, awaiting response... 502 Bad Gateway

2025-10-29 05:02:11 ERROR 502: Bad Gateway.

```
Changing the image to fix the error. Seems CentOS-Stream-GenericCloud-10-20250915.0.x86_64.qcow2 doesn't exist.