### PR TITLE
Change from ilo4 to ipmi protocol in bml

### DIFF
--- a/jenkins/scripts/bare_metal_lab/templates/bmhosts_crs.yaml.j2
+++ b/jenkins/scripts/bare_metal_lab/templates/bmhosts_crs.yaml.j2
@@ -18,7 +18,7 @@ spec:
   bootMACAddress: {{ bmh.mac }}
   bootMode: legacy
   bmc:
-    address: ilo4://{{ bmh.ip }}
+    address: ipmi://{{ bmh.ip }}:623
     credentialsName: bml-ilo-login-secret-{{ bmh.id }}
     disableCertificateVerification: true
   rootDeviceHints:


### PR DESCRIPTION
Change from ilo4 to ipmi protocol in bml as ilo4 support removed from BMO. 
https://github.com/metal3-io/baremetal-operator/pull/2750

Fixes: #1135