### PR TITLE
make metal3-dev-env not require release-1-11 test

### DIFF
--- a/prow/config/jobs/metal3-io/metal3-dev-env.yaml
+++ b/prow/config/jobs/metal3-io/metal3-dev-env.yaml
@@ -45,10 +45,6 @@ presubmits:
     agent: jenkins
     always_run: false
     optional: true
-  - name: metal3-centos-e2e-basic-test-release-1-9
-    agent: jenkins
-    always_run: false
-    optional: true
   - name: metal3-ubuntu-e2e-basic-test-main
     agent: jenkins
     always_run: false
@@ -65,10 +61,6 @@ presubmits:
     agent: jenkins
     always_run: false
     optional: true
-  - name: metal3-ubuntu-e2e-basic-test-release-1-9
-    agent: jenkins
-    always_run: false
-    optional: true
   # name: {job_prefix}-{image_os}-e2e-integration-test-{capm3_target_branch}
   - name: metal3-centos-e2e-integration-test-main
     agent: jenkins
@@ -81,12 +73,8 @@ presubmits:
   - name: metal3-centos-e2e-integration-test-release-1-11
     agent: jenkins
     always_run: false
-    optional: false
-  - name: metal3-centos-e2e-integration-test-release-1-10
-    agent: jenkins
-    always_run: false
     optional: true
-  - name: metal3-centos-e2e-integration-test-release-1-9
+  - name: metal3-centos-e2e-integration-test-release-1-10
     agent: jenkins
     always_run: false
     optional: true
@@ -103,10 +91,6 @@ presubmits:
     always_run: false
     optional: true
   - name: metal3-ubuntu-e2e-integration-test-release-1-10
-    agent: jenkins
-    always_run: false
-    optional: true
-  - name: metal3-ubuntu-e2e-integration-test-release-1-9
     agent: jenkins
     always_run: false
     optional: true
@@ -127,10 +111,6 @@ presubmits:
     agent: jenkins
     always_run: false
     optional: true
-  - name: metal3-centos-e2e-feature-test-release-1-9-pivoting
-    agent: jenkins
-    always_run: false
-    optional: true
   - name: metal3-centos-e2e-feature-test-main-remediation
     agent: jenkins
     always_run: false
@@ -144,10 +124,6 @@ presubmits:
     always_run: false
     optional: true
   - name: metal3-centos-e2e-feature-test-release-1-10-remediation
-    agent: jenkins
-    always_run: false
-    optional: true
-  - name: metal3-centos-e2e-feature-test-release-1-9-remediation
     agent: jenkins
     always_run: false
     optional: true
@@ -167,10 +143,6 @@ presubmits:
     agent: jenkins
     always_run: false
     optional: true
-  - name: metal3-centos-e2e-feature-test-release-1-9-features
-    agent: jenkins
-    always_run: false
-    optional: true
   - name: metal3-ubuntu-e2e-feature-test-main-pivoting
     agent: jenkins
     always_run: false
@@ -184,10 +156,6 @@ presubmits:
     always_run: false
     optional: true
   - name: metal3-ubuntu-e2e-feature-test-release-1-10-pivoting
-    agent: jenkins
-    always_run: false
-    optional: true
-  - name: metal3-ubuntu-e2e-feature-test-release-1-9-pivoting
     agent: jenkins
     always_run: false
     optional: true
@@ -207,10 +175,6 @@ presubmits:
     agent: jenkins
     always_run: false
     optional: true
-  - name: metal3-ubuntu-e2e-feature-test-release-1-9-remediation
-    agent: jenkins
-    always_run: false
-    optional: true
   - name: metal3-ubuntu-e2e-feature-test-main-features
     agent: jenkins
     always_run: false
@@ -224,10 +188,6 @@ presubmits:
     always_run: false
     optional: true
   - name: metal3-ubuntu-e2e-feature-test-release-1-10-features
-    agent: jenkins
-    always_run: false
-    optional: true
-  - name: metal3-ubuntu-e2e-feature-test-release-1-9-features
     agent: jenkins
     always_run: false
     optional: true
@@ -248,10 +208,6 @@ presubmits:
     agent: jenkins
     always_run: false
     optional: true
-  - name: metal3-e2e-clusterctl-upgrade-test-release-1-9
-    agent: jenkins
-    always_run: false
-    optional: true
   # name: {job_prefix}-e2e-{k8s_versions}-upgrade-test-{capm3_target_branch}
   - name: metal3-e2e-1-29-1-30-upgrade-test-main
     agent: jenkins
@@ -266,10 +222,6 @@ presubmits:
     always_run: false
     optional: true
   - name: metal3-e2e-1-29-1-30-upgrade-test-release-1-10
-    agent: jenkins
-    always_run: false
-    optional: true
-  - name: metal3-e2e-1-29-1-30-upgrade-test-release-1-9
     agent: jenkins
     always_run: false
     optional: true
@@ -289,10 +241,6 @@ presubmits:
     agent: jenkins
     always_run: false
     optional: true
-  - name: metal3-dev-env-integration-test-centos-release-1-9
-    agent: jenkins
-    always_run: false
-    optional: true
   - name: metal3-dev-env-integration-test-ubuntu-main
     agent: jenkins
     always_run: false
@@ -306,10 +254,6 @@ presubmits:
     always_run: false
     optional: true
   - name: metal3-dev-env-integration-test-ubuntu-release-1-10
-    agent: jenkins
-    always_run: false
-    optional: true
-  - name: metal3-dev-env-integration-test-ubuntu-release-1-9
     agent: jenkins
     always_run: false
     optional: true


### PR DESCRIPTION
It is replaced with 1.12 test. Cleanup 1.9 series triggers too.

This resolves last incorrect branch protection complaint.