### PR TITLE
Bump golang to v1.26 for IPAM  main branch tests

### DIFF
--- a/prow/config/jobs/metal3-io/ip-address-manager.yaml
+++ b/prow/config/jobs/metal3-io/ip-address-manager.yaml
@@ -14,7 +14,7 @@ presubmits:
         env:
         - name: IS_CONTAINER
           value: "TRUE"
-        image: docker.io/golang:1.25
+        image: docker.io/golang:1.26
         imagePullPolicy: Always
   # NOTE: The test jobs are for verifying the Makefile and hack/* scripts only
   - name: test
@@ -28,7 +28,7 @@ presubmits:
         - test
         command:
         - make
-        image: docker.io/golang:1.25
+        image: docker.io/golang:1.26
         imagePullPolicy: Always
   - name: markdownlint
     branches:
@@ -76,7 +76,7 @@ presubmits:
         env:
         - name: IS_CONTAINER
           value: "TRUE"
-        image: docker.io/golang:1.25
+        image: docker.io/golang:1.26
   - name: generate
     branches:
     - main
@@ -91,7 +91,7 @@ presubmits:
         env:
         - name: IS_CONTAINER
           value: "TRUE"
-        image: docker.io/golang:1.25
+        image: docker.io/golang:1.26
         imagePullPolicy: Always
   - name: manifestlint
     branches:


### PR DESCRIPTION
go1.26 is required by 1.14.x development