### PR TITLE
:seedling: bump github actions to new major versions

### DIFF
--- a/.github/workflows/container-image-build.yml
+++ b/.github/workflows/container-image-build.yml
@@ -96,7 +96,7 @@ jobs:
         echo "GITHUB_REFNAME=${REF_NAME}" >> "${GITHUB_ENV}"
         echo "Using GITHUB REFNAME: ${REF_NAME}"
 
-    - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+    - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       with:
         ref: ${{ env.GITHUB_REF }}
 
@@ -132,7 +132,7 @@ jobs:
     - name: Download artifact
       id: download-artifact
       if: ${{ inputs.artifact-name }} != ""
-      uses: actions/download-artifact@634f93cb2916e3fdff6788551b99b062d0335ce0 # v5.0.0
+      uses: actions/download-artifact@37930b1c2abaa49bbe596cd826c3c89aef350131 # v7.0.0
       with:
         name: ${{ inputs.artifact-name }}
         path: /tmp/build-${{ inputs.image-name }}
@@ -208,7 +208,7 @@ jobs:
     - name: Upload SBOM artifact
       id: upload-sbom
       if: ${{ inputs.generate-sbom && inputs.pushImage }}
-      uses: actions/upload-artifact@330a01c490aca151604b8cf639adc76d48f6c5d4 # v5.0.0
+      uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f # v6.0.0
       with:
         name: ${{ inputs.image-name }}-sbom
         path: ${{ inputs.image-name }}-sbom.spdx.json

--- a/.github/workflows/pr-gh-workflow-approve.yaml
+++ b/.github/workflows/pr-gh-workflow-approve.yaml
@@ -21,7 +21,7 @@ jobs:
     if: contains(github.event.pull_request.labels.*.name, 'ok-to-test')
     steps:
     - name: Update PR
-      uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b # v7.1.0
+      uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8.0.0
       continue-on-error: true
       with:
         github-token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/pr-link-check.yml
+++ b/.github/workflows/pr-link-check.yml
@@ -22,7 +22,7 @@ jobs:
 
     steps:
     - name: Clone repository
-      uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+      uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       with:
         fetch-depth: 0
         ref: ${{github.event.pull_request.head.ref}}

--- a/.github/workflows/pr-verifier.yaml
+++ b/.github/workflows/pr-verifier.yaml
@@ -9,7 +9,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Check out repository
-      uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+      uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
     - name: Validate PR Title
       env:

--- a/.github/workflows/scheduled-link-check.yml
+++ b/.github/workflows/scheduled-link-check.yml
@@ -20,7 +20,7 @@ jobs:
       issues: write
 
     steps:
-    - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+    - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
     - name: Link Checker
       id: linkcheck
@@ -45,7 +45,7 @@ jobs:
 
     - name: Create Issue From File
       if: steps.linkcheck.outputs.exit_code != 0
-      uses: peter-evans/create-issue-from-file@e8ef132d6df98ed982188e460ebb3b5d4ef3a9cd # v5.0.1
+      uses: peter-evans/create-issue-from-file@fca9117c27cdc29c6c4db3b86c48e4115a786710 # v6.0.0
       with:
         title: Link Checker Report
         content-filepath: /tmp/lychee_output.md

--- a/.github/workflows/yamllint.yaml
+++ b/.github/workflows/yamllint.yaml
@@ -25,7 +25,7 @@ jobs:
     - name: Install yamllint
       run: sudo apt-get update && sudo apt-get install -y yamllint
 
-    - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+    - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
     - name: Extract YAML snippets from md files
       run: |


### PR DESCRIPTION
Dependabot isn't allowed to bump to new major versions automatically in case there is a breaking change. In these updates, we don't have any breaking changes right now as the runner version is new enough to support them.