### PR TITLE
Fix agent label for pre-release test

### DIFF
--- a/jenkins/jobs/pre_release_tests.groovy
+++ b/jenkins/jobs/pre_release_tests.groovy
@@ -19,11 +19,7 @@ script {
     }
     echo "Checkout ${ci_git_url} branch ${ci_git_branch}"
 
-    if ( "${GINKGO_FOCUS}" == 'integration' ) {
-        agent_label = "metal3ci-4c16gb-${IMAGE_OS}-oci"
-    } else if ( "${GINKGO_FOCUS}" == 'k8s-upgrade' ) {
-        agent_label = "metal3ci-8c24gb-${IMAGE_OS}-oci"
-    }
+    agent_label = "metal3ci-8c32gb-${IMAGE_OS}-oci"
 }
 
 pipeline {


### PR DESCRIPTION
After moving the test to OCI we only have one type of agent which is 8C32gb- . Fixing it for pre-release test since it is now stuck finding the wrong agents.