### PR TITLE
Revert "jenkins: set PATH in the stage's environment block"

### DIFF
--- a/jenkins/jobs/image_building.groovy
+++ b/jenkins/jobs/image_building.groovy
@@ -126,9 +126,6 @@ pipeline {
                     }
                     stage('Verify the new CI image') {
                         agent { label "metal3ci-${IMAGE_OS}-staging-jnlp" }
-                        environment {
-                          PATH = "/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin:${env.PATH}"
-                        }
                         options {
                             timeout(time: 2, unit: 'HOURS')
                         }


### PR DESCRIPTION
This reverts commit e23ead1ce9f5a578e4cba87ee0071dc009fa347f as we have a "proper" fix that was made outside of git on the Jenkins to include the -i flag to ` sudo -u foo /usr/bin/java`.