### PR TITLE
Bump golang to v1.26 for CAPM3 main branch tests

### DIFF
--- a/prow/config/jobs/metal3-io/cluster-api-provider-metal3.yaml
+++ b/prow/config/jobs/metal3-io/cluster-api-provider-metal3.yaml
@@ -14,7 +14,7 @@ presubmits:
         env:
         - name: IS_CONTAINER
           value: "TRUE"
-        image: docker.io/golang:1.25
+        image: docker.io/golang:1.26
         imagePullPolicy: Always
   # NOTE: The test jobs are for verifying Makefile and hack/* script changes only
   - name: test
@@ -28,7 +28,7 @@ presubmits:
         - test
         command:
         - make
-        image: docker.io/golang:1.25
+        image: docker.io/golang:1.26
         imagePullPolicy: Always
   - name: markdownlint
     branches:
@@ -76,7 +76,7 @@ presubmits:
         env:
         - name: IS_CONTAINER
           value: "TRUE"
-        image: docker.io/golang:1.25
+        image: docker.io/golang:1.26
         imagePullPolicy: Always
   - name: unit
     branches:
@@ -92,7 +92,7 @@ presubmits:
         env:
         - name: IS_CONTAINER
           value: "TRUE"
-        image: docker.io/golang:1.25
+        image: docker.io/golang:1.26
         imagePullPolicy: Always
   - name: manifestlint
     branches:
@@ -129,7 +129,7 @@ presubmits:
   #       env:
   #       - name: IS_CONTAINER
   #         value: "TRUE"
-  #       image: docker.io/golang:1.25
+  #       image: docker.io/golang:1.26
   #       imagePullPolicy: Always
   - name: build-fkas
     branches:
@@ -147,7 +147,7 @@ presubmits:
           value: "TRUE"
         - name: BUILD_FKAS
           value: "TRUE"
-        image: docker.io/golang:1.25
+        image: docker.io/golang:1.26
         imagePullPolicy: Always
   # name: {job_prefix}-{image_os}-e2e-basic-test-{capm3_target_branch}
   - name: metal3-centos-e2e-basic-test-main


### PR DESCRIPTION
go1.26 is required by 1.14.x development