### PR TITLE
fix cloud-init-datasources element invocation

### DIFF
--- a/jenkins/image_building/dib_elements/ci-base/README.md
+++ b/jenkins/image_building/dib_elements/ci-base/README.md
@@ -16,3 +16,4 @@ ci-base element depends following elements.
 * [openssh-server](https://docs.openstack.org/diskimage-builder/latest/elements/openssh-server/README.html)
 * [pkg-map](https://docs.openstack.org/diskimage-builder/latest/elements/pkg-map/README.html)
 * [package-installs](https://docs.openstack.org/diskimage-builder/latest/elements/package-installs/README.html)
+* [cloud-init-datasources](https://opendev.org/openstack/diskimage-builder/src/branch/master/diskimage_builder/elements/cloud-init-datasources)

--- a/jenkins/image_building/dib_elements/ci-base/element-deps
+++ b/jenkins/image_building/dib_elements/ci-base/element-deps
@@ -4,3 +4,4 @@ devuser
 openssh-server
 pkg-map
 package-installs
+cloud-init-datasources


### PR DESCRIPTION
This PR:
  - Explicitly includes cloud-init-datasources in the ci-base element

This commit is needed because cloud-init on leap is missing the OpenStack
data source from its config by default. Which lead to an investigation which
lead to the fact that the explicit OpenStack data source configuration was
missing because the related element was not included in the dependency list.