### PR TITLE
add gh cli to ci images

### DIFF
--- a/jenkins/image_building/dib_elements/centos-ci/install.d/55-install
+++ b/jenkins/image_building/dib_elements/centos-ci/install.d/55-install
@@ -10,6 +10,11 @@ sudo dnf install epel-release -y
 # Install podman
 sudo dnf install podman -y
 
+# Install GitHub CLI
+sudo dnf install -y 'dnf-command(config-manager)'
+sudo dnf config-manager --add-repo https://cli.github.com/packages/rpm/gh-cli.repo
+sudo dnf install -y gh --repo gh-cli
+
 # Without this minikube cannot start properly kvm and fails.
 # As a simple workaround, this will create an empty file which can
 # disable the new firmware, more details here [1], look for firmware description.

--- a/jenkins/image_building/dib_elements/ubuntu-ci/install.d/55-install
+++ b/jenkins/image_building/dib_elements/ubuntu-ci/install.d/55-install
@@ -36,6 +36,16 @@ sudo echo \
 
 sudo apt-get update
 sudo apt-get install docker-ce docker-ce-cli containerd.io docker-buildx-plugin docker-compose-plugin jq -y
+
+# Install GitHub CLI
+sudo mkdir -p -m 755 /etc/apt/keyrings
+out=$(mktemp) && wget -nv -O"$out" https://cli.github.com/packages/githubcli-archive-keyring.gpg \
+  && cat "$out" | sudo tee /etc/apt/keyrings/githubcli-archive-keyring.gpg > /dev/null
+sudo chmod go+r /etc/apt/keyrings/githubcli-archive-keyring.gpg
+echo "deb [arch=$(dpkg --print-architecture) signed-by=/etc/apt/keyrings/githubcli-archive-keyring.gpg] https://cli.github.com/packages stable main" \
+  | sudo tee /etc/apt/sources.list.d/github-cli.list > /dev/null
+sudo apt-get update
+sudo apt-get install -y gh
 sudo groupadd docker || true
 sudo usermod -aG docker metal3ci || true
 sudo systemctl enable docker


### PR DESCRIPTION
Needed by the new repo sync script and also very handy to have available in general for development purposes too.

Required by: https://github.com/Nordix/metal3-dev-tools/pull/824
As noted failing in: https://jenkins.nordix.org/view/Metal3%20periodic%20FAIL/job/metal3_nordix_dev_tools_repos/71637/console