### PR TITLE
increase fullstack timeout to 90 min

### DIFF
--- a/jenkins/jobs/dynamic_fullstack_building.groovy
+++ b/jenkins/jobs/dynamic_fullstack_building.groovy
@@ -1,5 +1,5 @@
 // Global variables
-def TIMEOUT = 1800, ci_git_url, ci_git_branch, ci_git_base, refspec, agent_label
+def TIMEOUT = 5400, ci_git_url, ci_git_branch, ci_git_base, refspec, agent_label
 def UPDATED_REPO, BUILD_TAG, GINKGO_SKIP, CURRENT_START_TIME, CURRENT_END_TIME
 
 script {


### PR DESCRIPTION
This PR:
 - Increases the timeout of the periodic and the manual fullstack test from 30 to 90 minutes.

The change is needed because current 30 min timeout is a bit too optimistic and I am also working on extending the fullstack test process so it will take more time to run the build anyways.