### PR TITLE
Add copilot-review plugin and related resources

### DIFF
--- a/prow/manifests/overlays/metal3/external-plugins/copilot-review-deployment.yaml
+++ b/prow/manifests/overlays/metal3/external-plugins/copilot-review-deployment.yaml
@@ -1,0 +1,67 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  namespace: prow
+  name: copilot-review
+  labels:
+    app: copilot-review
+spec:
+  replicas: 1
+  strategy:
+    type: RollingUpdate
+    rollingUpdate:
+      maxSurge: 1
+      maxUnavailable: 0
+  selector:
+    matchLabels:
+      app: copilot-review
+  template:
+    metadata:
+      labels:
+        app: copilot-review
+    spec:
+      serviceAccountName: ""
+      serviceAccount: ""
+      terminationGracePeriodSeconds: 180
+      containers:
+      - name: copilot-review
+        image: quay.io/metal3-io/copilot-review-prow-plugin:main_2026-05-27_bb9e4a9a3422eb9a7b5ed78b0190a0f46f7d2a95
+        imagePullPolicy: Always
+        args:
+        - --hmac-secret-file=/etc/webhook/hmac
+        - --github-token-path=/etc/github/token
+        - --github-endpoint=http://ghproxy
+        - --github-endpoint=https://api.github.com
+        - --github-graphql-endpoint=http://ghproxy/graphql
+        - --dry-run=false
+        env:
+        # This is token for requesting review
+        # This token is separate from github token meant for adding comments to PR
+        - name: COPILOT_REVIEW_TOKEN
+          valueFrom:
+            secretKeyRef:
+              name: copilot-review-github-token
+              key: token
+        ports:
+        - name: http
+          containerPort: 8888
+        volumeMounts:
+        - name: hmac
+          mountPath: /etc/webhook
+          readOnly: true
+        - name: github-token
+          mountPath: /etc/github
+          readOnly: true
+        - name: tmp
+          mountPath: /tmp
+      volumes:
+      - name: tmp
+        emptyDir: {}
+      - name: hmac
+        secret:
+          secretName: hmac-token
+      - name: github-token
+      # This is the BOT token for adding comments to PR,
+      # this is separate from token used for requesting review.
+        secret:
+          secretName: github-token

--- a/prow/manifests/overlays/metal3/external-plugins/copilot-review-service.yaml
+++ b/prow/manifests/overlays/metal3/external-plugins/copilot-review-service.yaml
@@ -1,0 +1,12 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: copilot-review
+  namespace: prow
+spec:
+  selector:
+    app: copilot-review
+  ports:
+  - port: 80
+    targetPort: 8888
+  type: ClusterIP

--- a/prow/manifests/overlays/metal3/kustomization.yaml
+++ b/prow/manifests/overlays/metal3/kustomization.yaml
@@ -11,6 +11,8 @@ resources:
 - external-plugins/needs-rebase_service.yaml
 - external-plugins/labels_cronjob.yaml
 - external-plugins/jenkins-operator.yaml
+- external-plugins/copilot-review-deployment.yaml
+- external-plugins/copilot-review-service.yaml
 - pdb.yaml
 - limitrange.yaml
 - prow-externalsecrets.yaml
@@ -30,6 +32,7 @@ patches:
 - path: patches/cherrypicker.yaml
 - path: patches/needs-rebase.yaml
 - path: patches/jenkins-operator.yaml
+- path: patches/copilot-review.yaml
 # Run on infra nodes
 - path: toleration-node-selector-patch.yaml
   target:

--- a/prow/manifests/overlays/metal3/patches/copilot-review.yaml
+++ b/prow/manifests/overlays/metal3/patches/copilot-review.yaml
@@ -1,0 +1,14 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  namespace: prow
+  name: copilot-review
+spec:
+  template:
+    spec:
+      containers:
+      - name: copilot-review
+        resources:
+          requests:
+            cpu: 50m
+            memory: 20Mi

--- a/prow/manifests/overlays/metal3/prow-externalsecrets.yaml
+++ b/prow/manifests/overlays/metal3/prow-externalsecrets.yaml
@@ -82,3 +82,20 @@ spec:
     remoteRef:
       # <item-name>/[section-name/]<field-name>
       key: "prow-jenkins-token/password"
+---
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: copilot-review-github-token
+  namespace: prow
+spec:
+  secretStoreRef:
+    kind: ClusterSecretStore
+    name: onepassword
+  target:
+    creationPolicy: Owner
+  data:
+  - secretKey: token
+    remoteRef:
+      # <item-name>/[section-name/]<field-name>
+      key: "prow-copilot-review-github-token/password"


### PR DESCRIPTION
## Deploy copilot-review Prow external plugin

This PR adds the `copilot-review` external plugin to the Prow deployment. The plugin listens for `issue_comment` events and enables AI-assisted code review on pull requests.

### Changes

- **Plugin registration** (`prow/config/plugins.yaml`): Register `copilot-review` as an external plugin listening on `issue_comment` events.
- **Deployment & Service** (`prow/manifests/overlays/metal3/external-plugins/`): Add Deployment and ClusterIP Service for the plugin. The deployment mounts HMAC and GitHub token secrets and exposes port 8888.
- **Resource limits patch** (`prow/manifests/overlays/metal3/patches/copilot-review.yaml`): Set CPU/memory resource requests (50m / 20Mi).
- **External secrets** (`prow/manifests/overlays/metal3/prow-externalsecrets.yaml`): Add two `ExternalSecret` resources to provision the bot GitHub token and the Copilot review token from 1Password.
- **Kustomization** (`prow/manifests/overlays/metal3/kustomization.yaml`): Wire up the new resources and patch.

### Notes

- The container image is currently a placeholder (`<image>`) and needs to be updated once a release is available.
- Two separate tokens are used: one for adding PR comments (bot token) and one for requesting reviews (Copilot review token).