### PR TITLE
Download ubuntu base from longterm archive

### DIFF
--- a/jenkins/image_building/build-image.sh
+++ b/jenkins/image_building/build-image.sh
@@ -64,9 +64,11 @@ export DIB_DEV_USER_AUTHORIZED_KEYS="${current_dir}/authorized_keys"
 
 if [[ "${IMAGE_OS}" == "ubuntu" ]]; then
   export DIB_RELEASE=noble
-  # Setting upstrem Ubuntu 24.04 image
-  export DIB_CLOUD_IMAGES="https://cloud-images.ubuntu.com/${DIB_RELEASE}/20250725"
   numeric_release=24.04
+  build_number=20251031
+  # Setting upstrem Ubuntu 24.04 image
+  export DIB_CLOUD_IMAGES="https://cloud-images.ubuntu.com/releases/${DIB_RELEASE}/release-${build_number}/"
+  export BASE_IMAGE_FILE="${IMAGE_OS}-${numeric_release}-server-cloudimg-amd64.squashfs"
 elif [[ "${IMAGE_OS}" == "centos" ]]; then
   numeric_release=10
   # Setting upstrem Centos 10 stream image


### PR DESCRIPTION
This commit:
 - Changes the location where the ubuntu DIB element downloads the base image. The image is downloaded during Metal3 CI and node image building.

This change is needed because previously the image was downloaded from short term storage that induced pipeline breakages after when the retention period ended for the image.