### PR TITLE
Comment out CAPM3 build job

### DIFF
--- a/prow/config/jobs/metal3-io/cluster-api-provider-metal3.yaml
+++ b/prow/config/jobs/metal3-io/cluster-api-provider-metal3.yaml
@@ -112,22 +112,22 @@ presubmits:
           value: "/"
         image: ghcr.io/yannh/kubeconform:v0.6.7-alpine@sha256:824e0c248809e4b2da2a768b16b107cf17ada88a89ec6aa6050e566ba93ebbc6
         imagePullPolicy: Always
-  - name: build
-    branches:
-    - main
-    run_if_changed: "^api|^test|^Makefile$|^hack/build.sh$"
-    decorate: true
-    spec:
-      containers:
-      - args:
-        - ./hack/build.sh
-        command:
-        - sh
-        env:
-        - name: IS_CONTAINER
-          value: "TRUE"
-        image: docker.io/golang:1.24
-        imagePullPolicy: Always
+  # - name: build
+  #   branches:
+  #   - main
+  #   run_if_changed: "^api|^test|^Makefile$|^hack/build.sh$"
+  #   decorate: true
+  #   spec:
+  #     containers:
+  #     - args:
+  #       - ./hack/build.sh
+  #       command:
+  #       - sh
+  #       env:
+  #       - name: IS_CONTAINER
+  #         value: "TRUE"
+  #       image: docker.io/golang:1.24
+  #       imagePullPolicy: Always
   - name: build-fkas
     branches:
     - main


### PR DESCRIPTION
This job is constantly retriggered for some reason. Every 5-10 minutes it runs on all PRs where the build job is supposed to run, like it did not notice that it already did run.
Let's try to remove the job for now to stop this madness. We can try adding it back again in the next release cycle.