### PR TITLE
make blunderbuss request exactly 3 reviews

### DIFF
--- a/prow/config/plugins.yaml
+++ b/prow/config/plugins.yaml
@@ -90,6 +90,7 @@ approve:
   lgtm_acts_as_approve: false
 
 blunderbuss:
+  request_count: 3
   max_request_count: 3
   use_status_availability: true
 


### PR DESCRIPTION
Earlier we allowed blunderbuss to ask for max 3 reviews, but it never did more than 2, which is the default if request_count is undefined. Raise it explicitly to 3.

Ref: 
- https://github.com/metal3-io/project-infra/pull/1239 raising the max to 3