### PR TITLE
introduce artifact cache preloading &  better api token handling in artifact cleanup workflow

### DIFF
--- a/hack/clean_artifactory.sh
+++ b/hack/clean_artifactory.sh
@@ -3,7 +3,10 @@
 set -eu
 
 RT_TOKEN_FILE="${RT_TOKEN_FILE:-/etc/artifactory/token}"
+# Used to clean a cached artifact
 CACHE_URL="${CACHE_URL:-https://artifactory.nordix.org/artifactory/openstack-remote-cache/ironic-python-agent/dib/ipa-centos9-master.tar.gz}"
+# User facing proxy endpoint that is backed by the content of the cache, users should pull from here
+PROXY_URL="${PROXY_URL:-https://artifactory.nordix.org/artifactory/openstack-remote/ironic-python-agent/dib/ipa-centos9-master.tar.gz}"
 
 if [ ! -r "${RT_TOKEN_FILE}" ]; then
   echo "ERROR: Token file '${RT_TOKEN_FILE}' does not exist or is not readable" >&2
@@ -16,8 +19,22 @@ if [ -z "${RT_TOKEN}" ]; then
   exit 1
 fi
 
-HTTP_CODE=$(curl -s -H "Authorization: Bearer ${RT_TOKEN}" -XDELETE "${CACHE_URL}" -o /dev/null -w "%{http_code}")
-if [ "${HTTP_CODE}" -ne 204 ] && [ "${HTTP_CODE}" -ne 200 ]; then
-  echo "ERROR: DELETE failed with status ${HTTP_CODE}, URL:${CACHE_URL}" >&2
+# Hardening to avoid leaking token (as much as possible)
+HEADER_FILE=$(mktemp)
+trap 'rm -f "${HEADER_FILE}"' EXIT
+printf 'Authorization: Bearer %s\n' "${RT_TOKEN}" > "${HEADER_FILE}"
+chmod 600 "${HEADER_FILE}"
+
+# Clean the cached artifact
+DELETE_CALL=$(curl -s -H @"${HEADER_FILE}" -XDELETE "${CACHE_URL}" -o /dev/null -w "%{http_code}")
+if [ "${DELETE_CALL}" -ne 204 ] && [ "${DELETE_CALL}" -ne 200 ]; then
+  echo "ERROR: Artifact delete failed with status ${DELETE_CALL}, URL:${CACHE_URL}" >&2
+  exit 1
+fi
+
+# Preloading cache, so that jobs can access the new artifact faster
+PRELOAD_CALL=$(curl -sS --retry 10 --retry-delay 5 "${PROXY_URL}" -o /dev/null -w "%{http_code}")
+if [ "${PRELOAD_CALL}" -ne 200 ]; then
+  echo "ERROR: Preload failed with status ${PRELOAD_CALL}, URL:${PROXY_URL}" >&2
   exit 1
 fi


### PR DESCRIPTION
This commit:
 - Introduces cache preloading logic to the artifact cache cleanup script.
 - New workflow: clear cache -> verify -> preload via public proxy -> verify.
 - Harden the Artifactory token handling

Goal is to make the new artifact available faster and safer.