### PR TITLE
Revert "temporarily comment out id-token: write permission"

### DIFF
--- a/.github/workflows/container-image-build.yml
+++ b/.github/workflows/container-image-build.yml
@@ -73,8 +73,7 @@ jobs:
 
     permissions:
       contents: read
-      # temporarily disabled to fix the builds
-      # id-token: write
+      id-token: write  # Required for Sigstore keyless attestation
 
     outputs:
       digest: ${{ steps.get-digest.outputs.digest }}


### PR DESCRIPTION
This reverts commit d21ca25379ed7fb9911d7ce550974ddd2a5e4ad0.

This enables SBOM attestations again, but requires anyone calling the container-image-build.yml to pass it.  If caller doesn't have it, the workflow is considered invalid and won't run at all.

This will be 
/hold
until all of the following are merged:

- https://github.com/metal3-io/utility-images/pull/47
- https://github.com/metal3-io/ironic-image/pull/813
- https://github.com/metal3-io/mariadb-image/pull/40
- https://github.com/metal3-io/ironic-ipa-downloader/pull/72
- https://github.com/metal3-io/baremetal-operator/pull/2813
- https://github.com/metal3-io/ironic-standalone-operator/pull/445
- https://github.com/metal3-io/cluster-api-provider-metal3/pull/2979

IPAM and project-infra itself have it already.