### PR TITLE
Add kernel parameters to print leap kernel log

### DIFF
--- a/jenkins/image_building/dib_elements/leap-node/finalise.d/51-edit-grub-config
+++ b/jenkins/image_building/dib_elements/leap-node/finalise.d/51-edit-grub-config
@@ -6,6 +6,22 @@
 # root filesystem and this cannot be modified. If we don't change the kernel
 # command line parameters, the image will try to look for nonexistent label
 # ROOT during boot and the boot will fail.
+#
+# We add serial console parameters (console=tty0 console=ttyS0,115200)
+# to ensure the image boots properly on platforms that use serial consoles
+# (Oracle Cloud), as well as that we get serial console output which eases
+# debugging.
 
-sed -i 's/GRUB_CMDLINE_LINUX.*/GRUB_CMDLINE_LINUX="root=LABEL=cloudimg-rootfs"/' /etc/default/grub
+GRUB_ARGS="root=LABEL=cloudimg-rootfs console=tty0 console=ttyS0,115200"
+
+# DIB_BOOTLOADER_DEFAULT_CMDLINE if set (e.g., net.ifnames=1 for node images)
+if [[ -n "${DIB_BOOTLOADER_DEFAULT_CMDLINE:-}" ]]; then
+  GRUB_ARGS="${DIB_BOOTLOADER_DEFAULT_CMDLINE} ${GRUB_ARGS}"
+fi
+
+# Replace only the GRUB_CMDLINE_LINUX line (anchored to avoid matching
+# GRUB_CMDLINE_LINUX_DEFAULT). Use | as delimiter so any / in GRUB_ARGS
+# (e.g. from DIB_BOOTLOADER_DEFAULT_CMDLINE) does not break the expression.
+# Then regenerate the GRUB config to apply the updated kernel parameters.
+sed -i "s|^GRUB_CMDLINE_LINUX=.*|GRUB_CMDLINE_LINUX=\"${GRUB_ARGS}\"|" /etc/default/grub
 grub2-mkconfig --output=/boot/grub2/grub.cfg


### PR DESCRIPTION
Add kernel command line parameters so that the kernel log is printed to serial log. The current leap issue (as well as any future issue) is hard to debug without the kernel log.

Related issue: #1363