### PR TITLE
fix build image permissions for signing

### DIFF
--- a/.github/workflows/build-images-action.yml
+++ b/.github/workflows/build-images-action.yml
@@ -10,13 +10,13 @@ on:
     - '.github/workflows/build-images-action.yml'
     - '.github/workflows/container-image-build.yml'
 
-permissions:
-  contents: read
-
 jobs:
   build_basic_checks:
     name: Build basic-checks image
     if: github.repository == 'metal3-io/project-infra'
+    permissions:
+      contents: read
+      id-token: write
     uses: ./.github/workflows/container-image-build.yml
     with:
       image-name: 'basic-checks'


### PR DESCRIPTION
We need id-token in the container-image-build workflow, but it must inherit it from the calling workflow.