### PR TITLE
Ignore containerd CVEs in OSV scanner 

### DIFF
--- a/jenkins/jobs/osv_scanner_metal3.groovy
+++ b/jenkins/jobs/osv_scanner_metal3.groovy
@@ -124,6 +124,16 @@ def runOsvScan = { String repoName, String refType, String ref, String repoUrl, 
             }
         }
 
+        // containerd CVEs with no fix available; only affects test/go.mod
+        ['GO-2026-5064', 'GO-2026-5338', 'GO-2026-5622'].each { vulnId ->
+            sh """
+                echo '' >> config.toml
+                echo '[[IgnoredVulns]]' >> config.toml
+                echo 'id = "${vulnId}"' >> config.toml
+                echo 'reason = "containerd vulnerability with no fix available. Only affects tests."' >> config.toml
+            """
+        }
+
         def helmIgnoredBranches = [
             'CAPM3': ~/^release-1\.12$/,
         ]


### PR DESCRIPTION

Add ignore rules for:
- GO-2026-5064
- GO-2026-5338
-  GO-2026-5622 

These are containerd vulnerabilities with no fix available upstream. 



Signed-off-by: Saad Zia <saad.zia@est.tech>