### PR TITLE
cleanup: remove bmo upgrade tests from Prow

### DIFF
--- a/prow/config/jobs/metal3-io/baremetal-operator-release-0.12.yaml
+++ b/prow/config/jobs/metal3-io/baremetal-operator-release-0.12.yaml
@@ -170,12 +170,6 @@ presubmits:
     agent: jenkins
     always_run: false
     optional: true
-  - name: metal3-e2e-1-34-1-35-upgrade-test-release-1-12
-    branches:
-    - release-0.12
-    agent: jenkins
-    always_run: false
-    optional: true
   - name: metal3-dev-env-integration-test-centos-release-1-12
     branches:
     - release-0.12

--- a/prow/config/jobs/metal3-io/baremetal-operator-release-0.13.yaml
+++ b/prow/config/jobs/metal3-io/baremetal-operator-release-0.13.yaml
@@ -170,12 +170,6 @@ presubmits:
     agent: jenkins
     always_run: false
     optional: true
-  - name: metal3-e2e-1-34-1-35-upgrade-test-release-1-13
-    branches:
-    - release-0.13
-    agent: jenkins
-    always_run: false
-    optional: true
   - name: metal3-dev-env-integration-test-centos-release-1-13
     branches:
     - release-0.13

--- a/prow/config/jobs/metal3-io/baremetal-operator.yaml
+++ b/prow/config/jobs/metal3-io/baremetal-operator.yaml
@@ -174,13 +174,6 @@ presubmits:
     agent: jenkins
     always_run: false
     optional: true
-  # name: {job_prefix}-e2e-{k8s_versions}-upgrade-test-{capm3_target_branch}
-  - name: metal3-e2e-1-34-1-35-upgrade-test-main
-    branches:
-    - main
-    agent: jenkins
-    always_run: false
-    optional: true
   - name: metal3-dev-env-integration-test-centos-main
     branches:
     - main


### PR DESCRIPTION
There is no corresponding JJB nor do we plan to run upgrade tests on BMO. 