### PR TITLE
enable keyless container signing

### DIFF
--- a/.github/workflows/build-images-action.yml
+++ b/.github/workflows/build-images-action.yml
@@ -24,6 +24,7 @@ jobs:
       dockerfile-directory: 'prow/container-images/basic-checks'
       pushImage: true
       generate-sbom: true
+      sign-image: true
     secrets:
       QUAY_USERNAME: ${{ secrets.QUAY_USERNAME }}
       QUAY_PASSWORD: ${{ secrets.QUAY_PASSWORD }}

--- a/.github/workflows/container-image-build.yml
+++ b/.github/workflows/container-image-build.yml
@@ -51,6 +51,11 @@ on:
         description: "Generate SBOM for the container image"
         type: boolean
         default: false
+      sign-image:
+        required: false
+        description: "Sign the container image with Cosign (keyless)"
+        type: boolean
+        default: false
     secrets:
       QUAY_USERNAME:
         required: true
@@ -182,8 +187,14 @@ jobs:
         echo "Package count: $(jq '.packages | length' ${{ inputs.image-name }}-sbom.spdx.json)"
 
     - name: Install Cosign
-      if: ${{ inputs.generate-sbom && inputs.pushImage }}
+      if: ${{ (inputs.generate-sbom || inputs.sign-image) && inputs.pushImage }}
       uses: sigstore/cosign-installer@faadad0cce49287aee09b3a48701e75088a2c6ad # v4.0.0
+
+    - name: Sign container image
+      if: ${{ inputs.sign-image && inputs.pushImage }}
+      run: |
+        cosign sign --yes "${IMAGE_REF}"
+        echo "Container image signed: ${IMAGE_REF}"
 
     - name: Attest SBOM to image
       if: ${{ inputs.generate-sbom && inputs.pushImage }}


### PR DESCRIPTION
Enable keyless container signing with Cosign. This requires calling build-images-action.yml to add "sign-image: true" to enable it for them to allow gradually phasing this in.

This PR enables signing for basic-checks image.