### PR TITLE
add renovate-validator job for metal3-dev-env main

### DIFF
--- a/prow/config/jobs/metal3-io/metal3-dev-env.yaml
+++ b/prow/config/jobs/metal3-io/metal3-dev-env.yaml
@@ -28,6 +28,20 @@ presubmits:
           value: "TRUE"
         image: docker.io/pipelinecomponents/markdownlint-cli2:0.12.0@sha256:a3977fba9814f10d33a1d69ae607dc808e7a6470b2ba03e84c17193c0791aac0
         imagePullPolicy: Always
+  - name: renovate-config-validator
+    run_if_changed: '(renovate\.json|renovate-validator\.sh)$'
+    decorate: true
+    spec:
+      containers:
+      - args:
+        - ./hack/renovate-validator.sh
+        command:
+        - sh
+        env:
+        - name: IS_CONTAINER
+          value: "TRUE"
+        image: docker.io/node:24-alpine
+        imagePullPolicy: Always
   # name: {job_prefix}-{image_os}-e2e-basic-test-{capm3_target_branch}
   - name: metal3-centos-e2e-basic-test-main
     agent: jenkins


### PR DESCRIPTION
Add renovate-validator job for ironic-image main.

Requires https://github.com/metal3-io/metal3-dev-env/pull/1631 to be merged first.
/hold