### PR TITLE
:bug: Improve venv setup for ostack resource cleanup

### DIFF
--- a/jenkins/image_building/build-image.sh
+++ b/jenkins/image_building/build-image.sh
@@ -55,7 +55,7 @@ fi
 
 # shellcheck source=/dev/null
 . venv/bin/activate
-pip install --no-cache-dir diskimage-builder==3.33.0
+pip install --no-cache-dir "diskimage-builder==3.40.2"
 
 export ELEMENTS_PATH="${current_dir}/dib_elements"
 export DIB_DEV_USER_USERNAME="metal3ci"

--- a/jenkins/image_building/dib_elements/ubuntu-ci/install.d/55-install
+++ b/jenkins/image_building/dib_elements/ubuntu-ci/install.d/55-install
@@ -13,7 +13,8 @@ sudo apt-get install -y \
   python-is-python3 \
   chrony \
   qemu-system \
-  qemu-utils
+  qemu-utils \
+  python3.12-venv
 
 # Configure
 sudo chronyc -a 'burst 4/4' && sudo chronyc -a makestep
@@ -56,3 +57,6 @@ sudo -u metal3ci bash -c 'echo "export DOCKER_BUILDKIT=1" >> /home/metal3ci/.bas
 
 # Add metal3ci user to libvirt group
 sudo adduser metal3ci libvirt
+
+sudo -u metal3ci bash -c 'python3 -m venv /home/metal3ci/civenv'
+sudo -u metal3ci bash -c '. /home/metal3ci/civenv/bin/activate && pip install python-openstackclient==7.0.0 && echo "METAL3CI VENV PACKAGES:" && pip freeze'

--- a/jenkins/scripts/clean_resources.sh
+++ b/jenkins/scripts/clean_resources.sh
@@ -43,18 +43,21 @@ cleanup() {
     done
 }
 
-sudo apt install -y python3.12-venv
+WORK_VENV="${HOME}/civenv"
+WORK_VENV_ACTIVATOR="${WORK_VENV}/bin/activate"
 
-rm -rf venv
-python3 -m venv venv
+if [[ ! -x "${WORK_VENV_ACTIVATOR}" ]]; then
+    sudo apt-get update
+    sudo apt-get install -y python3.12-venv
+    python3 -m venv "${WORK_VENV}"
+fi
 
 # shellcheck source=/dev/null
-. venv/bin/activate
+. "${WORK_VENV_ACTIVATOR}"
 # Install openstack client
 pip install python-openstackclient=="${CLIENT_VERSION}"
 # export openstackclient path
 export PATH="${PATH}:${HOME}/.local/bin"
-
 #unset openstack variables
 unset "${!OS_@}"
 
@@ -72,3 +75,5 @@ cleanup
 
 #unset openstack variables
 unset "${!OS_@}"
+# deactiveate the python venv (for non ci use)
+deactivate


### PR DESCRIPTION
This PR:
 - makes clean_resource.sh utilize pre-installed openstack client
 - modifies ubuntu ci image building to include openstack cli venv
   bootstrapping
 - bump the DIB version from 3.33.0 (2+years old) to most recent 3.40.2

This commit is needed:
Because there have been situations where the DEB repository list was
out of date on a in-use ubuntu ci image thus the python3.12-venv package
install failed on the ci image while running clean_resources.sh.

Also it doesn't make sense to bootstrap the venv for Openstack client during
the cleanup job, when the venv can be bootstrapped during ci image building.

DIB bump was needed because 3.33.0 was struggling with some of its
dependencies, at least with 'pkg_resources' (that made it fail so not sure if
there was any other problematic package other than this).