### PR TITLE
Simplify BMO e2e optional pipeline

### DIFF
--- a/jenkins/jobs/bmo_e2e_optional_tests.groovy
+++ b/jenkins/jobs/bmo_e2e_optional_tests.groovy
@@ -15,17 +15,10 @@ pipeline {
         stage('Run Baremetal Operator optional e2e tests') {
             matrix {
                 agent { label 'metal3ci-8c16gb-ubuntu' }
-                // Skip redfish on PRs, test all for periodic jobs
-                when {
-                    anyOf {
-                        expression { env.BMC_PROTOCOL != 'redfish' }
-                        triggeredBy 'TimerTrigger'
-                    }
-                }
                 axes {
                     axis {
                         name 'BMC_PROTOCOL'
-                        values 'ipmi', 'redfish', 'redfish-virtualmedia'
+                        values 'ipmi', 'redfish-virtualmedia'
                     }
                 }
                 environment {


### PR DESCRIPTION
We do not run these periodically through jenkins so there is no point complicating the pipeline with this logic. We can simply set only the protocols we want to test on PRs. The periodic jobs are run as github workflows.