### PR TITLE
Set dhcp_ignore and dhcp_hosts variables via IRSO

### DIFF
--- a/jenkins/scripts/bare_metal_lab/bml_test/03_launch_bootstrap_cluster.sh
+++ b/jenkins/scripts/bare_metal_lab/bml_test/03_launch_bootstrap_cluster.sh
@@ -1,6 +1,7 @@
 #!/usr/bin/env bash
 
 set +x
+set -o pipefail
 
 SCRIPTDIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 # shellcheck disable=SC1091
@@ -152,9 +153,14 @@ launch_ironic_standalone_operator()
         -n ironic-standalone-operator-system deployment/ironic-standalone-operator-controller-manager
 }
 
+render_dhcp_hosts_list()
+{
+    local vars_yaml="${SCRIPTDIR}/../default_vars/vars.yaml"
+    yq eval '.bare_metal_hosts[].mac' "${vars_yaml}" | sed 's/^/        - /'
+}
+
 launch_ironic_via_irso()
 {
-
     kubectl create secret generic ironic-auth -n "${IRONIC_NAMESPACE}" \
         --from-file=username="${IRONIC_AUTH_DIR}ironic-username"  \
         --from-file=password="${IRONIC_AUTH_DIR}ironic-password"
@@ -182,6 +188,10 @@ spec:
       rangeBegin: "172.22.0.10"
       rangeEnd: "172.22.0.100"
       networkCIDR: "172.22.0.0/24"
+      hosts:
+$(render_dhcp_hosts_list)
+      ignore:
+        - "tag:!known"
     interface: "ironicendpoint"
     ipAddress: "172.22.0.2"
     ipAddressManager: keepalived

--- a/jenkins/scripts/bare_metal_lab/default_vars/vars.yaml
+++ b/jenkins/scripts/bare_metal_lab/default_vars/vars.yaml
@@ -46,5 +46,3 @@ bare_metal_hosts:
 #   ip: "192.168.1.33"
 #   bootMode: "legacy"
 #   rootDeviceHint: "/dev/disk/by-path/pci-0000:03:00.0-scsi-0:1:0:0"
-DHCP_HOSTS: "{{ bare_metal_hosts | map(attribute='mac') | join(';') }}"
-DHCP_IGNORE: "tag:!known"

--- a/jenkins/scripts/bare_metal_lab/deploy-lab.yaml
+++ b/jenkins/scripts/bare_metal_lab/deploy-lab.yaml
@@ -1,9 +1,6 @@
 ---
 - hosts: localhost
   connection: local
-  environment:
-    DHCP_HOSTS: "{{ DHCP_HOSTS }}"
-    DHCP_IGNORE: "{{ DHCP_IGNORE }}"
   vars_files:
   - default_vars/vars.yaml
   tasks:


### PR DESCRIPTION
This PR sets dhcp_ignore and dhcp_hosts variables via IRSO to limit dnsmasq giving ip addresses for servers used in test