### PR TITLE
Pin Java 21 packages in CI images

### DIFF
--- a/jenkins/image_building/dib_elements/centos-ci/post-install.d/55-configure
+++ b/jenkins/image_building/dib_elements/centos-ci/post-install.d/55-configure
@@ -7,7 +7,7 @@ sudo sed -i "0,/.*PermitRootLogin.*/s//PermitRootLogin yes/" /etc/ssh/sshd_confi
 
 # SETUP MONITORING
 ## Install atop and sysstat
-sudo dnf install sysstat atop --enablerepo=epel -y 
+sudo dnf install sysstat atop --enablerepo=epel -y
 
 ## Collect all metrics every minute
 sudo sed -i 's/^LOGINTERVAL=600.*/LOGINTERVAL=60/' /etc/sysconfig/atop
@@ -28,3 +28,7 @@ sudo systemctl enable atop.service crond.service sysstat.service
 
 # Change default to shell to bash
 sudo usermod --shell /bin/bash metal3ci
+
+# Hold JDK packages to prevent unintended upgrades
+sudo dnf install python3-dnf-plugin-versionlock -y
+sudo dnf versionlock add java-21-openjdk java-21-openjdk-headless

--- a/jenkins/image_building/dib_elements/leap-ci/post-install.d/55-configure
+++ b/jenkins/image_building/dib_elements/leap-ci/post-install.d/55-configure
@@ -44,3 +44,6 @@ sudo usermod --shell /bin/bash metal3ci
 ## Add /usr/local/bin/
 sed -i -e "/secure_path/ s@\([\'\"]\?\)\$@:/usr/local/bin/\1@" /etc/sudoers
 visudo -c
+
+# Hold JDK packages to prevent unintended upgrades
+sudo zypper addlock java-21-openjdk*

--- a/jenkins/image_building/dib_elements/ubuntu-ci/post-install.d/configure
+++ b/jenkins/image_building/dib_elements/ubuntu-ci/post-install.d/configure
@@ -154,3 +154,6 @@ sudo systemctl enable atop.service cron.service sysstat.service
 
 # Change default to shell to bash
 sudo usermod --shell /bin/bash metal3ci
+
+# Hold JDK packages to prevent unintended upgrades
+sudo apt-mark hold openjdk-21-jre-headless openjdk-21-jre


### PR DESCRIPTION
Add package locks/holds for JDK 21 on CentOS, openSUSE Leap, and Ubuntu CI images to prevent unintended upgrades during subsequent image builds or package updates.

- CentOS: Install dnf versionlock and pin java-21-openjdk
- Leap: Use zypper addlock to lock java-21-openjdk*
- Ubuntu: Use apt-mark hold to lock openjdk-21-jre