### PR TITLE
Prow: Upgrade traefik to v3.6.17

### DIFF
--- a/prow/infra/traefik/kustomization.yaml
+++ b/prow/infra/traefik/kustomization.yaml
@@ -1,5 +1,5 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
-- https://github.com/traefik/traefik-helm-chart/traefik/crds?ref=v39.0.6
+- https://github.com/traefik/traefik-helm-chart/traefik/crds?ref=v39.0.9
 - resources.yaml

--- a/prow/infra/traefik/resources.yaml
+++ b/prow/infra/traefik/resources.yaml
@@ -3,7 +3,7 @@
 # Generate like this:
 # helm repo add traefik https://traefik.github.io/charts
 # helm repo update
-# helm template traefik traefik/traefik --version 39.0.6 \
+# helm template traefik traefik/traefik --version 39.0.9 \
 #   --namespace traefik \
 #   --api-versions policy/v1/PodDisruptionBudget \
 #   --values infra/traefik/traefik-values.yaml > infra/traefik/resources.yaml
@@ -16,7 +16,7 @@ metadata:
   labels:
     app.kubernetes.io/name: traefik
     app.kubernetes.io/instance: traefik-traefik
-    helm.sh/chart: traefik-39.0.6
+    helm.sh/chart: traefik-39.0.9
     app.kubernetes.io/managed-by: Helm
 spec:
   selector:
@@ -34,7 +34,7 @@ metadata:
   labels:
     app.kubernetes.io/name: traefik
     app.kubernetes.io/instance: traefik-traefik
-    helm.sh/chart: traefik-39.0.6
+    helm.sh/chart: traefik-39.0.9
     app.kubernetes.io/managed-by: Helm
   annotations:
 automountServiceAccountToken: false
@@ -47,7 +47,7 @@ metadata:
   labels:
     app.kubernetes.io/name: traefik
     app.kubernetes.io/instance: traefik-traefik
-    helm.sh/chart: traefik-39.0.6
+    helm.sh/chart: traefik-39.0.9
     app.kubernetes.io/managed-by: Helm
 rules:
 - apiGroups:
@@ -153,7 +153,7 @@ metadata:
   labels:
     app.kubernetes.io/name: traefik
     app.kubernetes.io/instance: traefik-traefik
-    helm.sh/chart: traefik-39.0.6
+    helm.sh/chart: traefik-39.0.9
     app.kubernetes.io/managed-by: Helm
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -173,7 +173,7 @@ metadata:
   labels:
     app.kubernetes.io/name: traefik
     app.kubernetes.io/instance: traefik-traefik
-    helm.sh/chart: traefik-39.0.6
+    helm.sh/chart: traefik-39.0.9
     app.kubernetes.io/managed-by: Helm
   annotations:
     loadbalancer.openstack.org/keep-floatingip: "true"
@@ -203,7 +203,7 @@ metadata:
   labels:
     app.kubernetes.io/name: traefik
     app.kubernetes.io/instance: traefik-traefik
-    helm.sh/chart: traefik-39.0.6
+    helm.sh/chart: traefik-39.0.9
     app.kubernetes.io/managed-by: Helm
   annotations:
 spec:
@@ -229,7 +229,7 @@ spec:
         app.kubernetes.io/instance: traefik-traefik
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: traefik
-        helm.sh/chart: traefik-39.0.6
+        helm.sh/chart: traefik-39.0.9
     spec:
       automountServiceAccountToken: true
       containers:
@@ -260,7 +260,7 @@ spec:
               fieldPath: metadata.namespace
         - name: USER
           value: traefik
-        image: docker.io/traefik:v3.6.11
+        image: docker.io/traefik:v3.6.17
         imagePullPolicy: IfNotPresent
         lifecycle: null
         livenessProbe:
@@ -339,7 +339,7 @@ metadata:
   labels:
     app.kubernetes.io/name: traefik
     app.kubernetes.io/instance: traefik-traefik
-    helm.sh/chart: traefik-39.0.6
+    helm.sh/chart: traefik-39.0.9
     app.kubernetes.io/managed-by: Helm
   name: traefik
 spec:
@@ -354,7 +354,7 @@ metadata:
   labels:
     app.kubernetes.io/name: traefik
     app.kubernetes.io/instance: traefik-traefik
-    helm.sh/chart: traefik-39.0.6
+    helm.sh/chart: traefik-39.0.9
     app.kubernetes.io/managed-by: Helm
 spec:
   gatewayClassName: traefik
@@ -392,7 +392,7 @@ metadata:
   labels:
     app.kubernetes.io/name: traefik
     app.kubernetes.io/instance: traefik-traefik
-    helm.sh/chart: traefik-39.0.6
+    helm.sh/chart: traefik-39.0.9
     app.kubernetes.io/managed-by: Helm
 spec:
   controllerName: traefik.io/gateway-controller

--- a/prow/infra/traefik/traefik-values.yaml
+++ b/prow/infra/traefik/traefik-values.yaml
@@ -1,3 +1,6 @@
+image:
+  tag: v3.6.17
+
 providers:
   kubernetesIngress:
     enabled: false


### PR DESCRIPTION
The helm chart is upgraded to 39.0.9, which is the latest version compatible with traefik v3.6.