### PR TITLE
Prow: Fix CPO node selector

### DIFF
--- a/prow/cluster-resources/kustomization.yaml
+++ b/prow/cluster-resources/kustomization.yaml
@@ -37,6 +37,19 @@ patches:
   target:
     kind: Deployment
     name: csi-cinder-controllerplugin|calico-kube-controllers
+# Fix node-selector for openstack cloud controller manager
+# Upstream selects nodes with "node-role.kubernetes.io/control-plane=true" but we want to use the kubeadm default
+# which is empty value for the same key.
+# This is only needed for v1.34, so we can remove this when we update to v1.35.
+# See https://github.com/kubernetes/cloud-provider-openstack/blob/a031201ff26f3df433192b91df2be0e7d50acb70/manifests/controller-manager/openstack-cloud-controller-manager-ds.yaml#L31
+- patch: |-
+    - op: replace
+      path: /spec/template/spec/nodeSelector
+      value:
+        node-role.kubernetes.io/control-plane: ""
+  target:
+    kind: DaemonSet
+    name: openstack-cloud-controller-manager
 
 ## If there is ever a need to deploy without ESO, the following can be used to create the secret directly.
 # generatorOptions:


### PR DESCRIPTION
The node-selector was changed upstream in v1.34 and I missed it. Fix it with a patch.
Changes are already applied and confirmed working.