### PR TITLE
Change scalability timeout to 5h

### DIFF
--- a/jenkins/jobs/capm3-e2e-tests.groovy
+++ b/jenkins/jobs/capm3-e2e-tests.groovy
@@ -33,13 +33,13 @@ script {
   } else if ( "${GINKGO_FOCUS}" == 'k8s-upgrade' ) {
         agent_label = "metal3ci-8c32gb-${IMAGE_OS}-oci"
         TIMEOUT = 14400 // 4h
-  } else if ( "${GINKGO_FOCUS}" == 'k8s-upgrade-n3' ) {
+  } else if ( "${GINKGO_FOCUS}" == 'k8s-upgrade-n3' || "${GINKGO_FOCUS}" == 'scalability' ) {
         agent_label = "metal3ci-8c32gb-${IMAGE_OS}-oci"
         TIMEOUT = 18000 // 5h
   } else if ( "${GINKGO_FOCUS}" == 'k8s-conformance' ) {
         TIMEOUT = 7200 // 2h
         agent_label = "metal3ci-8c32gb-${IMAGE_OS}-oci"
-  } else if ( "${GINKGO_FOCUS}" == 'capi-md-tests'  || "${GINKGO_FOCUS}" == 'scalability') {
+  } else if ( "${GINKGO_FOCUS}" == 'capi-md-tests') {
         TIMEOUT = 10800 // 3h
         agent_label = "metal3ci-8c32gb-${IMAGE_OS}-oci"
   } else {


### PR DESCRIPTION
The job is constantly timing out. It is suspected that a change in CAPI e2e framework made the checks more rigid, and this is now causing the test to take longer.