### PR TITLE
osv-scan 3 IRSO release branches

### DIFF
--- a/jenkins/jobs/osv_scanner_metal3.groovy
+++ b/jenkins/jobs/osv_scanner_metal3.groovy
@@ -136,7 +136,7 @@ pipeline {
                     .findAll { branch -> branch }
 
                     IRSO_BRANCHES = sh(
-                      script: "jenkins/scripts/get_last_n_release_branches.sh ${IRSO_GIT_URL} 2",
+                      script: "jenkins/scripts/get_last_n_release_branches.sh ${IRSO_GIT_URL} 3",
                       returnStdout: true
                     ).trim()
                     .split('\\n')


### PR DESCRIPTION
Currently, 3 IRSO release branches are supported, so scan them all.