### PR TITLE
reduce parallelism for osv-scanner

### DIFF
--- a/jenkins/jobs/osv_scanner_metal3.groovy
+++ b/jenkins/jobs/osv_scanner_metal3.groovy
@@ -316,12 +316,11 @@ pipeline {
                     def tasks = [:]
 
                     REPO_BRANCH_MAP.each { entry ->
-                        // Branch scans
-                        entry.branches.each { br ->
-                            def label = "${entry.name}-branch-${br}"
-                            tasks[label] = {
+                        def repoEntry = entry
+                        tasks[repoEntry.name] = {
+                            repoEntry.branches.each { br ->
                                 catchError(buildResult: 'SUCCESS', stageResult: 'FAILURE') {
-                                    runOsvScan(entry.name, 'branch', br, entry.url, GO_VERSION, 'branch_scan_failures.txt')
+                                    runOsvScan(repoEntry.name, 'branch', br, repoEntry.url, GO_VERSION, 'branch_scan_failures.txt')
                                 }
                             }
                         }
@@ -342,12 +341,11 @@ pipeline {
                     def tasks = [:]
 
                     REPO_BRANCH_MAP.each { entry ->
-                        // Tag scans
-                        entry.tags.each { tg ->
-                            def label = "${entry.name}-tag-${tg}".replace('/', '_')
-                            tasks[label] = {
+                        def repoEntry = entry
+                        tasks[repoEntry.name] = {
+                            repoEntry.tags.each { tg ->
                                 catchError(buildResult: 'SUCCESS', stageResult: 'FAILURE') {
-                                    runOsvScan(entry.name, 'tag', tg, entry.url, GO_VERSION, 'tag_scan_failures.txt')
+                                    runOsvScan(repoEntry.name, 'tag', tg, repoEntry.url, GO_VERSION, 'tag_scan_failures.txt')
                                 }
                             }
                         }


### PR DESCRIPTION
We OOM out during branch scans.
Scans for branches and tags are now run sequentially within each repo while repos are still scanned in parallel. This reduces peak concurrency from ~12 to 4, lowering memory pressure on the 32GB worker node.

https://jenkins.nordix.org/blue/organizations/jenkins/metal3-periodic-osv-scanner-metal3-repos/detail/metal3-periodic-osv-scanner-metal3-repos/114/pipeline/158

```
[2026-02-25T05:07:25.369Z] + bash -o pipefail -c osv-scanner scan --config ./config.toml --recursive . | tee "_home_metal3ci_workspace_metal3-periodic-osv-scanner-metal3-repos_results_CAPM3_branch_main.txt"
[2026-02-25T05:07:25.369Z] Scanning dir .
[2026-02-25T05:07:25.369Z] Starting filesystem walk for root: /
[2026-02-25T05:07:25.369Z] Scanned /home/metal3ci/workspace/metal3-periodic-osv-scanner-metal3-repos/work-CAPM3-branch-main/api/go.mod file and found 57 packages
[2026-02-25T05:07:25.369Z] Scanned /home/metal3ci/workspace/metal3-periodic-osv-scanner-metal3-repos/work-CAPM3-branch-main/go.mod file and found 104 packages
[2026-02-25T05:07:25.369Z] Scanned /home/metal3ci/workspace/metal3-periodic-osv-scanner-metal3-repos/work-CAPM3-branch-main/hack/fake-apiserver/go.mod file and found 108 packages
[2026-02-25T05:07:25.369Z] Scanned /home/metal3ci/workspace/metal3-periodic-osv-scanner-metal3-repos/work-CAPM3-branch-main/hack/tools/go.mod file and found 68 packages
[2026-02-25T05:07:25.369Z] Scanned /home/metal3ci/workspace/metal3-periodic-osv-scanner-metal3-repos/work-CAPM3-branch-main/test/go.mod file and found 193 packages
[2026-02-25T05:07:25.369Z] End status: 207 dirs visited, 793 inodes visited, 5 Extract calls, 25.54417ms elapsed, 25.54437ms wall time
[2026-02-25T05:07:25.369Z] Filtered 2 local/unscannable package/s from the scan.
[2026-02-25T05:08:14.248Z] bash: line 1: 12899 Killed                  osv-scanner scan --config ./config.toml --recursive .
[2026-02-25T05:08:14.248Z]      12900 Done                    | tee "_home_metal3ci_workspace_metal3-periodic-osv-scanner-metal3-repos_results_CAPM3_branch_main.txt"
```