### PR TITLE
disable default buildx provenance attestations

### DIFF
--- a/.github/workflows/container-image-build.yml
+++ b/.github/workflows/container-image-build.yml
@@ -139,6 +139,8 @@ jobs:
 
     - name: Build ${{ inputs.image-name }} image
       uses: mr-smithers-excellent/docker-build-push@19d2beefef6bcdc202195fdcb9deb79a4fab5c1f # v6.8
+      env:
+        BUILDX_NO_DEFAULT_ATTESTATIONS: 1
       with:
         image: metal3-io/${{ inputs.image-name }}
         tags: ${{ env.IMAGE_TAGS }}


### PR DESCRIPTION
Docker Engine 29 (rolled out to GitHub Actions runners on Feb 9-12, 2026) enables the containerd image store by default, which causes docker build to produce OCI image indexes with provenance attestation manifests. The bom tool (v0.7.1) cannot handle these attestation manifests and fails with 'archive/tar: invalid tar header' during SBOM generation.

Disable the default attestations with BUILDX_NO_DEFAULT_ATTESTATIONS=1. This is safe because we already generate and attest our own SBOM with cosign in later workflow steps.

Ref: https://github.com/actions/runner-images/issues/13474
Ref: https://www.docker.com/blog/docker-engine-version-29/