### PR TITLE
Prow: Bump CAPI operator to v0.23.1

### DIFF
--- a/prow/capi/kustomization.yaml
+++ b/prow/capi/kustomization.yaml
@@ -2,7 +2,7 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
 - https://github.com/cert-manager/cert-manager/releases/download/v1.18.5/cert-manager.yaml
-- https://github.com/kubernetes-sigs/cluster-api-operator/releases/download/v0.22.0/operator-components.yaml
+- https://github.com/kubernetes-sigs/cluster-api-operator/releases/download/v0.23.1/operator-components.yaml
 # ORC is needed for CAPO
 - https://github.com/k-orc/openstack-resource-controller/releases/download/v2.2.0/install.yaml
 - core.yaml


### PR DESCRIPTION
Upgrading one minor version at a time. We are a bit behind.

These changes are applied automatically by Flux.