### PR TITLE
Use External Secrets Operator and 1password SDK for prow secrets

### DIFF
--- a/prow/bootstrap/calico/kustomization.yaml
+++ b/prow/bootstrap/calico/kustomization.yaml
@@ -1,0 +1,8 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+- https://raw.githubusercontent.com/projectcalico/calico/v3.30.1/manifests/calico.yaml
+patches:
+- path: toleration-node-selector-patch.yaml
+  target:
+    kind: Deployment

--- a/prow/bootstrap/calico/toleration-node-selector-patch.yaml
+++ b/prow/bootstrap/calico/toleration-node-selector-patch.yaml
@@ -1,0 +1,13 @@
+- op: add
+  path: /spec/template/spec/tolerations/-
+  value:
+    key: node-role.kubernetes.io/infra
+    operator: Exists
+    effect: NoSchedule
+# We add the node selector for node-role.kubernetes.io/infra=""
+# The key has to be included in the path or it would overwrite any existing nodeSelectors.
+# We have to write the "/" as "~1" since it is the separator in the path field.
+# See https://datatracker.ietf.org/doc/html/rfc6901#section-3
+- op: add
+  path: /spec/template/spec/nodeSelector/node-role.kubernetes.io~1infra
+  value: ""

--- a/prow/bootstrap/clustersecretstore.yaml
+++ b/prow/bootstrap/clustersecretstore.yaml
@@ -1,0 +1,20 @@
+apiVersion: external-secrets.io/v1
+kind: ClusterSecretStore
+metadata:
+  name: onepassword
+spec:
+  provider:
+    onepasswordSDK:
+      vault: Prow_GitOps
+      auth:
+        serviceAccountSecretRef:
+          namespace: external-secrets
+          name: onepassword-prow-service-account
+          key: token
+  # Only allow this to be used from specific namespaces
+  conditions:
+  - namespaces:
+    - default # CAPO cluster resources
+    - kube-system # CPO runs here
+    - prow # Prow components run here
+    - test-pods # Pods for ProwJobs run here

--- a/prow/bootstrap/external-secrets-operator/.gitignore
+++ b/prow/bootstrap/external-secrets-operator/.gitignore
@@ -1,0 +1,2 @@
+# Ignore helm charts folder created by kustomize
+charts

--- a/prow/bootstrap/external-secrets-operator/kustomization.yaml
+++ b/prow/bootstrap/external-secrets-operator/kustomization.yaml
@@ -1,0 +1,20 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+namespace: external-secrets
+resources:
+- namespace.yaml
+helmCharts:
+- name: external-secrets
+  includeCRDs: true
+  repo: https://charts.external-secrets.io
+  releaseName: external-secrets
+  namespace: external-secrets
+  version: 1.1.0
+  valuesInline:
+    global:
+      nodeSelector:
+        node-role.kubernetes.io/infra: ""
+      tolerations:
+      - key: "node-role.kubernetes.io/infra"
+        operator: "Exists"
+        effect: "NoSchedule"

--- a/prow/bootstrap/external-secrets-operator/namespace.yaml
+++ b/prow/bootstrap/external-secrets-operator/namespace.yaml
@@ -1,0 +1,4 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: external-secrets

--- a/prow/bootstrap/kustomization.yaml
+++ b/prow/bootstrap/kustomization.yaml
@@ -1,0 +1,6 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+- calico
+- external-secrets-operator
+- clustersecretstore.yaml

--- a/prow/capo-cluster/externalsecret.yaml
+++ b/prow/capo-cluster/externalsecret.yaml
@@ -1,0 +1,20 @@
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: prow-cloud-config
+spec:
+  secretStoreRef:
+    kind: ClusterSecretStore
+    name: onepassword
+  target:
+    creationPolicy: Owner
+    template:
+      metadata:
+        labels:
+          # Make the secret move with clusterctl move.
+          clusterctl.cluster.x-k8s.io/move: "true"
+  data:
+  - secretKey: clouds.yaml
+    remoteRef:
+      # <item-name>/[section-name/]<file-name>
+      key: "xerces-credentials/clouds.yaml"

--- a/prow/capo-cluster/kustomization.yaml
+++ b/prow/capo-cluster/kustomization.yaml
@@ -9,22 +9,22 @@ resources:
 - openstackmachinetemplates.yaml
 - infra-kct.yaml
 - infra-md.yaml
+- externalsecret.yaml
 
-generatorOptions:
-  disableNameSuffixHash: true
-
-secretGenerator:
-- files:
-  - clouds.yaml
-  name: prow-cloud-config
-  type: Opaque
-
-# Add label for moving the prow-cloud-config secret with clusterctl move.
-patches:
-- patch: |-
-    apiVersion: v1
-    kind: Secret
-    metadata:
-      name: prow-cloud-config
-      labels:
-        clusterctl.cluster.x-k8s.io/move: "true"
+## If there is ever a need to deploy without ESO, the following can be used to create the secret directly.
+# generatorOptions:
+#   disableNameSuffixHash: true
+# secretGenerator:
+# - files:
+#   - clouds.yaml
+#   name: prow-cloud-config
+#   type: Opaque
+# # Add label for moving the prow-cloud-config secret with clusterctl move.
+# patches:
+# - patch: |-
+#     apiVersion: v1
+#     kind: Secret
+#     metadata:
+#       name: prow-cloud-config
+#       labels:
+#         clusterctl.cluster.x-k8s.io/move: "true"

--- a/prow/cluster-resources/externalsecret.yaml
+++ b/prow/cluster-resources/externalsecret.yaml
@@ -1,0 +1,16 @@
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: cloud-config
+  namespace: kube-system
+spec:
+  secretStoreRef:
+    kind: ClusterSecretStore
+    name: onepassword
+  target:
+    creationPolicy: Owner
+  data:
+  - secretKey: cloud.conf
+    remoteRef:
+      # <item-name>/[section-name/]<file-name>
+      key: "xerces-credentials/cloud.conf"

--- a/prow/cluster-resources/kustomization.yaml
+++ b/prow/cluster-resources/kustomization.yaml
@@ -1,7 +1,6 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
-- https://raw.githubusercontent.com/projectcalico/calico/v3.30.1/manifests/calico.yaml
 # Check available versions at https://github.com/kubernetes/cloud-provider-openstack/releases
 - https://raw.githubusercontent.com/kubernetes/cloud-provider-openstack/v1.33.1/manifests/controller-manager/cloud-controller-manager-roles.yaml
 - https://raw.githubusercontent.com/kubernetes/cloud-provider-openstack/v1.33.1/manifests/controller-manager/cloud-controller-manager-role-bindings.yaml
@@ -13,21 +12,12 @@ resources:
 - https://raw.githubusercontent.com/kubernetes/cloud-provider-openstack/v1.33.1/manifests/cinder-csi-plugin/csi-cinder-driver.yaml
 - autoscaler.yaml
 - coredns-pdb.yaml
+- externalsecret.yaml
 
 images:
 # Check available tags at https://github.com/kubernetes/autoscaler/tags
 - name: registry.k8s.io/autoscaling/cluster-autoscaler
   newTag: v1.33.1
-
-generatorOptions:
-  disableNameSuffixHash: true
-
-secretGenerator:
-- files:
-  - cloud.conf
-  name: cloud-config
-  namespace: kube-system
-  type: Opaque
 
 patches:
 # CSI Cinder does not set any toleration or nodeSelector so we have to first create
@@ -47,3 +37,13 @@ patches:
   target:
     kind: Deployment
     name: csi-cinder-controllerplugin|calico-kube-controllers
+
+## If there is ever a need to deploy without ESO, the following can be used to create the secret directly.
+# generatorOptions:
+#   disableNameSuffixHash: true
+# secretGenerator:
+# - files:
+#   - cloud.conf
+#   name: cloud-config
+#   namespace: kube-system
+#   type: Opaque

--- a/prow/manifests/overlays/metal3/kustomization.yaml
+++ b/prow/manifests/overlays/metal3/kustomization.yaml
@@ -13,50 +13,8 @@ resources:
 - external-plugins/jenkins-operator.yaml
 - pdb.yaml
 - limitrange.yaml
-
-
-# For some of the secrets we could use suffix hash,
-# but some will be used directly by prow, which cannot know about
-# the suffix. So we disable it.
-generatorOptions:
-  disableNameSuffixHash: true
-
-secretGenerator:
-- files:
-  - token=github-token
-  name: github-token
-  namespace: prow
-  type: Opaque
-- files:
-  - token=github-token
-  name: github-token
-  namespace: test-pods
-  type: Opaque
-- files:
-  - hmac=hmac-token
-  name: hmac-token
-  namespace: prow
-  type: Opaque
-- files:
-  - service-account.json
-  name: s3-credentials
-  namespace: prow
-  type: Opaque
-- files:
-  - service-account.json
-  name: s3-credentials
-  namespace: test-pods
-  type: Opaque
-- files:
-  - token=cherrypick-bot-github-token
-  name: cherrypick-bot-github-token
-  namespace: prow
-  type: Opaque
-- files:
-  - token=jenkins-token
-  name: jenkins-token
-  namespace: prow
-  type: Opaque
+- prow-externalsecrets.yaml
+- test-pods-externalsecrets.yaml
 
 patches:
 - path: patches/crier.yaml
@@ -81,3 +39,43 @@ labels:
   pairs:
     app.kubernetes.io/instance: metal3
     app.kubernetes.io/part-of: prow
+
+## If there is ever a need to deploy without ESO, the following can be used to create the secrets directly.
+# generatorOptions:
+#   disableNameSuffixHash: true
+# secretGenerator:
+# - files:
+#   - token=github-token
+#   name: github-token
+#   namespace: prow
+#   type: Opaque
+# - files:
+#   - token=github-token
+#   name: github-token
+#   namespace: test-pods
+#   type: Opaque
+# - files:
+#   - hmac=hmac-token
+#   name: hmac-token
+#   namespace: prow
+#   type: Opaque
+# - files:
+#   - service-account.json
+#   name: s3-credentials
+#   namespace: prow
+#   type: Opaque
+# - files:
+#   - service-account.json
+#   name: s3-credentials
+#   namespace: test-pods
+#   type: Opaque
+# - files:
+#   - token=cherrypick-bot-github-token
+#   name: cherrypick-bot-github-token
+#   namespace: prow
+#   type: Opaque
+# - files:
+#   - token=jenkins-token
+#   name: jenkins-token
+#   namespace: prow
+#   type: Opaque

--- a/prow/manifests/overlays/metal3/prow-externalsecrets.yaml
+++ b/prow/manifests/overlays/metal3/prow-externalsecrets.yaml
@@ -1,0 +1,84 @@
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: github-token
+  namespace: prow
+spec:
+  secretStoreRef:
+    kind: ClusterSecretStore
+    name: onepassword
+  target:
+    creationPolicy: Owner
+  data:
+  - secretKey: token
+    remoteRef:
+      # <item-name>/[section-name/]<field-name>
+      key: "prow-github-token/password"
+---
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: hmac-token
+  namespace: prow
+spec:
+  secretStoreRef:
+    kind: ClusterSecretStore
+    name: onepassword
+  target:
+    creationPolicy: Owner
+  data:
+  - secretKey: hmac
+    remoteRef:
+      # <item-name>/[section-name/]<field-name>
+      key: "hmac-token/password"
+---
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: s3-credentials
+  namespace: prow
+spec:
+  secretStoreRef:
+    kind: ClusterSecretStore
+    name: onepassword
+  target:
+    creationPolicy: Owner
+  data:
+  - secretKey: service-account.json
+    remoteRef:
+      # <item-name>/[section-name/]<file-name>
+      key: "s3-credentials/service-account.json"
+---
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: cherrypick-bot-github-token
+  namespace: prow
+spec:
+  secretStoreRef:
+    kind: ClusterSecretStore
+    name: onepassword
+  target:
+    creationPolicy: Owner
+  data:
+  - secretKey: token
+    remoteRef:
+      # <item-name>/[section-name/]<field-name>
+      key: "prow-cherrypick-github-token/password"
+---
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: jenkins-token
+  namespace: prow
+spec:
+  secretStoreRef:
+    kind: ClusterSecretStore
+    name: onepassword
+  target:
+    creationPolicy: Owner
+  data:
+  - secretKey: token
+    remoteRef:
+      # <item-name>/[section-name/]<field-name>
+      key: "prow-jenkins-token/password"

--- a/prow/manifests/overlays/metal3/test-pods-externalsecrets.yaml
+++ b/prow/manifests/overlays/metal3/test-pods-externalsecrets.yaml
@@ -1,0 +1,33 @@
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: github-token
+  namespace: test-pods
+spec:
+  secretStoreRef:
+    kind: ClusterSecretStore
+    name: onepassword
+  target:
+    creationPolicy: Owner
+  data:
+  - secretKey: token
+    remoteRef:
+      # <item-name>/[section-name/]<field-name>
+      key: "prow-github-token/password"
+---
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: s3-credentials
+  namespace: test-pods
+spec:
+  secretStoreRef:
+    kind: ClusterSecretStore
+    name: onepassword
+  target:
+    creationPolicy: Owner
+  data:
+  - secretKey: service-account.json
+    remoteRef:
+      # <item-name>/[section-name/]<file-name>
+      key: "s3-credentials/service-account.json"


### PR DESCRIPTION
Add External Secrets Operator, ExternalSecrets and ClusterSecretStore.
Remove kustomize secret generators that used to create the secrets from
local files outside of version control.

Calico was also moved to a new folder "bootstrap". This contains the
things needed to bootstrap a new cluster before anything else can be
applied, i.e. ESO and Calico.