### PR TITLE
image building: Set cloud init data source

### DIFF
--- a/jenkins/image_building/build-image.sh
+++ b/jenkins/image_building/build-image.sh
@@ -88,8 +88,8 @@ elif [[ "${IMAGE_OS}" == "leap" ]]; then
 fi
 
 if [[ "${IMAGE_TYPE}" == "node" ]]; then
-  # The default data source for cloud-init element is exclusively Amazon EC2
-  export DIB_CLOUD_INIT_DATASOURCES="ConfigDrive"
+  # Set the default data source for cloud-init
+  export DIB_CLOUD_INIT_DATASOURCES="ConfigDrive,OpenStack,Oracle"
   export KUBERNETES_VERSION="${KUBERNETES_VERSION:-"v1.35.0"}"
 
   if [[ "${PRE_RELEASE:-}" == "true" ]]; then
@@ -108,6 +108,7 @@ if [[ "${IMAGE_TYPE}" == "node" ]]; then
   # enable predictable interface names
   export DIB_BOOTLOADER_DEFAULT_CMDLINE="net.ifnames=1"
 else
+  export DIB_CLOUD_INIT_DATASOURCES="Oracle,OpenStack,ConfigDrive"
   commit_short="$(git rev-parse --short HEAD)"
   img_date="$(date --utc +"%Y%m%dT%H%MZ")"
   img_name="metal3${IMAGE_TYPE}-${IMAGE_OS}-${img_date}-${commit_short}"


### PR DESCRIPTION
This PR sets cloud init data source fir our ci and node images:
- node images can be used in prow cluster
- ci images can be used in oracle cloud