### PR TITLE
add renovate-validator prow job for ironic-image main

### DIFF
--- a/prow/config/jobs/metal3-io/ironic-image.yaml
+++ b/prow/config/jobs/metal3-io/ironic-image.yaml
@@ -32,6 +32,22 @@ presubmits:
           value: "TRUE"
         image: docker.io/pipelinecomponents/markdownlint-cli2:0.12.0@sha256:a3977fba9814f10d33a1d69ae607dc808e7a6470b2ba03e84c17193c0791aac0
         imagePullPolicy: Always
+  - name: renovate-config-validator
+    branches:
+    - main
+    run_if_changed: '(renovate\.json|renovate-validator\.sh)$'
+    decorate: true
+    spec:
+      containers:
+      - args:
+        - ./hack/renovate-validator.sh
+        command:
+        - sh
+        env:
+        - name: IS_CONTAINER
+          value: "TRUE"
+        image: docker.io/node:24-alpine
+        imagePullPolicy: Always
   # name: {job_prefix}-{image_os}-e2e-integration-test-{capm3_target_branch}
   - name: metal3-centos-e2e-integration-test-main
     branches:


### PR DESCRIPTION
Add renovate-validator job for ironic-image main. 

Requires https://github.com/metal3-io/ironic-image/pull/883 to be merged first.
/hold