### PR TITLE
tune selinux on centos ci hosts for DIB

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,3 +16,8 @@
 
 # python stuff
 hack/__pycache__
+
+# SELinux policy build artifacts
+*.pp
+*.mod
+*.te

--- a/jenkins/image_building/build-image.sh
+++ b/jenkins/image_building/build-image.sh
@@ -43,6 +43,10 @@ elif [[ "${AGENT_OS}" == "centos" ]]; then
   sudo pip3 install virtualenv
 
   python3 -m virtualenv venv
+
+  # configure SELinux on the Jenkins agent OS
+  # shellcheck disable=SC1091
+  "${current_dir}/selinux_centos_img_build.sh"
 elif [[ "${AGENT_OS}" == "opensuse-leap" ]]; then
   sudo zypper refresh
   sudo zypper -n in python3-devel python3-pip qemu

--- a/jenkins/image_building/selinux_centos_img_build.sh
+++ b/jenkins/image_building/selinux_centos_img_build.sh
@@ -1,0 +1,16 @@
+#!/usr/bin/env bash
+
+# This script is used to build and insert an SELinux module on centos CI
+# hosts so that the hosts can use DIB to build images.
+set -eux
+
+cat > setfilesmac_chroot.te <<'EOF'
+module setfilesmac_chroot 1.0;
+require { type cloud_init_t; type setfiles_mac_t; class process transition; }
+allow cloud_init_t setfiles_mac_t:process transition;
+EOF
+# Building selinux module
+checkmodule -M -m -o setfilesmac_chroot.mod setfilesmac_chroot.te
+semodule_package -o setfilesmac_chroot.pp -m setfilesmac_chroot.mod
+# Inserting selinux module
+sudo semodule -i setfilesmac_chroot.pp


### PR DESCRIPTION
This PR:
 - Introduces a script to build and insert an SELinux module on centos CI hosts so that the hosts can use DIB to build images.
 - Modifies the pre_release_test pipeline such that in case the pipeline is running on a centos based agent, the SELinux tuning script will be executed before the actual test script is started.

This change is needed because newer version of DIB explicitly require the host's SELinux to allow transitioning to setfiles_mac_t domain and execute chroot + do setfile editing in setfiles_mac_t domain.