### PR TITLE
amend Lychee config for PR checks as well

### DIFF
--- a/.github/workflows/pr-link-check.yml
+++ b/.github/workflows/pr-link-check.yml
@@ -64,6 +64,9 @@ jobs:
           --root-dir "$(pwd)/"
           --fallback-extensions "md"
           --github-token "${GITHUB_TOKEN}"
+          --insecure
+          --exclude-all-private
+          --no-progress
           $(cat changed-files.txt | tr '\n' ' ')
 
     - name: Provide helpful failure message


### PR DESCRIPTION
I forgot Lychee has two reusable jobs, one for schedued runs (fixed in #1178) and one for PR runs (this fix).