### PR TITLE
🌱 Remove 1.9 scalability tests

### DIFF
--- a/prow/config/jobs/metal3-io/cluster-api-provider-metal3-release-1.9.yaml
+++ b/prow/config/jobs/metal3-io/cluster-api-provider-metal3-release-1.9.yaml
@@ -200,9 +200,3 @@ presubmits:
     agent: jenkins
     always_run: false
     optional: true
-  - name: metal3-centos-e2e-feature-test-release-1-9-scalability
-    branches:
-    - release-1.9
-    agent: jenkins
-    always_run: false
-    optional: true


### PR DESCRIPTION
Remove 1.9 scalability test. 
This is failing in CI as 1.9 is not supported we are removing this test early. 