### PR TITLE
Fix agent label for bmo optional tests

### DIFF
--- a/jenkins/jobs/bmo_e2e_optional_tests.groovy
+++ b/jenkins/jobs/bmo_e2e_optional_tests.groovy
@@ -14,7 +14,7 @@ pipeline {
     stages {
         stage('Run Baremetal Operator optional e2e tests') {
             matrix {
-                agent { label 'metal3ci-4c16gb-ubuntu-oci' }
+                agent { label 'metal3ci-8c32gb-ubuntu-oci' }
                 axes {
                     axis {
                         name 'BMC_PROTOCOL'


### PR DESCRIPTION
Sets Jenkins agent label to "metal3ci-8c32gb-ubuntu-oci" for bmo e2e optional tests