### PR TITLE
Add release 1.13 tests and update triggers

### DIFF
--- a/jenkins/README.md
+++ b/jenkins/README.md
@@ -27,6 +27,10 @@ the commands below. The job result will be posted as a comment.
   v1beta1 and branch main on Ubuntu
 * **/test-centos-integration-main** run integration tests with CAPM3 API version
   v1beta1 and branch main on CentOS
+* **/test-ubuntu-integration-release-1-13** run integration tests with CAPM3 API
+  version v1beta1 and branch release-1.13 on Ubuntu
+* **/test-centos-integration-release-1-13** run integration tests with CAPM3 API
+  version v1beta1 and branch release-1.13 on CentOS
 * **/test-ubuntu-integration-release-1-12** run integration tests with CAPM3 API
   version v1beta1 and branch release-1.12 on Ubuntu
 * **/test-centos-integration-release-1-12** run integration tests with CAPM3 API

--- a/prow/config/jobs/metal3-io/ironic-image-release-35.0.yaml
+++ b/prow/config/jobs/metal3-io/ironic-image-release-35.0.yaml
@@ -33,25 +33,25 @@ presubmits:
         image: docker.io/pipelinecomponents/markdownlint-cli2:0.12.0@sha256:a3977fba9814f10d33a1d69ae607dc808e7a6470b2ba03e84c17193c0791aac0
         imagePullPolicy: Always
   # name: {job_prefix}-{image_os}-e2e-integration-test-{capm3_target_branch}
-  - name: metal3-centos-e2e-integration-test-release-1-12
+  - name: metal3-centos-e2e-integration-test-release-1-13
     branches:
     - release-35.0
     agent: jenkins
     always_run: false
     optional: false
-  - name: metal3-ubuntu-e2e-integration-test-release-1-12
+  - name: metal3-ubuntu-e2e-integration-test-release-1-13
     branches:
     - release-35.0
     agent: jenkins
     always_run: false
     optional: false
-  - name: metal3-dev-env-integration-test-centos-release-1-12
+  - name: metal3-dev-env-integration-test-centos-release-1-13
     branches:
     - release-35.0
     agent: jenkins
     always_run: false
     optional: true
-  - name: metal3-dev-env-integration-test-ubuntu-release-1-12
+  - name: metal3-dev-env-integration-test-ubuntu-release-1-13
     branches:
     - release-35.0
     agent: jenkins

--- a/prow/config/jobs/metal3-io/ironic-ipa-downloader.yaml
+++ b/prow/config/jobs/metal3-io/ironic-ipa-downloader.yaml
@@ -33,6 +33,10 @@ presubmits:
     agent: jenkins
     always_run: false
     optional: false
+  - name: metal3-centos-e2e-integration-test-release-1-13
+    agent: jenkins
+    always_run: false
+    optional: true
   - name: metal3-centos-e2e-integration-test-release-1-12
     agent: jenkins
     always_run: false
@@ -46,6 +50,10 @@ presubmits:
     always_run: false
     optional: true
   - name: metal3-ubuntu-e2e-integration-test-main
+    agent: jenkins
+    always_run: false
+    optional: true
+  - name: metal3-ubuntu-e2e-integration-test-release-1-13
     agent: jenkins
     always_run: false
     optional: true

--- a/prow/config/jobs/metal3-io/mariadb-image.yaml
+++ b/prow/config/jobs/metal3-io/mariadb-image.yaml
@@ -33,6 +33,10 @@ presubmits:
     agent: jenkins
     always_run: false
     optional: true
+  - name: metal3-centos-e2e-integration-test-release-1-13
+    agent: jenkins
+    always_run: false
+    optional: true
   - name: metal3-centos-e2e-integration-test-release-1-12
     agent: jenkins
     always_run: false
@@ -49,6 +53,10 @@ presubmits:
     agent: jenkins
     always_run: false
     optional: false
+  - name: metal3-ubuntu-e2e-integration-test-release-1-13
+    agent: jenkins
+    always_run: false
+    optional: true
   - name: metal3-ubuntu-e2e-integration-test-release-1-12
     agent: jenkins
     always_run: false

--- a/prow/config/jobs/metal3-io/metal3-dev-env.yaml
+++ b/prow/config/jobs/metal3-io/metal3-dev-env.yaml
@@ -47,6 +47,10 @@ presubmits:
     agent: jenkins
     always_run: false
     optional: true
+  - name: metal3-centos-e2e-basic-test-release-1-13
+    agent: jenkins
+    always_run: false
+    optional: true
   - name: metal3-centos-e2e-basic-test-release-1-12
     agent: jenkins
     always_run: false
@@ -60,6 +64,10 @@ presubmits:
     always_run: false
     optional: true
   - name: metal3-ubuntu-e2e-basic-test-main
+    agent: jenkins
+    always_run: false
+    optional: true
+  - name: metal3-ubuntu-e2e-basic-test-release-1-13
     agent: jenkins
     always_run: false
     optional: true
@@ -80,6 +88,10 @@ presubmits:
     agent: jenkins
     always_run: false
     optional: true
+  - name: metal3-centos-e2e-integration-test-release-1-13
+    agent: jenkins
+    always_run: false
+    optional: false
   - name: metal3-centos-e2e-integration-test-release-1-12
     agent: jenkins
     always_run: false
@@ -93,6 +105,10 @@ presubmits:
     always_run: false
     optional: true
   - name: metal3-ubuntu-e2e-integration-test-main
+    agent: jenkins
+    always_run: false
+    optional: true
+  - name: metal3-ubuntu-e2e-integration-test-release-1-13
     agent: jenkins
     always_run: false
     optional: true
@@ -113,6 +129,10 @@ presubmits:
     agent: jenkins
     always_run: false
     optional: true
+  - name: metal3-centos-e2e-feature-test-release-1-13-pivoting
+    agent: jenkins
+    always_run: false
+    optional: true
   - name: metal3-centos-e2e-feature-test-release-1-12-pivoting
     agent: jenkins
     always_run: false
@@ -126,6 +146,10 @@ presubmits:
     always_run: false
     optional: true
   - name: metal3-centos-e2e-feature-test-main-remediation
+    agent: jenkins
+    always_run: false
+    optional: true
+  - name: metal3-centos-e2e-feature-test-release-1-13-remediation
     agent: jenkins
     always_run: false
     optional: true
@@ -145,6 +169,10 @@ presubmits:
     agent: jenkins
     always_run: false
     optional: true
+  - name: metal3-centos-e2e-feature-test-release-1-13-features
+    agent: jenkins
+    always_run: false
+    optional: true
   - name: metal3-centos-e2e-feature-test-release-1-12-features
     agent: jenkins
     always_run: false
@@ -158,6 +186,10 @@ presubmits:
     always_run: false
     optional: true
   - name: metal3-ubuntu-e2e-feature-test-main-pivoting
+    agent: jenkins
+    always_run: false
+    optional: true
+  - name: metal3-ubuntu-e2e-feature-test-release-1-13-pivoting
     agent: jenkins
     always_run: false
     optional: true
@@ -177,6 +209,10 @@ presubmits:
     agent: jenkins
     always_run: false
     optional: true
+  - name: metal3-ubuntu-e2e-feature-test-release-1-13-remediation
+    agent: jenkins
+    always_run: false
+    optional: true
   - name: metal3-ubuntu-e2e-feature-test-release-1-12-remediation
     agent: jenkins
     always_run: false
@@ -190,6 +226,10 @@ presubmits:
     always_run: false
     optional: true
   - name: metal3-ubuntu-e2e-feature-test-main-features
+    agent: jenkins
+    always_run: false
+    optional: true
+  - name: metal3-ubuntu-e2e-feature-test-release-1-13-features
     agent: jenkins
     always_run: false
     optional: true
@@ -210,6 +250,10 @@ presubmits:
     agent: jenkins
     always_run: false
     optional: true
+  - name: metal3-e2e-clusterctl-upgrade-test-release-1-13
+    agent: jenkins
+    always_run: false
+    optional: true
   - name: metal3-e2e-clusterctl-upgrade-test-release-1-12
     agent: jenkins
     always_run: false
@@ -224,6 +268,10 @@ presubmits:
     optional: true
   # name: {job_prefix}-e2e-{k8s_versions}-upgrade-test-{capm3_target_branch}
   - name: metal3-e2e-1-29-1-30-upgrade-test-main
+    agent: jenkins
+    always_run: false
+    optional: true
+  - name: metal3-e2e-1-29-1-30-upgrade-test-release-1-13
     agent: jenkins
     always_run: false
     optional: true
@@ -243,6 +291,10 @@ presubmits:
     agent: jenkins
     always_run: false
     optional: true
+  - name: metal3-dev-env-integration-test-centos-release-1-13
+    agent: jenkins
+    always_run: false
+    optional: true
   - name: metal3-dev-env-integration-test-centos-release-1-12
     agent: jenkins
     always_run: false
@@ -259,6 +311,10 @@ presubmits:
     agent: jenkins
     always_run: false
     optional: false
+  - name: metal3-dev-env-integration-test-ubuntu-release-1-13
+    agent: jenkins
+    always_run: false
+    optional: true
   - name: metal3-dev-env-integration-test-ubuntu-release-1-12
     agent: jenkins
     always_run: false

--- a/prow/config/plugins.yaml
+++ b/prow/config/plugins.yaml
@@ -178,17 +178,20 @@ triggers:
 
 milestone_applier:
   metal3-io/cluster-api-provider-metal3:
-    main: "CAPM3 - v1.13"
+    main: "CAPM3 - v1.14"
+    release-1.13: "CAPM3 - v1.13"
     release-1.12: "CAPM3 - v1.12"
     release-1.11: "CAPM3 - v1.11"
     release-1.10: "CAPM3 - v1.10"
   metal3-io/baremetal-operator:
-    main: "BMO - v0.13"
+    main: "BMO - v0.14"
+    release-0.13: "BMO - v0.13"
     release-0.12: "BMO - v0.12"
     release-0.11: "BMO - v0.11"
     release-0.10: "BMO - v0.10"
   metal3-io/ip-address-manager:
-    main: "IPAM - v1.13"
+    main: "IPAM - v1.14"
+    release-1.13: "IPAM - v1.13"
     release-1.12: "IPAM - v1.12"
     release-1.11: "IPAM - v1.11"
     release-1.10: "IPAM - v1.10"


### PR DESCRIPTION
This PR :
- Updates milestone applier
- Update ironic image release 35.0 tests with release-1.13 triggers
- Add release-1.13 tests for dev-env, ipa and mariadb
