### PR TITLE
Keep linter images in sync between Prow jobs and hack scripts

### DIFF
--- a/prow/config/jobs/metal3-io/project-infra.yaml
+++ b/prow/config/jobs/metal3-io/project-infra.yaml
@@ -48,7 +48,7 @@ presubmits:
         image: docker.io/koalaman/shellcheck-alpine:v0.10.0@sha256:5921d946dac740cbeec2fb1c898747b6105e585130cc7f0602eec9a10f7ddb63
         imagePullPolicy: Always
   - name: groovylint
-    run_if_changed: '(\.groovy)$'
+    run_if_changed: '(\.groovy|groovylint\.sh)$'
     decorate: true
     spec:
       containers:

--- a/renovate.json
+++ b/renovate.json
@@ -21,9 +21,19 @@
   "customManagers": [
     {
       "customType": "regex",
-      "managerFilePatterns": ["hack/groovylint.sh"],
+      "description": "Bump container images in Prow job configs",
+      "managerFilePatterns": ["prow/config/jobs/**/*.yaml"],
       "matchStrings": [
-        "docker\\.io/(?<depName>[^:]+):(?<currentValue>[^@]+)@(?<currentDigest>sha256:[a-f0-9]+)"
+        "image: (?<depName>[^:@\\s]+):(?<currentValue>[^@\\s]+)@(?<currentDigest>sha256:[a-f0-9]+)"
+      ],
+      "datasourceTemplate": "docker"
+    },
+    {
+      "customType": "regex",
+      "description": "Bump container images in hack scripts",
+      "managerFilePatterns": ["hack/*.sh"],
+      "matchStrings": [
+        "(?<depName>(?:[a-z0-9.-]+\\.)+[a-z]{2,}/[^:\\s]+):(?<currentValue>[^@\\s]+)@(?<currentDigest>sha256:[a-f0-9]+)"
       ],
       "datasourceTemplate": "docker"
     },


### PR DESCRIPTION
This PR:

- Track linter images in prow job configs and hack scripts via   Renovate with matching depNames so both files are updated in one PR
- Trigger linter jobs on project-infra.yaml changes so Renovate   image bump PRs are validated in CI
- Add groovylint.sh to the groovylint run_if_changed pattern

Inludes fix: https://github.com/metal3-io/project-infra/issues/1382