### PR TITLE
Prow: Bump CAPI/CAPO versions

### DIFF
--- a/prow/capi/bootstrap.yaml
+++ b/prow/capi/bootstrap.yaml
@@ -4,7 +4,7 @@ metadata:
   name: kubeadm
   namespace: capi-kubeadm-bootstrap-system
 spec:
-  version: v1.11.11
+  version: v1.12.8
   deployment:
     nodeSelector:
       node-role.kubernetes.io/infra: ""

--- a/prow/capi/control-plane.yaml
+++ b/prow/capi/control-plane.yaml
@@ -4,7 +4,7 @@ metadata:
   name: kubeadm
   namespace: capi-kubeadm-control-plane-system
 spec:
-  version: v1.11.11
+  version: v1.12.8
   deployment:
     nodeSelector:
       node-role.kubernetes.io/infra: ""

--- a/prow/capi/core.yaml
+++ b/prow/capi/core.yaml
@@ -4,7 +4,7 @@ metadata:
   name: cluster-api
   namespace: capi-system
 spec:
-  version: v1.11.11
+  version: v1.12.8
   deployment:
     nodeSelector:
       node-role.kubernetes.io/infra: ""

--- a/prow/capi/infrastructure.yaml
+++ b/prow/capi/infrastructure.yaml
@@ -4,7 +4,7 @@ metadata:
   name: openstack
   namespace: capo-system
 spec:
-  version: v0.12.7
+  version: v0.14.4
   deployment:
     nodeSelector:
       node-role.kubernetes.io/infra: ""


### PR DESCRIPTION
Bumping CAPI to next minor version. Note that CAPO doesn't follow the same release schedule as CAPI. Bumping two minor versions for CAPO to "sync". CAPO v0.14 uses internally CAPI v1.12, so these are matching well.

Changes are applied automatically by flux.