### PR TITLE
ignore otel 1.43 bump for release branches in osv-scanner job

### DIFF
--- a/jenkins/jobs/osv_scanner_metal3.groovy
+++ b/jenkins/jobs/osv_scanner_metal3.groovy
@@ -62,6 +62,22 @@ def runOsvScan = { String repoName, String refType, String ref, String repoUrl, 
         try { gv = sh(script: 'make go-version', returnStdout: true).trim() } catch (e) { echo "make go-version failed: ${e}" }
         gv = gv ?: goVersion
         sh "echo 'GoVersionOverride = \"${gv}\"' > config.toml"
+        // GHSA-hfvc-g4fc-pqhx: BSD/Solaris-only PATH hijack in otel kenv; fix requires otel v1.43.0 (Go 1.25).
+        // Only affects release branches where otel cannot be bumped due to Go version constraint.
+        def ignoredBranches = [
+            'CAPM3': ~/^release-1\.(1[0-2]|[0-9])$/,
+            'IPAM':  ~/^release-1\.(1[0-2]|[0-9])$/,
+            'BMO':   ~/^release-0\.(1[0-2]|[0-9])$/,
+            'IRSO':  ~/^release-0\.([0-8])$/,
+        ]
+        if (ignoredBranches[repoName]?.matcher(ref)?.matches()) {
+            sh '''
+                echo '' >> config.toml
+                echo '[[IgnoredVulns]]' >> config.toml
+                echo 'id = "GHSA-hfvc-g4fc-pqhx"' >> config.toml
+                echo 'reason = "BSD/Solaris-only PATH hijack via kenv; not applicable to Linux deployments. Fix requires otel v1.43.0 which needs Go 1.25."' >> config.toml
+            '''
+        }
 
         def label   = "${repoName}-${refType}-${ref}".replace('/', '_')
         def outFile = "${WORKSPACE}/results/${repoName}_${refType}_${ref}.txt".replace('/', '_')


### PR DESCRIPTION
[otel 1.43 bump has vuln fix for BSD only](https://osv.dev/vulnerability/GHSA-hfvc-g4fc-pqhx), but it requires go 1.25 so we cannot bump it for no value in release branches. Just silence the vuln for branches. It has been bumped in main.

Silencing will make the osv-scanner job valuable again, otherwise it'll fail until 1.12 falls out of maintenance, which is 5 months away.

Global config file applies to all submodule go.mod files. If the config file would be placed in the repo and auto-discovered, each ignore would apply only to go.mod next to it. In CAPM3 case, that'd be 3 files in both release branches. Putting it in the global ignore solves the whole thing with one PR.