### PR TITLE
Prow: Add flux for GitOps

### DIFF
--- a/prow/README.md
+++ b/prow/README.md
@@ -480,6 +480,11 @@ Metal3 CI ssh key.
       --from-file=config/jobs
    ```
 
+### Enabling GitOps with Flux
+
+After the initial deployment, it is possible to use Flux to automatically apply
+changes. This is currently work-in-progress. See `flux` for more details.
+
 ## Enabling Metal3 prow for new org/repo
 
 Metal3 prow is currently working with two Github organizations(orgs):

--- a/prow/flux/README.md
+++ b/prow/flux/README.md
@@ -1,0 +1,6 @@
+# Flux for GitOps
+
+This folder contains resources for managing prow through Flux. For now this does
+not include everything. See the `kustomization.yaml` for what exactly it will
+synchronize. The goal is to include more and more of the prow resources here so
+that eventually everything is controlled by Flux.

--- a/prow/flux/flux.yaml
+++ b/prow/flux/flux.yaml
@@ -1,0 +1,40 @@
+apiVersion: fluxcd.controlplane.io/v1
+kind: FluxInstance
+metadata:
+  name: flux
+  namespace: flux-system
+spec:
+  distribution:
+    version: "2.7.5"
+    registry: "ghcr.io/fluxcd"
+    artifact: "oci://ghcr.io/controlplaneio-fluxcd/flux-operator-manifests"
+  cluster:
+    type: kubernetes
+    size: medium
+  kustomize:
+    patches:
+    # Set tolerations and node selector for all controllers
+    - patch: |
+        - op: add
+          path: /spec/template/spec/tolerations
+          value: []
+        - op: add
+          path: /spec/template/spec/tolerations/-
+          value:
+            key: node-role.kubernetes.io/infra
+            operator: Exists
+            effect: NoSchedule
+        # We add the node selector for node-role.kubernetes.io/infra=""
+        # The key has to be included in the path or it would overwrite any existing nodeSelectors.
+        # We have to write the "/" as "~1" since it is the separator in the path field.
+        # See https://datatracker.ietf.org/doc/html/rfc6901#section-3
+        - op: add
+          path: /spec/template/spec/nodeSelector/node-role.kubernetes.io~1infra
+          value: ""
+      target:
+        kind: Deployment
+  sync:
+    kind: GitRepository
+    url: "https://github.com/metal3-io/project-infra.git"
+    ref: "refs/heads/main"
+    path: "prow/flux"

--- a/prow/flux/kustomization.yaml
+++ b/prow/flux/kustomization.yaml
@@ -1,0 +1,14 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+- https://github.com/controlplaneio-fluxcd/flux-operator/releases/download/v0.40.0/install.yaml
+- flux.yaml
+- ../capi
+
+patches:
+# Add toleration and node selector to run on infra nodes
+- path: toleration-node-selector-patch.yaml
+  target:
+    kind: Deployment
+    name: flux-operator
+    namespace: flux-system

--- a/prow/flux/toleration-node-selector-patch.yaml
+++ b/prow/flux/toleration-node-selector-patch.yaml
@@ -1,0 +1,21 @@
+# Flux operator does not set either tolerations or nodeSelector so we have to first create
+# the array/map before we can add values to them...
+- op: add
+  path: /spec/template/spec/nodeSelector
+  value: {}
+- op: add
+  path: /spec/template/spec/tolerations
+  value: []
+- op: add
+  path: /spec/template/spec/tolerations/-
+  value:
+    key: node-role.kubernetes.io/infra
+    operator: Exists
+    effect: NoSchedule
+# We add the node selector for node-role.kubernetes.io/infra=""
+# The key has to be included in the path or it would overwrite any existing nodeSelectors.
+# We have to write the "/" as "~1" since it is the separator in the path field.
+# See https://datatracker.ietf.org/doc/html/rfc6901#section-3
+- op: add
+  path: /spec/template/spec/nodeSelector/node-role.kubernetes.io~1infra
+  value: ""


### PR DESCRIPTION
This adds flux as GitOps controller in the Prow cluster. It is configured to sync anything in the prow/flux kustomization. For now this only means the flux-operator, the flux instance (controllers) and the prow/capi kustomization. The point of this is to test it with a relatively safe scope before including more sensitive components.