### PR TITLE
adding /usr/local/bin to leap secure_path

### DIFF
--- a/jenkins/image_building/dib_elements/leap-ci/post-install.d/55-configure
+++ b/jenkins/image_building/dib_elements/leap-ci/post-install.d/55-configure
@@ -40,3 +40,7 @@ sudo systemctl enable atop.service cron.service sysstat.service
 
 # Change default to shell to bash
 sudo usermod --shell /bin/bash metal3ci
+
+## Add /usr/local/bin/
+sed -i -e "/secure_path/ s@\([\'\"]\?\)\$@:/usr/local/bin/\1@" /etc/sudoers
+visudo -c


### PR DESCRIPTION
This commit:
 -  Extends the configuration script of the leap-ci image build element such that the element will make sure the secure_path in /etc/sudoers contains the /usr/local/bin path.

This /usr/local/bin is where dev-env installs minikube so it is expected to be available even after sudo cleans the PATH.