### PR TITLE
Prow: S3 lifecycle policy for log retention

### DIFF
--- a/prow/README.md
+++ b/prow/README.md
@@ -55,12 +55,14 @@ A webhook must be configured in GitHub to
 send events to Prow and a DNS record must be configured so that
 <https://prow.apps.test.metal3.io> points to the IP where Prow can be accessed.
 
-The DNS records are managed by CNCF for us. Any changes to them can be done
-through the
-[service desk](https://cncfservicedesk.atlassian.net/servicedesk/customer/user/login?destination=portals).
-All project maintainers have (or can request) access. See
-[their FAQ](https://github.com/cncf/servicedesk#how-do-i-file-a-ticket-with-the-service-desk)
-for more details.
+Maintainers can manage the DNS records through
+[Netlify](https://app.netlify.com/teams/cncf-projects/dns/metal3.io). CNCF
+controls the Netlify project. Maintainers can request access through the
+[service
+desk](https://cncfservicedesk.atlassian.net/servicedesk/customer/user/login?destination=portals).
+If you do not have access to the service desk, see [their
+FAQ](https://github.com/cncf/servicedesk#how-do-i-file-a-ticket-with-the-service-desk)
+for more details on how to request access.
 
 ### Requirements
 
@@ -454,6 +456,12 @@ Metal3 CI ssh key.
    s3cmd --config .s3cfg mb s3://prow-logs
    s3cmd --config .s3cfg mb s3://tide
    s3cmd --config .s3cfg mb s3://status-reconciler
+   ```
+
+1. Create S3 Lifecycle rules to automatically delete old logs.
+
+   ```bash
+   s3cmd --config .s3cfg setlifecycle s3/lifecycle-policy.xml s3://prow-logs
    ```
 
 1. Deploy Prow

--- a/prow/s3/lifecycle-policy.xml
+++ b/prow/s3/lifecycle-policy.xml
@@ -1,0 +1,12 @@
+<LifecycleConfiguration>
+  <Rule>
+    <ID>Expiration Rule</ID>
+    <Filter>
+       <Prefix></Prefix>
+    </Filter>
+    <Status>Enabled</Status>
+    <Expiration>
+      <Days>90</Days>
+    </Expiration>
+  </Rule>
+</LifecycleConfiguration>


### PR DESCRIPTION
Add S3 Lifecycle policy for removing logs that are older than 90 days. We only need this for the logs bucket since tide and status-reconciler doesn't accumulate data.

Also update DNS documentation with information about self-management through Netlify.