### PR TITLE
Make leap ci image to run in OCI cloud

### DIFF
--- a/jenkins/image_building/dib_elements/leap-ci/finalise.d/50-rebuild-initrd
+++ b/jenkins/image_building/dib_elements/leap-ci/finalise.d/50-rebuild-initrd
@@ -1,0 +1,22 @@
+#!/usr/bin/env bash
+
+# Rebuild initrd with drivers required for cloud environments.
+
+set -eux
+
+mkdir -p /etc/dracut.conf.d
+
+# Force dracut to include virtio and other drivers
+cat > /etc/dracut.conf.d/99-cloud-drivers.conf <<EOF
+# Ensure virtio and cloud-essential drivers are included in the initrd
+add_drivers+=" virtio_blk virtio_net virtio_pci virtio_scsi virtio_console "
+add_drivers+=" nvme "
+# Do not use hostonly mode — build a generic initrd suitable for any cloud
+hostonly=no
+EOF
+
+# Rebuild initrd for all installed kernels
+for kernel_version in /lib/modules/*/; do
+  kernel_version=$(basename "${kernel_version}")
+  dracut --force "/boot/initrd-${kernel_version}" "${kernel_version}"
+done

--- a/jenkins/image_building/dib_elements/leap-ci/finalise.d/51-edit-grub-config
+++ b/jenkins/image_building/dib_elements/leap-ci/finalise.d/51-edit-grub-config
@@ -6,6 +6,22 @@
 # root filesystem and this cannot be modified. If we don't change the kernel
 # command line parameters, the image will try to look for nonexistent label
 # ROOT during boot and the boot will fail.
+#
+# We add serial console parameters (console=tty0 console=ttyS0,115200)
+# to ensure the image boots properly on platforms that use serial consoles
+# (Oracle Cloud).
 
-sed -i 's/GRUB_CMDLINE_LINUX.*/GRUB_CMDLINE_LINUX="root=LABEL=cloudimg-rootfs"/' /etc/default/grub
+GRUB_ARGS="root=LABEL=cloudimg-rootfs console=tty0 console=ttyS0,115200"
+
+# DIB_BOOTLOADER_DEFAULT_CMDLINE if set (e.g., net.ifnames=1 for node images)
+if [[ -n "${DIB_BOOTLOADER_DEFAULT_CMDLINE:-}" ]]; then
+  GRUB_ARGS="${DIB_BOOTLOADER_DEFAULT_CMDLINE} ${GRUB_ARGS}"
+fi
+
+
+# Replace only the GRUB_CMDLINE_LINUX line (anchored to avoid matching
+# GRUB_CMDLINE_LINUX_DEFAULT). Use | as delimiter so any / in GRUB_ARGS
+# (e.g. from DIB_BOOTLOADER_DEFAULT_CMDLINE) does not break the expression.
+# Then regenerate the GRUB config to apply the updated kernel parameters.
+sed -i "s|^GRUB_CMDLINE_LINUX=.*|GRUB_CMDLINE_LINUX=\"${GRUB_ARGS}\"|" /etc/default/grub
 grub2-mkconfig --output=/boot/grub2/grub.cfg

--- a/jenkins/image_building/dib_elements/leap-ci/install.d/55-install
+++ b/jenkins/image_building/dib_elements/leap-ci/install.d/55-install
@@ -6,5 +6,10 @@ set -eux
 sudo zypper refresh
 sudo zypper -n in atop sysstat
 
+# Switch from wicked to NetworkManager.
+sudo zypper -n in NetworkManager
+sudo systemctl disable wicked wickedd
+sudo systemctl enable NetworkManager
+
 # Add metal3ci user to libvirt group
 sudo usermod -aG libvirt metal3ci


### PR DESCRIPTION
This PR:
1. Makes networkManager default
2. Intalls virtio drivers to support paravirtualized mode of OCI
Paravirtualized mode requires virtio devices to properly boot image in OCI.
3. Set hostonly=no so the initrd is generic and  ensures the image boots
correctly on any target
4. Adds console parameters to ensure the image boots properly in OCI 