### PR TITLE
Bump golang to v1.25 for IrSO main branch prow jobs

### DIFF
--- a/prow/config/jobs/metal3-io/ironic-standalone-operator.yaml
+++ b/prow/config/jobs/metal3-io/ironic-standalone-operator.yaml
@@ -14,7 +14,7 @@ presubmits:
         env:
         - name: IS_CONTAINER
           value: "TRUE"
-        image: docker.io/golang:1.24
+        image: docker.io/golang:1.25
         imagePullPolicy: Always
   - name: shellcheck
     branches:


### PR DESCRIPTION
Bump golang to v1.25 for IrSO main branch prow jobs
