### PR TITLE
attempt to fix prow test trigger for capm3 build

### DIFF
--- a/prow/config/jobs/metal3-io/cluster-api-provider-metal3.yaml
+++ b/prow/config/jobs/metal3-io/cluster-api-provider-metal3.yaml
@@ -115,7 +115,7 @@ presubmits:
   - name: build
     branches:
     - main
-    run_if_changed: "^api|^test|^Makefile$|^hack/build.sh$"
+    run_if_changed: "^api/.*|^test/.*|^Makefile$|^hack/build.sh$"
     decorate: true
     spec:
       containers:


### PR DESCRIPTION
This PR:
 - Changes the regex trigger to a more accurate regex

This commit is needed because prow is periodically re-triggering this test even when it is not needed.