### PR TITLE
temporarily comment out id-token: write permission

### DIFF
--- a/.github/workflows/container-image-build.yml
+++ b/.github/workflows/container-image-build.yml
@@ -73,7 +73,8 @@ jobs:
 
     permissions:
       contents: read
-      id-token: write  # Required for Sigstore keyless attestation
+      # temporarily disabled to fix the builds
+      # id-token: write
 
     outputs:
       digest: ${{ steps.get-digest.outputs.digest }}


### PR DESCRIPTION
Callers who are missing id-token: write will have invalid workflow, and the workflows do not run AT ALL right now. Unblock them.

Currently build-images-action without id-token will get:
```
[Invalid workflow file: .github/workflows/build-images-action.yml#L15](https://github.com/metal3-io/baremetal-operator/actions/runs/19757425700/workflow)
The workflow is not valid. .github/workflows/build-images-action.yml (Line: 15, Col: 3): Error calling workflow 'metal3-io/project-infra/.github/workflows/container-image-build.yml@main'. The nested job 'job' is requesting 'id-token: write', but is only allowed 'id-token: none'.
```