### PR TITLE
Add CI config for IrSO release-0.10

### DIFF
--- a/prow/config/jobs/metal3-io/ironic-standalone-operator-release-0.10.yaml
+++ b/prow/config/jobs/metal3-io/ironic-standalone-operator-release-0.10.yaml
@@ -1,0 +1,82 @@
+presubmits:
+  metal3-io/ironic-standalone-operator:
+  - name: gomod
+    branches:
+    - release-0.10
+    skip_if_only_changed: '(((^|/)OWNERS)|((^|/)OWNERS_ALIASES)|(\.md))$'
+    decorate: true
+    spec:
+      containers:
+      - args:
+        - ./hack/gomod.sh
+        command:
+        - sh
+        env:
+        - name: IS_CONTAINER
+          value: "TRUE"
+        image: docker.io/golang:1.25
+        imagePullPolicy: Always
+  - name: shellcheck
+    branches:
+    - release-0.10
+    run_if_changed: '((\.sh)|^Makefile)$'
+    decorate: true
+    spec:
+      containers:
+      - args:
+        - ./hack/shellcheck.sh
+        command:
+        - sh
+        env:
+        - name: IS_CONTAINER
+          value: "TRUE"
+        image: docker.io/koalaman/shellcheck-alpine:v0.10.0@sha256:5921d946dac740cbeec2fb1c898747b6105e585130cc7f0602eec9a10f7ddb63
+        imagePullPolicy: Always
+  - name: markdownlint
+    branches:
+    - release-0.10
+    run_if_changed: '(\.md|markdownlint\.sh)$'
+    decorate: true
+    spec:
+      containers:
+      - args:
+        - ./hack/markdownlint.sh
+        command:
+        - sh
+        env:
+        - name: IS_CONTAINER
+          value: "TRUE"
+        image: docker.io/pipelinecomponents/markdownlint-cli2:0.12.0@sha256:a3977fba9814f10d33a1d69ae607dc808e7a6470b2ba03e84c17193c0791aac0
+        imagePullPolicy: Always
+  - name: manifestlint
+    branches:
+    - release-0.10
+    skip_if_only_changed: '(((^|/)OWNERS)|((^|/)OWNERS_ALIASES)|(\.md))$'
+    decorate: true
+    spec:
+      containers:
+      - args:
+        - ./hack/manifestlint.sh
+        command:
+        - sh
+        env:
+        - name: IS_CONTAINER
+          value: "TRUE"
+        - name: KUBECONFORM_PATH
+          value: "/"
+        image: ghcr.io/yannh/kubeconform:v0.6.7-alpine@sha256:824e0c248809e4b2da2a768b16b107cf17ada88a89ec6aa6050e566ba93ebbc6
+        imagePullPolicy: Always
+  #NOTE(elfosardo): commented out until metal3-dev-env starts using IrSO
+  # name: metal3-dev-env-integration-test-{image_os}-release-1-11
+  # - name: metal3-dev-env-integration-test-ubuntu-release-1-11
+  #   branches:
+  #   - release-0.10
+  #   agent: jenkins
+  #   always_run: false
+  #   optional: true
+  # - name: metal3-dev-env-integration-test-centos-release-1-11
+  #   branches:
+  #   - release-0.10
+  #   agent: jenkins
+  #   always_run: false
+  #   optional: true

--- a/prow/config/plugins.yaml
+++ b/prow/config/plugins.yaml
@@ -211,7 +211,8 @@ milestone_applier:
     release-29.0: "ironic-image - v29.0"
     release-28.0: "ironic-image - v28.0"
   metal3-io/ironic-standalone-operator:
-    main: "IrSO - v0.10"
+    main: "IrSO - v0.11"
+    release-0.10: "IrSO - v0.10"
     release-0.9: "IrSO - v0.9"
     release-0.8: "IrSO - v0.8"
     release-0.7: "IrSO - v0.7"


### PR DESCRIPTION
Add Prow presubmit jobs for the ironic-standalone-operator release-0.10 branch (gomod, shellcheck, markdownlint, manifestlint) and update the milestone mapping in plugins.yaml, bumping main to v0.11.