### PR TITLE
add merge-labels into additional labels

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -27,7 +27,7 @@ Run locally before PRs:
 | `./hack/shellcheck.sh` | Shell script linting |
 | `./hack/markdownlint.sh` | Markdown linting |
 | `./hack/spellcheck.sh` | Spell checking |
-| `make -C prow validate` | Validate Prow config |
+| `cd prow && make validate` | Validate Prow config |
 
 ## Code Conventions
 
@@ -46,7 +46,7 @@ Run locally before PRs:
 ### Modifying Prow Config
 
 1. Edit files in `prow/config/`
-1. Run `make -C prow validate`
+1. Run `cd prow && make validate`
 1. Changes apply on merge to main
 
 ## Code Review Guidelines
@@ -63,7 +63,7 @@ Focus on: `jenkins/jobs/`, `prow/config/`, `jenkins/scripts/`.
 ## AI Agent Guidelines
 
 1. Run linters before committing
-1. Validate Prow changes with `make -C prow validate`
+1. Validate Prow changes with `cd prow && make validate`
 1. Follow existing Groovy job patterns
 1. Update `.cspell-config.json` for new terms
 

--- a/prow/config/plugins.yaml
+++ b/prow/config/plugins.yaml
@@ -76,6 +76,12 @@ plugins:
     plugins:
     - config-updater
 
+label:
+  additional_labels:
+  - tide/merge-method-merge
+  - tide/merge-method-rebase
+  - tide/merge-method-squash
+
 approve:
 - repos:
   - metal3-io


### PR DESCRIPTION
Before this, tide knows to do the squash merge, but the /label doesn't recognize them, since they're custom labels. Add them to additional labels, similarly to kubernetes/test-infra has. This should be the last bit to make /label tide/merge-method-squash work for squashing.

Also, fix AGENTS.md, so the prow config validation works as instructed.