### PR TITLE
add release-1-11 jobs to project infra tests

### DIFF
--- a/prow/config/jobs/metal3-io/project-infra.yaml
+++ b/prow/config/jobs/metal3-io/project-infra.yaml
@@ -66,6 +66,10 @@ presubmits:
     agent: jenkins
     always_run: false
     optional: true
+  - name: metal3-centos-e2e-basic-test-release-1-11
+    agent: jenkins
+    always_run: false
+    optional: true
   - name: metal3-centos-e2e-basic-test-release-1-10
     agent: jenkins
     always_run: false
@@ -79,6 +83,10 @@ presubmits:
     always_run: false
     optional: true
   - name: metal3-ubuntu-e2e-basic-test-main
+    agent: jenkins
+    always_run: false
+    optional: true
+  - name: metal3-ubuntu-e2e-basic-test-release-1-11
     agent: jenkins
     always_run: false
     optional: true
@@ -99,6 +107,10 @@ presubmits:
     agent: jenkins
     always_run: false
     optional: true
+  - name: metal3-centos-e2e-integration-test-release-1-11
+    agent: jenkins
+    always_run: false
+    optional: true
   - name: metal3-centos-e2e-integration-test-release-1-10
     agent: jenkins
     always_run: false
@@ -115,6 +127,10 @@ presubmits:
     agent: jenkins
     always_run: false
     optional: false
+  - name: metal3-ubuntu-e2e-integration-test-release-1-11
+    agent: jenkins
+    always_run: false
+    optional: true
   - name: metal3-ubuntu-e2e-integration-test-release-1-10
     agent: jenkins
     always_run: false
@@ -129,6 +145,10 @@ presubmits:
     optional: true
   # name: {job_prefix}-{image_os}-e2e-feature-test-{capm3_target_job}
   - name: metal3-centos-e2e-feature-test-main-pivoting
+    agent: jenkins
+    always_run: false
+    optional: true
+  - name: metal3-centos-e2e-feature-test-release-1-11-pivoting
     agent: jenkins
     always_run: false
     optional: true
@@ -148,6 +168,10 @@ presubmits:
     agent: jenkins
     always_run: false
     optional: true
+  - name: metal3-centos-e2e-feature-test-release-1-11-remediation
+    agent: jenkins
+    always_run: false
+    optional: true
   - name: metal3-centos-e2e-feature-test-release-1-10-remediation
     agent: jenkins
     always_run: false
@@ -161,6 +185,10 @@ presubmits:
     always_run: false
     optional: true
   - name: metal3-centos-e2e-feature-test-main-features
+    agent: jenkins
+    always_run: false
+    optional: true
+  - name: metal3-centos-e2e-feature-test-release-1-11-features
     agent: jenkins
     always_run: false
     optional: true
@@ -180,6 +208,10 @@ presubmits:
     agent: jenkins
     always_run: false
     optional: true
+  - name: metal3-ubuntu-e2e-feature-test-release-1-11-pivoting
+    agent: jenkins
+    always_run: false
+    optional: true
   - name: metal3-ubuntu-e2e-feature-test-release-1-10-pivoting
     agent: jenkins
     always_run: false
@@ -196,6 +228,10 @@ presubmits:
     agent: jenkins
     always_run: false
     optional: true
+  - name: metal3-ubuntu-e2e-feature-test-release-1-11-remediation
+    agent: jenkins
+    always_run: false
+    optional: true
   - name: metal3-ubuntu-e2e-feature-test-release-1-10-remediation
     agent: jenkins
     always_run: false
@@ -209,6 +245,10 @@ presubmits:
     always_run: false
     optional: true
   - name: metal3-ubuntu-e2e-feature-test-main-features
+    agent: jenkins
+    always_run: false
+    optional: true
+  - name: metal3-ubuntu-e2e-feature-test-release-1-11-features
     agent: jenkins
     always_run: false
     optional: true
@@ -229,6 +269,10 @@ presubmits:
     agent: jenkins
     always_run: false
     optional: true
+  - name: metal3-e2e-clusterctl-upgrade-test-release-1-11
+    agent: jenkins
+    always_run: false
+    optional: true
   - name: metal3-e2e-clusterctl-upgrade-test-release-1-10
     agent: jenkins
     always_run: false
@@ -243,6 +287,10 @@ presubmits:
     optional: true
   # name: {job_prefix}-e2e-{k8s_versions}-upgrade-test-{capm3_target_branch}
   - name: metal3-e2e-1-29-1-30-upgrade-test-main
+    agent: jenkins
+    always_run: false
+    optional: true
+  - name: metal3-e2e-1-29-1-30-upgrade-test-release-1-11
     agent: jenkins
     always_run: false
     optional: true
@@ -262,6 +310,10 @@ presubmits:
     agent: jenkins
     always_run: false
     optional: true
+  - name: metal3-dev-env-integration-test-centos-release-1-11
+    agent: jenkins
+    always_run: false
+    optional: true
   - name: metal3-dev-env-integration-test-centos-release-1-10
     agent: jenkins
     always_run: false
@@ -275,6 +327,10 @@ presubmits:
     always_run: false
     optional: true
   - name: metal3-dev-env-integration-test-ubuntu-main
+    agent: jenkins
+    always_run: false
+    optional: true
+  - name: metal3-dev-env-integration-test-ubuntu-release-1-11
     agent: jenkins
     always_run: false
     optional: true


### PR DESCRIPTION
We have forgotten to also add release-1-11 tests into project-infra's own test set.