### PR TITLE
🌱 Set default timeout for e2e tests

### DIFF
--- a/jenkins/jobs/capm3-e2e-tests.groovy
+++ b/jenkins/jobs/capm3-e2e-tests.groovy
@@ -1,5 +1,6 @@
 // Global variables
-def TIMEOUT, ci_git_url, ci_git_branch, ci_git_base, refspec, agent_label
+// Set default TIMEOUT to 10800 (3h)
+def TIMEOUT = 10800, ci_git_url, ci_git_branch, ci_git_base, refspec, agent_label
 def UPDATED_REPO, BUILD_TAG, GINKGO_SKIP, CURRENT_START_TIME, CURRENT_END_TIME
 
 script {


### PR DESCRIPTION
Set default timeout for e2e tests to 3h