### PR TITLE
Prow: Enable Gateway API support for cert-manager

### DIFF
--- a/prow/capi/kustomization.yaml
+++ b/prow/capi/kustomization.yaml
@@ -11,6 +11,15 @@ resources:
 - infrastructure.yaml
 
 patches:
+# Enable Gateway API support for cert-manager controller
+- patch: |-
+    - op: add
+      path: /spec/template/spec/containers/0/args/-
+      value: --enable-gateway-api
+  target:
+    kind: Deployment
+    name: cert-manager
+    namespace: cert-manager
 # Cert-manager does not set any toleration so we have to first create
 # the array/map before we can add values to them...
 - patch: |-


### PR DESCRIPTION
Part of #1265.
We currently solve the HTTP01 challenges for certificates using Ingress resources. In order to remove the ingress controller completely, we need to switch this over to gateway API first. The first step is to enable the feature in cert-manager.