### PR TITLE
Prow: Document status-reconciler bucket

### DIFF
--- a/prow/README.md
+++ b/prow/README.md
@@ -451,6 +451,7 @@ Metal3 CI ssh key.
    ```bash
    s3cmd --config .s3cfg mb s3://prow-logs
    s3cmd --config .s3cfg mb s3://tide
+   s3cmd --config .s3cfg mb s3://status-reconciler
    ```
 
 1. Deploy Prow


### PR DESCRIPTION
The status-reconciler is also supposed to have a bucket. It is already configured in the manifests, but somehow we missed to create this bucket. This commit adds it to the documentation.