### PR TITLE
reduce Lychee concurrency to avoid rate limiting

### DIFF
--- a/.github/workflows/pr-link-check.yml
+++ b/.github/workflows/pr-link-check.yml
@@ -57,13 +57,18 @@ jobs:
     - name: Check links in changed files
       if: env.foundFiles == 'true'
       uses: lycheeverse/lychee-action@a8c4c7cb88f0c7386610c35eb25108e448569cb0 # v2.7.0
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       with:
         failIfEmpty: false
         args: |
-          --user-agent "Mozilla/5.0 (Windows NT 6.1; Win64; x64; rv:135.0) Gecko/20100101 Firefox/135.0"
+          --user-agent "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/131.0.0.0 Safari/537.36 Brave/131"
           --root-dir "$(pwd)/"
           --fallback-extensions "md"
-          --github-token "${GITHUB_TOKEN}"
+          --github-token "${{ secrets.GITHUB_TOKEN }}"
+          --max-concurrency 8
+          --max-retries 5
+          --retry-wait-time 10
           --insecure
           --exclude-all-private
           --no-progress

--- a/.github/workflows/scheduled-link-check.yml
+++ b/.github/workflows/scheduled-link-check.yml
@@ -25,12 +25,17 @@ jobs:
     - name: Link Checker
       id: linkcheck
       uses: lycheeverse/lychee-action@a8c4c7cb88f0c7386610c35eb25108e448569cb0 # v2.7.0
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       with:
         args: |
-          --user-agent "Mozilla/5.0 (Windows NT 6.1; Win64; x64; rv:135.0) Gecko/20100101 Firefox/135.0"
+          --user-agent "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/131.0.0.0 Safari/537.36 Brave/131"
           --root-dir "$(pwd)/"
           --fallback-extensions "md"
-          --github-token "${GITHUB_TOKEN}"
+          --github-token "${{ secrets.GITHUB_TOKEN }}"
+          --max-concurrency 8
+          --max-retries 5
+          --retry-wait-time 10
           --insecure
           --exclude-all-private
           --no-progress


### PR DESCRIPTION
Fix Lychee config in multiple ways to improve its reliability:
- make user-agent a Brave clone (privacy protecting browser gets us maybe some slack)
- properly export GITHUB_TOKEN (I was wondering why we get rate limited on Github pages too, with token it should be "unlimited")
- reduce max concurrency to 8 (from 128, another source of surely getting rate limited)
- allow Lychee to retry after timeout, if something wonky happens

Ref: https://github.com/lycheeverse/lychee#commandline-usage

This makes it possible for large PRs with many URLs to be checked like https://github.com/metal3-io/metal3-docs/pull/636 to pass.