### PR TITLE
Prow: Upgrade Kubernetes to v1.34.3

### DIFF
--- a/prow/capo-cluster/infra-md.yaml
+++ b/prow/capo-cluster/infra-md.yaml
@@ -27,5 +27,5 @@ spec:
       infrastructureRef:
         apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
         kind: OpenStackMachineTemplate
-        name: prow-worker-v1-33-5
-      version: v1.33.5
+        name: prow-worker-v1-34-3
+      version: v1.34.3

--- a/prow/capo-cluster/kubeadmcontrolplane.yaml
+++ b/prow/capo-cluster/kubeadmcontrolplane.yaml
@@ -28,6 +28,6 @@ spec:
     infrastructureRef:
       apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
       kind: OpenStackMachineTemplate
-      name: prow-control-plane-v1-33-5
+      name: prow-control-plane-v1-34-3
   replicas: 1
-  version: v1.33.5
+  version: v1.34.3

--- a/prow/capo-cluster/machinedeployment.yaml
+++ b/prow/capo-cluster/machinedeployment.yaml
@@ -23,5 +23,5 @@ spec:
       infrastructureRef:
         apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
         kind: OpenStackMachineTemplate
-        name: prow-worker-v1-33-5
-      version: v1.33.5
+        name: prow-worker-v1-34-3
+      version: v1.34.3

--- a/prow/capo-cluster/openstackmachinetemplates.yaml
+++ b/prow/capo-cluster/openstackmachinetemplates.yaml
@@ -1,38 +1,6 @@
 apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
 kind: OpenStackMachineTemplate
 metadata:
-  name: prow-control-plane-v1-32-5
-spec:
-  template:
-    spec:
-      flavor: c4m12-est
-      identityRef:
-        cloudName: prow
-        name: prow-cloud-config
-      image:
-        filter:
-          name: ubuntu-2404-kube-v1.32.5
-      sshKeyName: prow
----
-apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
-kind: OpenStackMachineTemplate
-metadata:
-  name: prow-worker-v1-32-5
-spec:
-  template:
-    spec:
-      flavor: c8m24-est
-      identityRef:
-        cloudName: prow
-        name: prow-cloud-config
-      image:
-        filter:
-          name: ubuntu-2404-kube-v1.32.5
-      sshKeyName: prow
----
-apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
-kind: OpenStackMachineTemplate
-metadata:
   name: prow-control-plane-v1-33-5
 spec:
   template:
@@ -60,4 +28,36 @@ spec:
       image:
         filter:
           name: ubuntu-2404-kube-v1.33.5
+      sshKeyName: prow
+---
+apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+kind: OpenStackMachineTemplate
+metadata:
+  name: prow-control-plane-v1-34-3
+spec:
+  template:
+    spec:
+      flavor: c4m12-est
+      identityRef:
+        cloudName: prow
+        name: prow-cloud-config
+      image:
+        filter:
+          name: ubuntu-2404-kube-v1.34.3
+      sshKeyName: prow
+---
+apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+kind: OpenStackMachineTemplate
+metadata:
+  name: prow-worker-v1-34-3
+spec:
+  template:
+    spec:
+      flavor: c8m24-est
+      identityRef:
+        cloudName: prow
+        name: prow-cloud-config
+      image:
+        filter:
+          name: ubuntu-2404-kube-v1.34.3
       sshKeyName: prow


### PR DESCRIPTION
Changes already applied.
I tried using our own node images with v1.34.1 first but the nodes failed to get metadata then. This is likely fixed in https://github.com/metal3-io/project-infra/pull/1222.
I then reverted to the normal way of building an image using https://image-builder.sigs.k8s.io/.