### PR TITLE
Add Traefik configuration and HTTPRoute for Prow services

### DIFF
--- a/prow/README.md
+++ b/prow/README.md
@@ -448,6 +448,20 @@ Metal3 CI ssh key.
    kubectl apply -k infra
    ```
 
+1. Add Gateway Api controller, ClusterIssuer and StorageClass
+
+   ```bash
+   helm repo add traefik https://traefik.github.io/charts
+   helm repo update
+   helm install traefik traefik/traefik -f prow/infra/traefik-values.yaml -n traefik
+   
+   # Make sure traefik sees the necessary resources in prow namespace
+   kubectl apply -f prow/infra/referencegrant.yaml
+
+   kubectl apply -f prow/infra/storageclass.yaml
+   kubectl apply -f prow/infra/cluster-issuer-http.yaml
+   ```
+
 1. Set up S3 object storage buckets
 
    ```bash

--- a/prow/infra/referencegrant.yaml
+++ b/prow/infra/referencegrant.yaml
@@ -1,0 +1,13 @@
+apiVersion: gateway.networking.k8s.io/v1beta1
+kind: ReferenceGrant
+metadata:
+  name: traefik-tls-access
+  namespace: prow
+spec:
+  from:
+  - group: gateway.networking.k8s.io
+    kind: Gateway
+    namespace: traefik
+  to:
+  - group: ""
+    kind: Secret

--- a/prow/infra/traefik-values.yaml
+++ b/prow/infra/traefik-values.yaml
@@ -1,0 +1,47 @@
+providers:
+  kubernetesIngress:
+    enabled: false
+  kubernetesGateway:
+    enabled: true
+gateway:
+  listeners:
+    web:
+      port: 8000
+      hostname: "prow.apps.test.metal3.io"
+      protocol: HTTP
+      namespacePolicy:
+        from: All
+    websecure:
+      port: 8443
+      hostname: "prow.apps.test.metal3.io"
+      protocol: HTTPS
+      namespacePolicy:
+        from: All
+      certificateRefs:
+      - name: metal3-io-tls
+        namespace: prow
+
+# Pod replicas for HA
+deployment:
+  replicas: 2
+
+# Tolerations for infra nodes
+tolerations:
+- key: node-role.kubernetes.io/infra
+  operator: Exists
+  effect: NoSchedule
+# Node selector for infra nodes
+nodeSelector:
+  node-role.kubernetes.io/infra: ""
+
+# Pod Disruption Budget for HA
+podDisruptionBudget:
+  enabled: true
+  minAvailable: 1
+
+service:
+  type: LoadBalancer
+  loadBalancerIP: 129.192.68.144
+  externalTrafficPolicy: Cluster
+  annotations:
+    loadbalancer.openstack.org/keep-floatingip: "true"

--- a/prow/manifests/overlays/metal3/httproutes.yaml
+++ b/prow/manifests/overlays/metal3/httproutes.yaml
@@ -1,0 +1,31 @@
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: prow
+  namespace: prow
+spec:
+  parentRefs:
+  - name: traefik-gateway
+    namespace: traefik
+    sectionName: websecure
+  hostnames:
+  - "prow.apps.test.metal3.io"
+  rules:
+  - matches:
+    - path:
+        type: PathPrefix
+        value: /
+    backendRefs:
+    - name: deck
+      port: 80
+      namespace: prow
+      kind: Service
+  - matches:
+    - path:
+        type: PathPrefix
+        value: /hook
+    backendRefs:
+    - name: hook
+      port: 8888
+      namespace: prow
+      kind: Service

--- a/prow/manifests/overlays/metal3/kustomization.yaml
+++ b/prow/manifests/overlays/metal3/kustomization.yaml
@@ -5,6 +5,7 @@ kind: Kustomization
 resources:
 - ../../base
 - ingress.yaml
+- httproutes.yaml
 - external-plugins/cherrypicker_deployment.yaml
 - external-plugins/cherrypicker_service.yaml
 - external-plugins/needs-rebase_deployment.yaml


### PR DESCRIPTION
## Summary

This commit introduces Kubernetes Gateway API support with Traefik ingress controller for the Prow infrastructure, replacing the traditional Ingress API approach.

## Changes

### New Files:
- **`prow/infra/traefik-values.yaml`** - Helm values configuration for Traefik with Gateway API providers enabled, HA setup with 2 replicas, and pod disruption budgets
- **`prow/infra/referencegrant.yaml`** - ReferenceGrant allowing the Traefik gateway to access TLS secrets from the prow-demo namespace
- **`prow/manifests/overlays/metal3/httproutes.yaml`** - HTTPRoute resource defining routes for Prow services (deck and hook) with HTTPS/TLS support

## Usage

1. **Install Traefik** using the provided Helm values:
   ```bash
   helm repo add traefik https://traefik.github.io/charts
   helm repo update
   helm install traefik traefik/traefik -f prow/infra/traefik-values.yaml -n traefik
   ```
2. **Apply the ReferenceGrant** to allow cross-namespace secret access:
   ```bash
   kubectl apply -f prow/infra/referencegrant.yaml
   ```
3. **Apply HTTPRoutes** 
   ```bash
   prow/manifests/overlays/metal3/httproutes.yaml
   ```

## Migration to Full Gateway API

Once validation is complete and the Gateway API setup is stable in production, perform the following cleanup:

### Files to **DELETE**:
- `prow/manifests/overlays/metal3/ingress.yaml`
- `prow/infra/ingress-controller-deployment-patch.yaml`
- `prow/infra/ingress-controller-job-patch.yaml`
- `prow/infra/ingress-controller-pdb.yaml`
- `prow/infra/service.yaml`
- `prow/infra/toleration-node-selector-patch.yaml`

### Files to **KEEP**:
- `prow/infra/referencegrant.yaml` (new)
- `prow/infra/traefik-values.yaml` (new)
- `prow/infra/storageclass.yaml` (old)
- `prow/infra/cluster-issuer-http.yaml` (old)

Fixes: #1152 