### PR TITLE
use proper IPA cache address

### DIFF
--- a/jenkins/scripts/bare_metal_lab/bml_test/02_configure_host.sh
+++ b/jenkins/scripts/bare_metal_lab/bml_test/02_configure_host.sh
@@ -17,7 +17,7 @@ pushd "${IRONIC_DATA_DIR}/html/images"
 wget --no-check-certificate https://artifactory.nordix.org/artifactory/metal3/images/k8s_v1.34.1/CENTOS_9_NODE_IMAGE_K8S_v1.34.1.qcow2
 qemu-img convert -O raw CENTOS_9_NODE_IMAGE_K8S_v1.34.1.qcow2 CENTOS_9_NODE_IMAGE_K8S_v1.34.1-raw.img
 sha256sum "CENTOS_9_NODE_IMAGE_K8S_v1.34.1-raw.img" | awk '{print $1}' > "CENTOS_9_NODE_IMAGE_K8S_v1.34.1-raw.img.sha256sum"
-wget https://artifactory.nordix.org/artifactory/openstack-remote-cache/ironic-python-agent/dib/ipa-centos9-master.tar.gz
+wget https://artifactory.nordix.org/artifactory/openstack-remote/ironic-python-agent/dib/ipa-centos9-master.tar.gz
 popd
 
 # shellcheck disable=SC1091

--- a/jenkins/scripts/bare_metal_lab/bml_test/lib/vars.sh
+++ b/jenkins/scripts/bare_metal_lab/bml_test/lib/vars.sh
@@ -17,7 +17,7 @@ export CAPM3RELEASE="v1.13.99"
 export IPAMRELEASE="v1.13.99"
 export IRONIC_NAMESPACE="baremetal-operator-system"
 export NAMEPREFIX="baremetal-operator"
-export IPA_BASEURI=https://artifactory.nordix.org/artifactory/openstack-remote-cache/ironic-python-agent/dib
+export IPA_BASEURI=https://artifactory.nordix.org/artifactory/openstack-remote/ironic-python-agent/dib
 
 export CONTAINER_REGISTRY="registry.nordix.org/quay-io-proxy"
 export CAPM3_IMAGE="${CONTAINER_REGISTRY}/metal3-io/cluster-api-provider-metal3:main}"

--- a/jenkins/scripts/dynamic_worker_workflow/test_env.sh
+++ b/jenkins/scripts/dynamic_worker_workflow/test_env.sh
@@ -70,4 +70,4 @@ export CONTAINER_REGISTRY=${CONTAINER_REGISTRY:-"registry.nordix.org/quay-io-pro
 export DOCKER_HUB_PROXY=${DOCKER_HUB_PROXY:-"registry.nordix.org/docker-hub-proxy"}
 
 # Proxy IPA's base URI value to override the default value in m3-dev-env
-export IPA_BASEURI="https://artifactory.nordix.org/artifactory/openstack-remote-cache/ironic-python-agent/dib"
+export IPA_BASEURI="https://artifactory.nordix.org/artifactory/openstack-remote/ironic-python-agent/dib"


### PR DESCRIPTION
This commit:
 - Makes sure that the correct IPA nordix proxy is used.

Previous address circumvented the proper cache refresh trigger so in case the cache was empty after a cleanup, cache refresh was not triggered.