### PR TITLE
Fix cleaning for fullstack build

### DIFF
--- a/jenkins/jobs/dynamic_fullstack_building.groovy
+++ b/jenkins/jobs/dynamic_fullstack_building.groovy
@@ -38,6 +38,11 @@ pipeline {
                      ).trim()
         // jenkins job auto generates
         BUILD_TAG = "${env.BUILD_TAG}"
+        // set dev environment directory for the fullstack script
+        DEV_ENV_REPO_LOCATION = sh(
+                                script: 'echo $HOME/metal3',
+                                returnStdout: true
+                               ).trim()
     }
     stages {
         stage('Building and testing full Metal3 stack') {

--- a/jenkins/scripts/dynamic_worker_workflow/build_ipa.sh
+++ b/jenkins/scripts/dynamic_worker_workflow/build_ipa.sh
@@ -185,7 +185,7 @@ fi
 # Test whether the newly built IPA is compatible with the choosen Ironic version and with
 # the Metal3 dev-env
 if $ENABLE_BOOTSTRAP_TEST; then
-    git clone --single-branch --branch "${METAL3_DEV_ENV_BRANCH}" "${METAL3_DEV_ENV_REPO}"
+    git clone --single-branch --branch "${METAL3_DEV_ENV_BRANCH}" "${METAL3_DEV_ENV_REPO}" "${DEV_ENV_REPO_LOCATION}"
     if $TEST_IN_CI; then
         # shellcheck source=/dev/null
         source "/tmp/vars.sh"
@@ -285,4 +285,3 @@ if ! $DISABLE_UPLOAD ; then
         rt_upload_artifact  "${IPA_IMAGE_TAR}" "${REVIEW_ARTIFACTORY_PATH}" "0"
     fi
 fi
-

--- a/jenkins/scripts/dynamic_worker_workflow/run_clean.sh
+++ b/jenkins/scripts/dynamic_worker_workflow/run_clean.sh
@@ -2,6 +2,8 @@
 
 set -eux
 
+IMAGE_OS="${IMAGE_OS:-ubuntu}"
+
 if [[ "${IMAGE_OS}" == "ubuntu" ]]; then
     export CONTAINER_RUNTIME="docker"
     export BOOTSTRAP_CLUSTER="kind"


### PR DESCRIPTION
Default to Ubuntu in case `OS_IMAGE` is not defined when running clean up. This fixes the `IMAGE_OS: unbound variable` error.

Specify `DEV_ENV_REPO_LOCATION` as the destination directory when cloning metal3-dev-env, so the clone lands in the expected location.
