### PR TITLE
Prow: Upgrade Kubernetes to v1.35.4

### DIFF
--- a/prow/README.md
+++ b/prow/README.md
@@ -116,34 +116,16 @@ Please see [infra/kube-prometheus](infra/kube-prometheus).
 ## Building node images
 
 The Kubernetes cluster where Prow runs needs pre-built images for the Nodes. We
-use [image-builder](https://github.com/kubernetes-sigs/image-builder) for this.
+use the same node images as in CI for this. You can find them in
+[Artifactory](https://artifactory.nordix.org/ui/native/metal3/images/).
 
-Here is how to build a node image directly in Xerces. See the
-[image-builder book](https://image-builder.sigs.k8s.io/capi/providers/openstack-remote.html)
-for more details. Start by creating a JSON file with relevant parameters for the
-image. Here is an example:
-
-```json
-{
-  "source_image": "19e017ae-2759-479c-90ac-a400a3f64678",
-  "networks": "29fd620e-8145-43a2-8140-5cec6a69f344",
-  "flavor": "c4m12-est",
-  "floating_ip_network": "internet",
-  "ssh_username": "ubuntu",
-  "volume_type": "",
-  "image_disk_format": "raw",
-  "kubernetes_deb_version": "1.33.5-1.1",
-  "kubernetes_rpm_version": "1.33.5",
-  "kubernetes_semver": "v1.33.5",
-  "kubernetes_series": "v1.33"
-}
-```
-
-Then build the image like this:
+In order to use them for the cluster in Xerces, we need to download them from Artifactory,
+convert them to raw and then upload to Xerces. Like this:
 
 ```bash
-cd images/capi
-PACKER_VAR_FILES=var_file.json make build-openstack-ubuntu-2404
+curl -O https://artifactory.nordix.org/artifactory/metal3/images/k8s_v1.35.4/UBUNTU_24.04_NODE_IMAGE_K8S_v1.35.4.qcow2
+qemu-img convert -f qcow2 -O raw UBUNTU_24.04_NODE_IMAGE_K8S_v1.35.4.qcow2 UBUNTU_24.04_NODE_IMAGE_K8S_v1.35.4.img.raw
+openstack image create --file UBUNTU_24.04_NODE_IMAGE_K8S_v1.35.4.img.raw ubuntu-2404-node-k8s-v1.35.4
 ```
 
 ## Create credentials

--- a/prow/capo-cluster/infra-md.yaml
+++ b/prow/capo-cluster/infra-md.yaml
@@ -27,5 +27,5 @@ spec:
       infrastructureRef:
         apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
         kind: OpenStackMachineTemplate
-        name: prow-worker-v1-34-3
-      version: v1.34.3
+        name: prow-worker-v1-35-4
+      version: v1.35.4

--- a/prow/capo-cluster/kubeadmcontrolplane.yaml
+++ b/prow/capo-cluster/kubeadmcontrolplane.yaml
@@ -28,6 +28,6 @@ spec:
     infrastructureRef:
       apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
       kind: OpenStackMachineTemplate
-      name: prow-control-plane-v1-34-3
+      name: prow-control-plane-v1-35-4
   replicas: 1
-  version: v1.34.3
+  version: v1.35.4

--- a/prow/capo-cluster/machinedeployment.yaml
+++ b/prow/capo-cluster/machinedeployment.yaml
@@ -23,5 +23,5 @@ spec:
       infrastructureRef:
         apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
         kind: OpenStackMachineTemplate
-        name: prow-worker-v1-34-3
-      version: v1.34.3
+        name: prow-worker-v1-35-4
+      version: v1.35.4

--- a/prow/capo-cluster/openstackmachinetemplates.yaml
+++ b/prow/capo-cluster/openstackmachinetemplates.yaml
@@ -1,7 +1,7 @@
 apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
 kind: OpenStackMachineTemplate
 metadata:
-  name: prow-control-plane-v1-33-5
+  name: prow-control-plane-v1-35-4
 spec:
   template:
     spec:
@@ -11,13 +11,13 @@ spec:
         name: prow-cloud-config
       image:
         filter:
-          name: ubuntu-2404-kube-v1.33.5
+          name: ubuntu-2404-node-k8s-v1.35.4
       sshKeyName: prow
 ---
 apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
 kind: OpenStackMachineTemplate
 metadata:
-  name: prow-worker-v1-33-5
+  name: prow-worker-v1-35-4
 spec:
   template:
     spec:
@@ -27,7 +27,7 @@ spec:
         name: prow-cloud-config
       image:
         filter:
-          name: ubuntu-2404-kube-v1.33.5
+          name: ubuntu-2404-node-k8s-v1.35.4
       sshKeyName: prow
 ---
 apiVersion: infrastructure.cluster.x-k8s.io/v1beta1


### PR DESCRIPTION
This also marks the switch from image-builder images to the node images we use in Metal3 CI.