### PR TITLE
Try to fetch Ironic manifest that get created when IrSO is in use

### DIFF
--- a/jenkins/scripts/dynamic_worker_workflow/fetch_logs.sh
+++ b/jenkins/scripts/dynamic_worker_workflow/fetch_logs.sh
@@ -91,6 +91,7 @@ fetch_manifests()
       ippool
       ipclaim
       ipaddress
+      ironic
       m3data
       m3dataclaim
       m3datatemplate


### PR DESCRIPTION
When `USE_IRSO` is set an `Ironic` resource is created, having it in the resulting artifact tarball would ease debugging.