### PR TITLE
Fix conditional expression in container-image-build workflow

### DIFF
--- a/.github/workflows/container-image-build.yml
+++ b/.github/workflows/container-image-build.yml
@@ -131,7 +131,7 @@ jobs:
 
     - name: Download artifact
       id: download-artifact
-      if: ${{ inputs.artifact-name }} != ""
+      if: ${{ inputs.artifact-name != '' }}
       uses: actions/download-artifact@37930b1c2abaa49bbe596cd826c3c89aef350131 # v7.0.0
       with:
         name: ${{ inputs.artifact-name }}


### PR DESCRIPTION
Move the full comparison inside ${{ }} so the artifact-name check evaluates correctly instead of always being truthy.