### PR TITLE
Remove config.bootoptions edit

### DIFF
--- a/jenkins/image_building/dib_elements/leap-ci/finalise.d/51-edit-grub-config
+++ b/jenkins/image_building/dib_elements/leap-ci/finalise.d/51-edit-grub-config
@@ -9,4 +9,3 @@
 
 sed -i 's/GRUB_CMDLINE_LINUX.*/GRUB_CMDLINE_LINUX="root=LABEL=cloudimg-rootfs"/' /etc/default/grub
 grub2-mkconfig --output=/boot/grub2/grub.cfg
-sed -i 's/ROOT/cloudimg-rootfs/' /config.bootoptions

--- a/jenkins/image_building/dib_elements/leap-node/finalise.d/51-edit-grub-config
+++ b/jenkins/image_building/dib_elements/leap-node/finalise.d/51-edit-grub-config
@@ -9,4 +9,3 @@
 
 sed -i 's/GRUB_CMDLINE_LINUX.*/GRUB_CMDLINE_LINUX="root=LABEL=cloudimg-rootfs"/' /etc/default/grub
 grub2-mkconfig --output=/boot/grub2/grub.cfg
-sed -i 's/ROOT/cloudimg-rootfs/' /config.bootoptions


### PR DESCRIPTION
Image building has failed with `sed: can't read /config.bootoptions: No such file or directory` so this PR removes the sed to fix the build.

Fixes #1136