### PR TITLE
Prow: Bump cert-manager and ingress-nginx

### DIFF
--- a/prow/capi/kustomization.yaml
+++ b/prow/capi/kustomization.yaml
@@ -1,12 +1,7 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
-# Stick to v1.17 for now, as v1.18 has an issue when combined with nginx-ingress.
-# TL;DR: cert-manager v1.18 uses `PathType: Exact` for HTTP01 challenge paths,
-# and nginx-ingress has a bug that forbids dots (.) in the path when strict-validate-path-type
-# is enabled (default).
-# See https://cert-manager.io/docs/releases/release-notes/release-notes-1.18/#acme-http01-challenge-paths-now-use-pathtype-exact-in-ingress-routes
-- https://github.com/cert-manager/cert-manager/releases/download/v1.17.4/cert-manager.yaml
+- https://github.com/cert-manager/cert-manager/releases/download/v1.18.5/cert-manager.yaml
 - https://github.com/kubernetes-sigs/cluster-api-operator/releases/download/v0.22.0/operator-components.yaml
 # ORC is needed for CAPO
 - https://github.com/k-orc/openstack-resource-controller/releases/download/v2.2.0/install.yaml

--- a/prow/infra/kustomization.yaml
+++ b/prow/infra/kustomization.yaml
@@ -1,7 +1,7 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
-- https://github.com/kubernetes/ingress-nginx/deploy/static/provider/cloud?ref=controller-v1.12.3
+- https://github.com/kubernetes/ingress-nginx/deploy/static/provider/cloud?ref=controller-v1.13.7
 - cluster-issuer-http.yaml
 - storageclass.yaml
 - ingress-controller-pdb.yaml


### PR DESCRIPTION
Ingress-nginx has patch releases out with some vulnerabilities fixed. Bumping the version to stay secure.
This also means we now have a version with a fix for the bug that prevented us from using newer versions of cert-manager, so I am also bumping cert-manager one minor version. This is to stay on a supported version, without jumping too much in one upgrade.

Ingress-nginx CVEs:
- https://github.com/kubernetes/kubernetes/issues/136677
- https://github.com/kubernetes/kubernetes/issues/136678
- https://github.com/kubernetes/kubernetes/issues/136679
- https://github.com/kubernetes/kubernetes/issues/136680

Fix that allows us to take newer versions of cert-manager: https://github.com/kubernetes/ingress-nginx/pull/13798 (included in v1.13.2+)

Ingress-nginx has already been applied in the cluster. Cert-manager is applied by flux after merging.