### PR TITLE
add merge-labels support in Prow

### DIFF
--- a/prow/config/config.yaml
+++ b/prow/config/config.yaml
@@ -52,6 +52,9 @@ tide:
     Nordix/metal3-dev-tools: rebase
     Nordix/metal3-clusterapi-docs: rebase
     Nordix/sles-ironic-python-agent-builder: rebase
+  squash_label: tide/merge-method-squash
+  rebase_label: tide/merge-method-rebase
+  merge_label: tide/merge-method-merge
   queries:
   - repos:
     - metal3-io/.github


### PR DESCRIPTION
Add merge-labels support in Prow, to allow PR by PR control how they're merged. For example, applying tide/merge-method-squash, Tide will squash the commits before merging, so the PR author does not have to play with Git and get changes re-tested etc.

Ref:
- https://www.kubernetes.dev/blog/2022/12/12/prow-and-tide-for-kubernetes-contributors/
- https://github.com/kubernetes/test-infra/blob/873029a83fff4b61c5707dfa107176e1da5abbf3/config/prow/config.yaml#L867