### PR TITLE
Set bml test to use servers 4 and 7

### DIFF
--- a/jenkins/scripts/bare_metal_lab/bml_test/manifests/controlplane_centos.yaml
+++ b/jenkins/scripts/bare_metal_lab/bml_test/manifests/controlplane_centos.yaml
@@ -37,7 +37,7 @@ spec:
 
         vrrp_instance VI_1 {
             state MASTER
-            interface eno1.3
+            interface eno49.3
             virtual_router_id 1
             priority 101
             advert_int 1
@@ -51,13 +51,13 @@ spec:
       path: /etc/keepalived/keepalived.conf
     - content: |
         [connection]
-        id=eno1
+        id=eno49
         type=ethernet
-        interface-name=eno1
+        interface-name=eno49
         master=ironicendpoint
         slave-type=bridge
       owner: root:root
-      path: /etc/NetworkManager/system-connections/eno1.nmconnection
+      path: /etc/NetworkManager/system-connections/eno49.nmconnection
       permissions: "0600"
     - content: |
         [connection]
@@ -87,15 +87,15 @@ spec:
       path: /etc/containers/registries.conf
     - content: |
         [connection]
-        id=Vlan eno1.3
+        id=Vlan eno49.3
         type=vlan
         autoconnect-priority=999
-        interface-name=eno1.3
+        interface-name=eno49.3
 
         [vlan]
         flags=1
         id=3
-        parent=eno1
+        parent=eno49
 
         [ipv4]
         method=auto
@@ -104,7 +104,7 @@ spec:
         addr-gen-mode=eui64
         method=ignore
       owner: root:root
-      path: /etc/NetworkManager/system-connections/eno1.3.nmconnection
+      path: /etc/NetworkManager/system-connections/eno49.3.nmconnection
       permissions: "0600"
     initConfiguration:
       nodeRegistration:
@@ -148,10 +148,10 @@ spec:
     - systemctl restart NetworkManager.service
     - nmcli connection load /etc/NetworkManager/system-connections/ironicendpoint.nmconnection
     - nmcli connection up ironicendpoint
-    - nmcli connection load /etc/NetworkManager/system-connections/eno1.nmconnection
-    - nmcli connection up eno1
-    - nmcli connection load /etc/NetworkManager/system-connections/eno1.3.nmconnection
-    - nmcli connection up /etc/NetworkManager/system-connections/eno1.3.nmconnection
+    - nmcli connection load /etc/NetworkManager/system-connections/eno49.nmconnection
+    - nmcli connection up eno49
+    - nmcli connection load /etc/NetworkManager/system-connections/eno49.3.nmconnection
+    - nmcli connection up /etc/NetworkManager/system-connections/eno49.3.nmconnection
     - rm /etc/cni/net.d/*
     - systemctl enable --now keepalived
     - sleep 30
@@ -226,21 +226,21 @@ spec:
   networkData:
     links:
       ethernets:
-      - id: eno1
+      - id: eno49
         macAddress:
-          fromHostInterface: eno1
+          fromHostInterface: eno49
         type: phy
-      - id: eno2
+      - id: eno50
         macAddress:
-          fromHostInterface: eno2
+          fromHostInterface: eno50
         type: phy
       vlans:
       - id: vlan3
         macAddress:
-          fromHostInterface: eno1
+          fromHostInterface: eno49
         mtu: 1500
         vlanID: 3
-        vlanLink: eno1
+        vlanLink: eno49
     networks:
       ipv4:
       - id: externalv4

--- a/jenkins/scripts/bare_metal_lab/bml_test/manifests/workers_centos.yaml
+++ b/jenkins/scripts/bare_metal_lab/bml_test/manifests/workers_centos.yaml
@@ -79,21 +79,21 @@ spec:
   networkData:
     links:
       ethernets:
-      - id: eno1
+      - id: eno49
         macAddress:
-          fromHostInterface: eno1
+          fromHostInterface: eno49
         type: phy
-      - id: eno2
+      - id: eno50
         macAddress:
-          fromHostInterface: eno2
+          fromHostInterface: eno50
         type: phy
       vlans:
       - id: vlan3
         macAddress:
-          fromHostInterface: eno1
+          fromHostInterface: eno49
         mtu: 1500
         vlanID: 3
-        vlanLink: eno1
+        vlanLink: eno49
     networks:
       ipv4:
       - id: externalv4
@@ -137,9 +137,9 @@ spec:
         permissions: "0755"
       - content: |
           [connection]
-          id=eno1
+          id=eno49
           type=ethernet
-          interface-name=eno1
+          interface-name=eno49
           master=ironicendpoint
           slave-type=bridge
           autoconnect=yes
@@ -177,15 +177,15 @@ spec:
         permissions: "0644"
       - content: |
           [connection]
-          id=Vlan eno1.3
+          id=Vlan eno49.3
           type=vlan
           autoconnect-priority=999
-          interface-name=eno1.3
+          interface-name=eno49.3
 
           [vlan]
           flags=1
           id=3
-          parent=eno1
+          parent=eno49
 
           [ipv4]
           method=auto

--- a/jenkins/scripts/bare_metal_lab/default_vars/vars.yaml
+++ b/jenkins/scripts/bare_metal_lab/default_vars/vars.yaml
@@ -6,31 +6,31 @@ bml_ilo_password: "{{ lookup('env', 'BML_ILO_PASSWORD') }}"
 github_token: "{{ lookup('env', 'GITHUB_TOKEN') }}"
 serial_log_location: "/tmp/BMLlog"
 bare_metal_hosts:
-- id: "03"
-  mac: b4:b5:2f:6d:89:d8
-  ip: "192.168.1.24"
-  bootMode: "legacy"
-  rootDeviceHint: "/dev/disk/by-path/pci-0000:03:00.0-scsi-0:1:0:1"
-# - id: "04"
-#   mac: 6c:c2:17:40:7e:b0
-#   ip: "192.168.1.13"
+# - id: "03"
+#   mac: b4:b5:2f:6d:89:d8
+#   ip: "192.168.1.24"
+#   bootMode: "legacy"
+#   rootDeviceHint: "/dev/disk/by-path/pci-0000:03:00.0-scsi-0:1:0:1"
+- id: "04"
+  mac: 6c:c2:17:40:7e:b0
+  ip: "192.168.1.13"
+  bootMode: "UEFI"
+  rootDeviceHint: "/dev/disk/by-path/pci-0000:07:00.0-scsi-0:1:0:0"
+# - id: "05"
+#   mac: 80:c1:6e:7a:5a:a8
+#   ip: "192.168.1.14"
+#   bootMode: "legacy"
+#   rootDeviceHint: "/dev/disk/by-path/pci-0000:03:00.0-scsi-0:1:0:0"
+# - id: "06"
+#   mac: e4:11:5b:95:7e:98
+#   ip: "192.168.1.23"
 #   bootMode: "UEFI"
 #   rootDeviceHint: "/dev/disk/by-path/pci-0000:07:00.0-scsi-0:1:0:0"
-- id: "05"
-  mac: 80:c1:6e:7a:5a:a8
-  ip: "192.168.1.14"
-  bootMode: "legacy"
-  rootDeviceHint: "/dev/disk/by-path/pci-0000:03:00.0-scsi-0:1:0:0"
-# - id: "06"
-#   mac: b4:b5:2f:6d:68:10
-#   ip: "192.168.1.15"
-#   bootMode: "legacy"
-#   rootDeviceHint: "/dev/disk/by-path/pci-0000:03:00.0-scsi-0:1:0:0"
-# - id: "07"
-#   mac: b4:b5:2f:6d:a9:d8
-#   ip: "192.168.1.16"
-#   bootMode: "legacy"
-#   rootDeviceHint: "/dev/disk/by-path/pci-0000:03:00.0-scsi-0:1:0:0"
+- id: "07"
+  mac: 5c:b9:01:98:6d:6c
+  ip: "192.168.1.16"
+  bootMode: "UEFI"
+  rootDeviceHint: "/dev/disk/by-path/pci-0000:07:00.0-scsi-0:1:0:0"
 # - id: "14"
 #   mac: 6c:3b:e5:b5:03:c8
 #   ip: "192.168.1.32"


### PR DESCRIPTION
This PR change bml test to use servers 4 and 7. Server 4 adn 7 are gen 9 blade, where nic interface names changes accordingly.