### PR TITLE
Update k8s upgrade test versions in prow jobs

### DIFF
--- a/prow/config/jobs/metal3-io/cluster-api-provider-metal3-release-1.13.yaml
+++ b/prow/config/jobs/metal3-io/cluster-api-provider-metal3-release-1.13.yaml
@@ -205,7 +205,7 @@ presubmits:
     always_run: false
     optional: true
   # name: {job_prefix}-e2e-{k8s_versions}-upgrade-test-{capm3_target_branch}
-  - name: metal3-e2e-1-34-1-35-upgrade-test-release-1-13
+  - name: metal3-e2e-1-35-1-36-upgrade-test-release-1-13
     branches:
     - release-1.13
     agent: jenkins

--- a/prow/config/jobs/metal3-io/cluster-api-provider-metal3.yaml
+++ b/prow/config/jobs/metal3-io/cluster-api-provider-metal3.yaml
@@ -239,7 +239,7 @@ presubmits:
     always_run: false
     optional: true
   # name: {job_prefix}-e2e-{k8s_versions}-upgrade-test-{capm3_target_branch}
-  - name: metal3-e2e-1-34-1-35-upgrade-test-main
+  - name: metal3-e2e-1-35-1-36-upgrade-test-main
     branches:
     - main
     agent: jenkins

--- a/prow/config/jobs/metal3-io/ip-address-manager-release-1.13.yaml
+++ b/prow/config/jobs/metal3-io/ip-address-manager-release-1.13.yaml
@@ -178,7 +178,7 @@ presubmits:
     agent: jenkins
     always_run: false
     optional: true
-  - name: metal3-e2e-1-34-1-35-upgrade-test-release-1-13
+  - name: metal3-e2e-1-35-1-36-upgrade-test-release-1-13
     branches:
     - release-1.13
     agent: jenkins

--- a/prow/config/jobs/metal3-io/ip-address-manager.yaml
+++ b/prow/config/jobs/metal3-io/ip-address-manager.yaml
@@ -182,7 +182,7 @@ presubmits:
     always_run: false
     optional: true
   # name: {job_prefix}-e2e-{k8s_versions}-upgrade-test-{capm3_target_branch}
-  - name: metal3-e2e-1-34-1-35-upgrade-test-main
+  - name: metal3-e2e-1-35-1-36-upgrade-test-main
     branches:
     - main
     agent: jenkins

--- a/prow/config/jobs/metal3-io/metal3-dev-env.yaml
+++ b/prow/config/jobs/metal3-io/metal3-dev-env.yaml
@@ -267,23 +267,19 @@ presubmits:
     always_run: false
     optional: true
   # name: {job_prefix}-e2e-{k8s_versions}-upgrade-test-{capm3_target_branch}
-  - name: metal3-e2e-1-29-1-30-upgrade-test-main
+  - name: metal3-e2e-1-35-1-36-upgrade-test-main
     agent: jenkins
     always_run: false
     optional: true
-  - name: metal3-e2e-1-29-1-30-upgrade-test-release-1-13
+  - name: metal3-e2e-1-35-1-36-upgrade-test-release-1-13
     agent: jenkins
     always_run: false
     optional: true
-  - name: metal3-e2e-1-29-1-30-upgrade-test-release-1-12
+  - name: metal3-e2e-1-34-1-35-upgrade-test-release-1-12
     agent: jenkins
     always_run: false
     optional: true
-  - name: metal3-e2e-1-29-1-30-upgrade-test-release-1-11
-    agent: jenkins
-    always_run: false
-    optional: true
-  - name: metal3-e2e-1-29-1-30-upgrade-test-release-1-10
+  - name: metal3-e2e-1-33-1-34-upgrade-test-release-1-11
     agent: jenkins
     always_run: false
     optional: true

--- a/prow/config/jobs/metal3-io/project-infra.yaml
+++ b/prow/config/jobs/metal3-io/project-infra.yaml
@@ -226,15 +226,11 @@ presubmits:
     always_run: false
     optional: true
   # name: {job_prefix}-e2e-{k8s_versions}-upgrade-test-{capm3_target_branch}
-  - name: metal3-e2e-1-29-1-30-upgrade-test-main
+  - name: metal3-e2e-1-35-1-36-upgrade-test-main
     agent: jenkins
     always_run: false
     optional: true
-  - name: metal3-e2e-1-29-1-30-upgrade-test-release-1-11
-    agent: jenkins
-    always_run: false
-    optional: true
-  - name: metal3-e2e-1-29-1-30-upgrade-test-release-1-10
+  - name: metal3-e2e-1-33-1-34-upgrade-test-release-1-11
     agent: jenkins
     always_run: false
     optional: true


### PR DESCRIPTION
cluster-api-provider-metal3:
- main: 1-34-1-35 → 1-35-1-36
- release-1-13: 1-34-1-35 → 1-35-1-36

ip-address-manager:
- main: 1-34-1-35 → 1-35-1-36
- release-1-13: 1-34-1-35 → 1-35-1-36

metal3-dev-env:
- main: 1-29-1-30 → 1-35-1-36
- release-1-13: 1-29-1-30 → 1-35-1-36
- release-1-12: 1-29-1-30 → 1-34-1-35
- release-1-11: 1-29-1-30 → 1-33-1-34
- release-1-10: removed 

project-infra:
- main: 1-29-1-30 → 1-35-1-36
- release-1-11: 1-29-1-30 → 1-33-1-34
- release-1-10: removed