### PR TITLE
revert back some links that require logins

### DIFF
--- a/.lycheeignore
+++ b/.lycheeignore
@@ -1,3 +1,6 @@
 https://jenkins.nordix.org/log/GHPRB/
 https://jenkins.nordix.org/ghprbhook/
 https://prow.apps.test.metal3.io/hook
+# GitHub settings pages require authentication and redirect to login when unauthenticated.
+https://github.com/settings/.*
+https://github.com/organizations/.*/settings/.*

--- a/jenkins/README.md
+++ b/jenkins/README.md
@@ -197,5 +197,5 @@ builds, on pull requests) in CI.
 
 In case of issues or question on the Jenkins CI, please contact the maintainers
 by email to estjorvas \[at\] est.tech or by posting your message on the
-[\#cluster-api-baremetal](https://kubernetes.slack.com/?redir=%2Fmessages%2FCHD49TLE7)
+[\#cluster-api-baremetal](https://kubernetes.slack.com/archives/CHD49TLE7)
 channel on Kubernetes Slack.

--- a/prow/README.md
+++ b/prow/README.md
@@ -195,7 +195,7 @@ PACKER_VAR_FILES=var_file.json make build-openstack-ubuntu-2404
 1. Create a personal access token for the GitHub bot account. This should be
    done from the [metal3-io-bot](https://github.com/metal3-io-bot) GitHub bot
    account. You can follow this
-   [link](https://github.com/login?return_to=https%3A%2F%2Fgithub.com%2Fsettings%2Ftokens)
+   [link](https://github.com/settings/tokens)
    to create the token. When generating the token, make sure you have only the
    following scopes checked in.
 
@@ -208,7 +208,7 @@ PACKER_VAR_FILES=var_file.json make build-openstack-ubuntu-2404
 1. Create a personal access token for the cherry-picker bot. This should be done
    from the [metal3-io-bot](https://github.com/metal3-io-bot)
    GitHub bot account. You can follow this
-   [link](https://github.com/login?return_to=https%3A%2F%2Fgithub.com%2Fsettings%2Ftokens)
+   [link](https://github.com/settings/tokens)
    to create the token. When generating the token, make sure you have only the
    following scopes checked in.
 
@@ -219,7 +219,7 @@ PACKER_VAR_FILES=var_file.json make build-openstack-ubuntu-2404
    The token will be referred to as `${CHERRYPICK_TOKEN}`.
 
 1. Create a [GitHub webhook in the Metal3-io
-   organization](https://github.com/login?return_to=https%3A%2F%2Fgithub.com%2Forganizations%2Fmetal3-io%2Fsettings%2Fhooks)
+   organization](https://github.com/organizations/metal3-io/settings/hooks)
    for <https://prow.apps.test.metal3.io/hook> using the HMAC token generated
    earlier. Add the URL and token as below. Select **"Send me everything"**, and
    for Content type: **application/json**.


### PR DESCRIPTION
Revert back some link fixes in cases where it causes a login redirect. Those are wrong for most humans, and its better to just ignore them.