### PR TITLE
jenkins: set PATH in the stage's environment block

### DIFF
--- a/jenkins/jobs/image_building.groovy
+++ b/jenkins/jobs/image_building.groovy
@@ -126,6 +126,9 @@ pipeline {
                     }
                     stage('Verify the new CI image') {
                         agent { label "metal3ci-${IMAGE_OS}-staging-jnlp" }
+                        environment {
+                          PATH = "/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin:${env.PATH}"
+                        }
                         options {
                             timeout(time: 2, unit: 'HOURS')
                         }


### PR DESCRIPTION
Set `PATH` in the "Verify the new CI image" stage's environment block to unblock the misconfigured PATH during the image building.