### PR TITLE
Disable wicked by default in leap node

### DIFF
--- a/jenkins/image_building/build-image.sh
+++ b/jenkins/image_building/build-image.sh
@@ -85,10 +85,6 @@ elif [[ "${IMAGE_OS}" == "centos" ]]; then
 elif [[ "${IMAGE_OS}" == "leap" ]]; then
   numeric_release="15_6"
   export DIB_RELEASE="15.6"
-  # Patch DIB source to accept openSUSE Leap 15.6
-  # shellcheck disable=SC2016
-  sed -i '8i15.6) export OPENSUSE_REPO_DIR=openSUSE_Leap_${DIB_RELEASE} ;;' \
-      "${REPO_ROOT}"/venv/lib/python*/site-packages/diskimage_builder/elements/opensuse/environment.d/10-opensuse-distro-name.bash
 fi
 
 if [[ "${IMAGE_TYPE}" == "node" ]]; then

--- a/jenkins/image_building/dib_elements/leap-node/install.d/55-install
+++ b/jenkins/image_building/dib_elements/leap-node/install.d/55-install
@@ -24,3 +24,5 @@ sudo zypper -n in --repo CRI-O cri-o="${CRIO_SLES_VERSION}" cri-tools="${CRICTL_
 sudo zypper -n in keepalived
 # Install NM and enable it.
 sudo zypper -n in NetworkManager
+sudo systemctl disable wicked wickedd
+sudo systemctl enable NetworkManager


### PR DESCRIPTION
Disables wicked in the node image itself, similarly as it is disabled in the CI image.

Related to issue https://github.com/metal3-io/project-infra/issues/1363

I have investigated the failing e2e test and looks like the problem is faulty NetworkManager configurations. Cloud init does not render properly network manager configurations because network manager is not enabled. This is because wicked is used instead of network manager in the e2e tests. The dev env templates disable wicked and enable networkmanager in pre kubeadm commands.

Also, removes the DIB leap patching, because it is apparently using new enough version of DIB, which includes it already. DIB source code accepts versions 15.5 and 15.6. That patch is needed when building other versions but I think we don't need it ATM.