### PR TITLE
Bump golang to v1.25 for BMO main branch, basic-checks and container image build pipeline

### DIFF
--- a/.github/workflows/build-images-action.yml
+++ b/.github/workflows/build-images-action.yml
@@ -20,7 +20,7 @@ jobs:
     uses: ./.github/workflows/container-image-build.yml
     with:
       image-name: 'basic-checks'
-      image-tag: 'golang-1.24'
+      image-tag: 'golang-1.25'
       dockerfile-directory: 'prow/container-images/basic-checks'
       pushImage: true
       generate-sbom: true

--- a/.github/workflows/container-image-build.yml
+++ b/.github/workflows/container-image-build.yml
@@ -171,7 +171,7 @@ jobs:
       if: ${{ inputs.generate-sbom && inputs.pushImage }}
       uses: actions/setup-go@7a3fe6cf4cb3a834922a1244abfce67bcef6a0c5 # v6.2.0
       with:
-        go-version: '1.24'
+        go-version: '1.25'
 
     - name: Install bom tool
       if: ${{ inputs.generate-sbom && inputs.pushImage }}

--- a/prow/config/jobs/metal3-io/baremetal-operator.yaml
+++ b/prow/config/jobs/metal3-io/baremetal-operator.yaml
@@ -14,7 +14,7 @@ presubmits:
         env:
         - name: IS_CONTAINER
           value: "TRUE"
-        image: quay.io/metal3-io/basic-checks:golang-1.24
+        image: quay.io/metal3-io/basic-checks:golang-1.25
         imagePullPolicy: Always
   - name: markdownlint
     branches:
@@ -70,7 +70,7 @@ presubmits:
           value: "http://localhost:6385/v1/"
         - name: IRONIC_INSPECTOR_ENDPOINT
           value: "http://localhost:5050/v1/"
-        image: quay.io/metal3-io/basic-checks:golang-1.24
+        image: quay.io/metal3-io/basic-checks:golang-1.25
         imagePullPolicy: Always
   # NOTE: The test jobs are for verifying Makefile and hack/* script changes only
   - name: test
@@ -84,7 +84,7 @@ presubmits:
         - test
         command:
         - make
-        image: quay.io/metal3-io/basic-checks:golang-1.24
+        image: quay.io/metal3-io/basic-checks:golang-1.25
         imagePullPolicy: Always
   - name: manifestlint
     branches:

--- a/prow/container-images/basic-checks/Dockerfile
+++ b/prow/container-images/basic-checks/Dockerfile
@@ -1,4 +1,4 @@
-ARG GO_VERSION=1.24.10@sha256:7b13449f08287fdb53114d65bdf20eb3965e4e54997903b5cb9477df0ea37c12
+ARG GO_VERSION=1.25.7@sha256:85c0ab0b73087fda36bf8692efe2cf67c54a06d7ca3b49c489bbff98c9954d64
 FROM docker.io/golang:${GO_VERSION}
 
 # Install additional packages not present in regular golang image


### PR DESCRIPTION
bumps v1.25 for 
- BMO main branch
- basic checks
- container image build pipeline