### PR TITLE
Add 1.1.1.1 nameserver as fallback

### DIFF
--- a/prow/capo-cluster/openstackcluster.yaml
+++ b/prow/capo-cluster/openstackcluster.yaml
@@ -39,6 +39,7 @@ spec:
   - cidr: 10.6.0.0/24
     dnsNameservers:
     - 8.8.8.8
+    - 1.1.1.1
   bastion:
     enabled: true
     spec:


### PR DESCRIPTION
Add Cloudfare DNS nameserver in case Google's 8.8.8.8 server fails

Fixes: https://github.com/metal3-io/project-infra/issues/1284#issuecomment-4661140067