### PR TITLE
Make cri-tools explicilty be downladed from kuberentes repo

### DIFF
--- a/jenkins/image_building/dib_elements/leap-node/install.d/55-install
+++ b/jenkins/image_building/dib_elements/leap-node/install.d/55-install
@@ -18,8 +18,8 @@ net.ipv4.ip_forward                 = 1
 net.bridge.bridge-nf-call-ip6tables = 1
 EOF
 
-sudo zypper -n in --repo kubernetes kubelet="${KUBERNETES_SLES_VERSION}" kubeadm="${KUBERNETES_SLES_VERSION}" kubectl="${KUBERNETES_SLES_VERSION}"
-sudo zypper -n in --repo CRI-O cri-o="${CRIO_SLES_VERSION}" cri-tools="${CRICTL_SLES_VERSION}"
+sudo zypper -n in --repo kubernetes kubelet="${KUBERNETES_SLES_VERSION}" kubeadm="${KUBERNETES_SLES_VERSION}" kubectl="${KUBERNETES_SLES_VERSION}" cri-tools="${CRICTL_SLES_VERSION}"
+sudo zypper -n in --repo CRI-O cri-o="${CRIO_SLES_VERSION}"
 # keepalived is in the external oss repo, hence install it here.
 sudo zypper -n in keepalived
 # Install NM and enable it.


### PR DESCRIPTION
Cri-tools is not available in the CRI-O repository but is available in the kubernetes repository. It seems it was previously being downloaded as a [dependency for kubeadm](https://build.opensuse.org/projects/isv:kubernetes:core:stable:v1.36/packages/kubeadm.20260422175826/files/kubeadm.spec?expand=1) but this was dropped in [v1.36.2](https://build.opensuse.org/projects/isv:kubernetes:core:stable:v1.36/packages/kubeadm.20260612113530/files/kubeadm.spec?expand=1). 

It is now downloaded using the correct repositories.

Fix: https://github.com/metal3-io/project-infra/issues/1387




