### PR TITLE
Add cleanup step in fullstack pipeline

### DIFF
--- a/jenkins/jobs/dynamic_fullstack_building.groovy
+++ b/jenkins/jobs/dynamic_fullstack_building.groovy
@@ -92,5 +92,12 @@ pipeline {
                 archiveArtifacts "logs-${env.BUILD_TAG}.tgz"
             }
         }
+        cleanup {
+            script {
+                timestamps {
+                    sh './jenkins/scripts/dynamic_worker_workflow/run_clean.sh'
+                }
+            }
+        }
     }
 }


### PR DESCRIPTION
We might reuse jenkins agents some edge cases. Test folders/artifacts needs to be cleaned after it finishes/fails