### PR TITLE
Prow: Upgrade CAPI to v1.11.11

### DIFF
--- a/prow/capi/bootstrap.yaml
+++ b/prow/capi/bootstrap.yaml
@@ -4,7 +4,7 @@ metadata:
   name: kubeadm
   namespace: capi-kubeadm-bootstrap-system
 spec:
-  version: v1.10.4
+  version: v1.11.11
   deployment:
     nodeSelector:
       node-role.kubernetes.io/infra: ""

--- a/prow/capi/control-plane.yaml
+++ b/prow/capi/control-plane.yaml
@@ -4,7 +4,7 @@ metadata:
   name: kubeadm
   namespace: capi-kubeadm-control-plane-system
 spec:
-  version: v1.10.4
+  version: v1.11.11
   deployment:
     nodeSelector:
       node-role.kubernetes.io/infra: ""

--- a/prow/capi/core.yaml
+++ b/prow/capi/core.yaml
@@ -4,7 +4,7 @@ metadata:
   name: cluster-api
   namespace: capi-system
 spec:
-  version: v1.10.4
+  version: v1.11.11
   deployment:
     nodeSelector:
       node-role.kubernetes.io/infra: ""

--- a/prow/capi/infrastructure.yaml
+++ b/prow/capi/infrastructure.yaml
@@ -4,7 +4,7 @@ metadata:
   name: openstack
   namespace: capo-system
 spec:
-  version: v0.12.4
+  version: v0.12.7
   deployment:
     nodeSelector:
       node-role.kubernetes.io/infra: ""


### PR DESCRIPTION
One minor version at a time. We keep CAPO on v0.12 (but take the latest patch), since v0.13 requires CAPI v1beta2 API to be available.