### PR TITLE
switch jenkins jobs to use jnlp agent

### DIFF
--- a/jenkins/jobs/bmo_e2e_optional_tests.groovy
+++ b/jenkins/jobs/bmo_e2e_optional_tests.groovy
@@ -14,7 +14,7 @@ pipeline {
     stages {
         stage('Run Baremetal Operator optional e2e tests') {
             matrix {
-                agent { label 'metal3ci-8c16gb-ubuntu' }
+                agent { label 'metal3ci-4c16gb-ubuntu-jnlp' }
                 axes {
                     axis {
                         name 'BMC_PROTOCOL'

--- a/jenkins/jobs/capm3-e2e-tests.groovy
+++ b/jenkins/jobs/capm3-e2e-tests.groovy
@@ -20,30 +20,30 @@ script {
     echo "Checkout ${ci_git_url} branch ${ci_git_branch}"
 
     if ( "${GINKGO_FOCUS}" == 'integration' || "${GINKGO_FOCUS}" == 'basic' ) {
-        agent_label = "metal3ci-8c16gb-${IMAGE_OS}"
+        agent_label = "metal3ci-4c16gb-${IMAGE_OS}-jnlp"
         TIMEOUT = 10800 // 3h
   } else if ( "${GINKGO_FOCUS}" == 'pivoting' ) {
         BUILD_TAG = "${env.BUILD_TAG}-pivoting-based"
         TIMEOUT = 18000 // 5h for node reuse
-        agent_label = "metal3ci-8c32gb-${IMAGE_OS}"
+        agent_label = "metal3ci-8c32gb-${IMAGE_OS}-jnlp"
   } else if ( "${GINKGO_FOCUS}" == 'remediation' ) {
         BUILD_TAG = "${env.BUILD_TAG}-remediation-based"
         TIMEOUT = 18000 // 5h for remediation
-        agent_label = "metal3ci-8c24gb-${IMAGE_OS}"
+        agent_label = "metal3ci-8c24gb-${IMAGE_OS}-jnlp"
   } else if ( "${GINKGO_FOCUS}" == 'k8s-upgrade' ) {
-        agent_label = "metal3ci-8c24gb-${IMAGE_OS}"
+        agent_label = "metal3ci-8c24gb-${IMAGE_OS}-jnlp"
         TIMEOUT = 14400 // 4h
   } else if ( "${GINKGO_FOCUS}" == 'k8s-upgrade-n3' ) {
-        agent_label = "metal3ci-8c24gb-${IMAGE_OS}"
+        agent_label = "metal3ci-8c24gb-${IMAGE_OS}-jnlp"
         TIMEOUT = 18000 // 5h
   } else if ( "${GINKGO_FOCUS}" == 'k8s-conformance' ) {
         TIMEOUT = 7200 // 2h
-        agent_label = "metal3ci-8c32gb-${IMAGE_OS}"
+        agent_label = "metal3ci-8c32gb-${IMAGE_OS}-jnlp"
   } else if ( "${GINKGO_FOCUS}" == 'capi-md-tests'  || "${GINKGO_FOCUS}" == 'scalability') {
         TIMEOUT = 10800 // 3h
-        agent_label = "metal3ci-8c32gb-${IMAGE_OS}"
+        agent_label = "metal3ci-8c32gb-${IMAGE_OS}-jnlp"
   } else {
-        agent_label = "metal3ci-8c32gb-${IMAGE_OS}"
+        agent_label = "metal3ci-8c32gb-${IMAGE_OS}-jnlp"
         BUILD_TAG = "${env.BUILD_TAG}-other-features"
         GINKGO_SKIP = 'pivoting remediation' // Allow non pivoting features
     }

--- a/jenkins/jobs/clean_resources.groovy
+++ b/jenkins/jobs/clean_resources.groovy
@@ -8,7 +8,7 @@ script {
 }
 
 pipeline {
-    agent { label 'metal3ci-8c16gb-ubuntu' }
+    agent { label 'metal3ci-4c16gb-ubuntu-jnlp' }
     environment {
         OS_USERNAME = 'metal3ci'
         OS_AUTH_URL = 'https://kna1.citycloud.com:5000'

--- a/jenkins/jobs/dev_env_integration_tests.groovy
+++ b/jenkins/jobs/dev_env_integration_tests.groovy
@@ -16,7 +16,7 @@ script {
         ci_git_branch = 'main'
         refspec = '+refs/heads/*:refs/remotes/origin/*'
     }
-    agent_label = "metal3ci-8c16gb-${IMAGE_OS}"
+    agent_label = "metal3ci-4c16gb-${IMAGE_OS}-jnlp"
 }
 
 pipeline {

--- a/jenkins/jobs/dynamic_fullstack_building.groovy
+++ b/jenkins/jobs/dynamic_fullstack_building.groovy
@@ -20,7 +20,7 @@ script {
 }
 
 pipeline {
-    agent { label 'metal3ci-8c32gb-ubuntu' }
+    agent { label 'metal3ci-8c32gb-ubuntu-jnlp' }
     environment {
         // supplied by prow
         REPO_ORG = "${env.REPO_OWNER}"

--- a/jenkins/jobs/image_building.groovy
+++ b/jenkins/jobs/image_building.groovy
@@ -37,7 +37,7 @@ pipeline {
     stages {
         stage('SCM') {
             matrix {
-                agent { label 'metal3ci-8c16gb-ubuntu' }
+                agent { label 'metal3ci-4c16gb-ubuntu-jnlp' }
                 options { ansiColor('xterm') }
                 axes {
                     axis {
@@ -125,7 +125,7 @@ pipeline {
                         }
                     }
                     stage('Verify the new CI image') {
-                        agent { label "metal3ci-${IMAGE_OS}-staging" }
+                        agent { label "metal3ci-${IMAGE_OS}-staging-jnlp" }
                         options {
                             timeout(time: 2, unit: 'HOURS')
                         }

--- a/jenkins/jobs/osv_scanner_metal3.groovy
+++ b/jenkins/jobs/osv_scanner_metal3.groovy
@@ -74,7 +74,7 @@ def runOsvScan = { String repoName, String refType, String ref, String repoUrl, 
     }
 }
 
-script { agent_label = 'metal3ci-8c32gb-ubuntu' }
+script { agent_label = 'metal3ci-8c32gb-ubuntu-jnlp' }
 
 pipeline {
     agent { label agent_label }

--- a/jenkins/jobs/pre_release_tests.groovy
+++ b/jenkins/jobs/pre_release_tests.groovy
@@ -20,9 +20,9 @@ script {
     echo "Checkout ${ci_git_url} branch ${ci_git_branch}"
 
     if ( "${GINKGO_FOCUS}" == 'integration' ) {
-        agent_label = "metal3ci-8c16gb-${IMAGE_OS}"
+        agent_label = "metal3ci-4c16gb-${IMAGE_OS}-jnlp"
     } else if ( "${GINKGO_FOCUS}" == 'k8s-upgrade' ) {
-        agent_label = "metal3ci-8c24gb-${IMAGE_OS}"
+        agent_label = "metal3ci-8c24gb-${IMAGE_OS}-jnlp"
     }
 }
 


### PR DESCRIPTION
This PR:
 - Modifies the Jenkins pipeline scripts to use the agent templates with jnlp.
 - Changes templates that were previously 8c16gb to 4c16gb.

Note: previously used non jnlp templates with 8c16gb names were still using 4c16 OpenStack flavors, their name is incorrect.

Note 2: old agent templates were using ssh connection that required allocating IPs and ports that were publicly available on the internet, jnlp based agents will utilize a callback mechanism that does not require public IPs and ports.