### PR TITLE
🐛 Revert ":seedling: Update docker.io/pipelinecomponents/markdownlint-cli2 Docker tag to v0.14.19"

### DIFF
--- a/hack/markdownlint.sh
+++ b/hack/markdownlint.sh
@@ -15,6 +15,6 @@ else
         --volume "${PWD}:/workdir:ro,z" \
         --entrypoint sh \
         --workdir /workdir \
-        docker.io/pipelinecomponents/markdownlint-cli2:0.14.19@sha256:c651559a31fefc82cf864486d9472338ffa0aaa529ebf71a035d4f1d913809aa \
+        docker.io/pipelinecomponents/markdownlint-cli2:0.12.0@sha256:a3977fba9814f10d33a1d69ae607dc808e7a6470b2ba03e84c17193c0791aac0 \
         /workdir/hack/markdownlint.sh "$@"
 fi

--- a/prow/config/jobs/Nordix/metal3-clusterapi-docs.yaml
+++ b/prow/config/jobs/Nordix/metal3-clusterapi-docs.yaml
@@ -26,5 +26,5 @@ presubmits:
         env:
         - name: IS_CONTAINER
           value: "TRUE"
-        image: docker.io/pipelinecomponents/markdownlint-cli2:0.14.19@sha256:c651559a31fefc82cf864486d9472338ffa0aaa529ebf71a035d4f1d913809aa
+        image: docker.io/pipelinecomponents/markdownlint-cli2:0.12.0@sha256:a3977fba9814f10d33a1d69ae607dc808e7a6470b2ba03e84c17193c0791aac0
         imagePullPolicy: Always

--- a/prow/config/jobs/Nordix/metal3-dev-tools.yaml
+++ b/prow/config/jobs/Nordix/metal3-dev-tools.yaml
@@ -30,5 +30,5 @@ presubmits:
         env:
         - name: IS_CONTAINER
           value: "TRUE"
-        image: docker.io/pipelinecomponents/markdownlint-cli2:0.14.19@sha256:c651559a31fefc82cf864486d9472338ffa0aaa529ebf71a035d4f1d913809aa
+        image: docker.io/pipelinecomponents/markdownlint-cli2:0.12.0@sha256:a3977fba9814f10d33a1d69ae607dc808e7a6470b2ba03e84c17193c0791aac0
         imagePullPolicy: Always

--- a/prow/config/jobs/Nordix/sles-ironic-python-agent-builder.yaml
+++ b/prow/config/jobs/Nordix/sles-ironic-python-agent-builder.yaml
@@ -26,5 +26,5 @@ presubmits:
         env:
         - name: IS_CONTAINER
           value: "TRUE"
-        image: docker.io/pipelinecomponents/markdownlint-cli2:0.14.19@sha256:c651559a31fefc82cf864486d9472338ffa0aaa529ebf71a035d4f1d913809aa
+        image: docker.io/pipelinecomponents/markdownlint-cli2:0.12.0@sha256:a3977fba9814f10d33a1d69ae607dc808e7a6470b2ba03e84c17193c0791aac0
         imagePullPolicy: Always

--- a/prow/config/jobs/metal3-io/baremetal-operator-release-0.11.yaml
+++ b/prow/config/jobs/metal3-io/baremetal-operator-release-0.11.yaml
@@ -30,7 +30,7 @@ presubmits:
         env:
         - name: IS_CONTAINER
           value: "TRUE"
-        image: docker.io/pipelinecomponents/markdownlint-cli2:0.14.19@sha256:c651559a31fefc82cf864486d9472338ffa0aaa529ebf71a035d4f1d913809aa
+        image: docker.io/pipelinecomponents/markdownlint-cli2:0.12.0@sha256:a3977fba9814f10d33a1d69ae607dc808e7a6470b2ba03e84c17193c0791aac0
         imagePullPolicy: Always
   - name: shellcheck
     branches:

--- a/prow/config/jobs/metal3-io/baremetal-operator-release-0.12.yaml
+++ b/prow/config/jobs/metal3-io/baremetal-operator-release-0.12.yaml
@@ -30,7 +30,7 @@ presubmits:
         env:
         - name: IS_CONTAINER
           value: "TRUE"
-        image: docker.io/pipelinecomponents/markdownlint-cli2:0.14.19@sha256:c651559a31fefc82cf864486d9472338ffa0aaa529ebf71a035d4f1d913809aa
+        image: docker.io/pipelinecomponents/markdownlint-cli2:0.12.0@sha256:a3977fba9814f10d33a1d69ae607dc808e7a6470b2ba03e84c17193c0791aac0
         imagePullPolicy: Always
   - name: shellcheck
     branches:

--- a/prow/config/jobs/metal3-io/baremetal-operator-release-0.13.yaml
+++ b/prow/config/jobs/metal3-io/baremetal-operator-release-0.13.yaml
@@ -30,7 +30,7 @@ presubmits:
         env:
         - name: IS_CONTAINER
           value: "TRUE"
-        image: docker.io/pipelinecomponents/markdownlint-cli2:0.14.19@sha256:c651559a31fefc82cf864486d9472338ffa0aaa529ebf71a035d4f1d913809aa
+        image: docker.io/pipelinecomponents/markdownlint-cli2:0.12.0@sha256:a3977fba9814f10d33a1d69ae607dc808e7a6470b2ba03e84c17193c0791aac0
         imagePullPolicy: Always
   - name: shellcheck
     branches:

--- a/prow/config/jobs/metal3-io/baremetal-operator.yaml
+++ b/prow/config/jobs/metal3-io/baremetal-operator.yaml
@@ -30,7 +30,7 @@ presubmits:
         env:
         - name: IS_CONTAINER
           value: "TRUE"
-        image: docker.io/pipelinecomponents/markdownlint-cli2:0.14.19@sha256:c651559a31fefc82cf864486d9472338ffa0aaa529ebf71a035d4f1d913809aa
+        image: docker.io/pipelinecomponents/markdownlint-cli2:0.12.0@sha256:a3977fba9814f10d33a1d69ae607dc808e7a6470b2ba03e84c17193c0791aac0
         imagePullPolicy: Always
   - name: shellcheck
     branches:

--- a/prow/config/jobs/metal3-io/cluster-api-provider-metal3-release-1.11.yaml
+++ b/prow/config/jobs/metal3-io/cluster-api-provider-metal3-release-1.11.yaml
@@ -44,7 +44,7 @@ presubmits:
         env:
         - name: IS_CONTAINER
           value: "TRUE"
-        image: docker.io/pipelinecomponents/markdownlint-cli2:0.14.19@sha256:c651559a31fefc82cf864486d9472338ffa0aaa529ebf71a035d4f1d913809aa
+        image: docker.io/pipelinecomponents/markdownlint-cli2:0.12.0@sha256:a3977fba9814f10d33a1d69ae607dc808e7a6470b2ba03e84c17193c0791aac0
         imagePullPolicy: Always
   - name: shellcheck
     branches:

--- a/prow/config/jobs/metal3-io/cluster-api-provider-metal3-release-1.12.yaml
+++ b/prow/config/jobs/metal3-io/cluster-api-provider-metal3-release-1.12.yaml
@@ -44,7 +44,7 @@ presubmits:
         env:
         - name: IS_CONTAINER
           value: "TRUE"
-        image: docker.io/pipelinecomponents/markdownlint-cli2:0.14.19@sha256:c651559a31fefc82cf864486d9472338ffa0aaa529ebf71a035d4f1d913809aa
+        image: docker.io/pipelinecomponents/markdownlint-cli2:0.12.0@sha256:a3977fba9814f10d33a1d69ae607dc808e7a6470b2ba03e84c17193c0791aac0
         imagePullPolicy: Always
   - name: shellcheck
     branches:

--- a/prow/config/jobs/metal3-io/cluster-api-provider-metal3-release-1.13.yaml
+++ b/prow/config/jobs/metal3-io/cluster-api-provider-metal3-release-1.13.yaml
@@ -44,7 +44,7 @@ presubmits:
         env:
         - name: IS_CONTAINER
           value: "TRUE"
-        image: docker.io/pipelinecomponents/markdownlint-cli2:0.14.19@sha256:c651559a31fefc82cf864486d9472338ffa0aaa529ebf71a035d4f1d913809aa
+        image: docker.io/pipelinecomponents/markdownlint-cli2:0.12.0@sha256:a3977fba9814f10d33a1d69ae607dc808e7a6470b2ba03e84c17193c0791aac0
         imagePullPolicy: Always
   - name: shellcheck
     branches:

--- a/prow/config/jobs/metal3-io/cluster-api-provider-metal3.yaml
+++ b/prow/config/jobs/metal3-io/cluster-api-provider-metal3.yaml
@@ -44,7 +44,7 @@ presubmits:
         env:
         - name: IS_CONTAINER
           value: "TRUE"
-        image: docker.io/pipelinecomponents/markdownlint-cli2:0.14.19@sha256:c651559a31fefc82cf864486d9472338ffa0aaa529ebf71a035d4f1d913809aa
+        image: docker.io/pipelinecomponents/markdownlint-cli2:0.12.0@sha256:a3977fba9814f10d33a1d69ae607dc808e7a6470b2ba03e84c17193c0791aac0
         imagePullPolicy: Always
   - name: shellcheck
     branches:

--- a/prow/config/jobs/metal3-io/community.yaml
+++ b/prow/config/jobs/metal3-io/community.yaml
@@ -12,7 +12,7 @@ presubmits:
         env:
         - name: IS_CONTAINER
           value: "TRUE"
-        image: docker.io/pipelinecomponents/markdownlint-cli2:0.14.19@sha256:c651559a31fefc82cf864486d9472338ffa0aaa529ebf71a035d4f1d913809aa
+        image: docker.io/pipelinecomponents/markdownlint-cli2:0.12.0@sha256:a3977fba9814f10d33a1d69ae607dc808e7a6470b2ba03e84c17193c0791aac0
         imagePullPolicy: Always
   - name: shellcheck
     run_if_changed: '((\.sh)|^Makefile)$'

--- a/prow/config/jobs/metal3-io/ip-address-manager-release-1.11.yaml
+++ b/prow/config/jobs/metal3-io/ip-address-manager-release-1.11.yaml
@@ -44,7 +44,7 @@ presubmits:
         env:
         - name: IS_CONTAINER
           value: "TRUE"
-        image: docker.io/pipelinecomponents/markdownlint-cli2:0.14.19@sha256:c651559a31fefc82cf864486d9472338ffa0aaa529ebf71a035d4f1d913809aa
+        image: docker.io/pipelinecomponents/markdownlint-cli2:0.12.0@sha256:a3977fba9814f10d33a1d69ae607dc808e7a6470b2ba03e84c17193c0791aac0
         imagePullPolicy: Always
   - name: shellcheck
     branches:

--- a/prow/config/jobs/metal3-io/ip-address-manager-release-1.12.yaml
+++ b/prow/config/jobs/metal3-io/ip-address-manager-release-1.12.yaml
@@ -44,7 +44,7 @@ presubmits:
         env:
         - name: IS_CONTAINER
           value: "TRUE"
-        image: docker.io/pipelinecomponents/markdownlint-cli2:0.14.19@sha256:c651559a31fefc82cf864486d9472338ffa0aaa529ebf71a035d4f1d913809aa
+        image: docker.io/pipelinecomponents/markdownlint-cli2:0.12.0@sha256:a3977fba9814f10d33a1d69ae607dc808e7a6470b2ba03e84c17193c0791aac0
         imagePullPolicy: Always
   - name: shellcheck
     branches:

--- a/prow/config/jobs/metal3-io/ip-address-manager-release-1.13.yaml
+++ b/prow/config/jobs/metal3-io/ip-address-manager-release-1.13.yaml
@@ -44,7 +44,7 @@ presubmits:
         env:
         - name: IS_CONTAINER
           value: "TRUE"
-        image: docker.io/pipelinecomponents/markdownlint-cli2:0.14.19@sha256:c651559a31fefc82cf864486d9472338ffa0aaa529ebf71a035d4f1d913809aa
+        image: docker.io/pipelinecomponents/markdownlint-cli2:0.12.0@sha256:a3977fba9814f10d33a1d69ae607dc808e7a6470b2ba03e84c17193c0791aac0
         imagePullPolicy: Always
   - name: shellcheck
     branches:

--- a/prow/config/jobs/metal3-io/ip-address-manager.yaml
+++ b/prow/config/jobs/metal3-io/ip-address-manager.yaml
@@ -44,7 +44,7 @@ presubmits:
         env:
         - name: IS_CONTAINER
           value: "TRUE"
-        image: docker.io/pipelinecomponents/markdownlint-cli2:0.14.19@sha256:c651559a31fefc82cf864486d9472338ffa0aaa529ebf71a035d4f1d913809aa
+        image: docker.io/pipelinecomponents/markdownlint-cli2:0.12.0@sha256:a3977fba9814f10d33a1d69ae607dc808e7a6470b2ba03e84c17193c0791aac0
         imagePullPolicy: Always
   - name: shellcheck
     branches:

--- a/prow/config/jobs/metal3-io/ironic-hardware-inventory-recorder-image.yaml
+++ b/prow/config/jobs/metal3-io/ironic-hardware-inventory-recorder-image.yaml
@@ -26,5 +26,5 @@ presubmits:
         env:
         - name: IS_CONTAINER
           value: "TRUE"
-        image: docker.io/pipelinecomponents/markdownlint-cli2:0.14.19@sha256:c651559a31fefc82cf864486d9472338ffa0aaa529ebf71a035d4f1d913809aa
+        image: docker.io/pipelinecomponents/markdownlint-cli2:0.12.0@sha256:a3977fba9814f10d33a1d69ae607dc808e7a6470b2ba03e84c17193c0791aac0
         imagePullPolicy: Always

--- a/prow/config/jobs/metal3-io/ironic-image-release-29.0.yaml
+++ b/prow/config/jobs/metal3-io/ironic-image-release-29.0.yaml
@@ -30,7 +30,7 @@ presubmits:
         env:
         - name: IS_CONTAINER
           value: "TRUE"
-        image: docker.io/pipelinecomponents/markdownlint-cli2:0.14.19@sha256:c651559a31fefc82cf864486d9472338ffa0aaa529ebf71a035d4f1d913809aa
+        image: docker.io/pipelinecomponents/markdownlint-cli2:0.12.0@sha256:a3977fba9814f10d33a1d69ae607dc808e7a6470b2ba03e84c17193c0791aac0
         imagePullPolicy: Always
   # name: {job_prefix}-{image_os}-e2e-integration-test-{capm3_target_branch}
   - name: metal3-centos-e2e-integration-test-release-1-10

--- a/prow/config/jobs/metal3-io/ironic-image-release-32.0.yaml
+++ b/prow/config/jobs/metal3-io/ironic-image-release-32.0.yaml
@@ -30,7 +30,7 @@ presubmits:
         env:
         - name: IS_CONTAINER
           value: "TRUE"
-        image: docker.io/pipelinecomponents/markdownlint-cli2:0.14.19@sha256:c651559a31fefc82cf864486d9472338ffa0aaa529ebf71a035d4f1d913809aa
+        image: docker.io/pipelinecomponents/markdownlint-cli2:0.12.0@sha256:a3977fba9814f10d33a1d69ae607dc808e7a6470b2ba03e84c17193c0791aac0
         imagePullPolicy: Always
   # name: {job_prefix}-{image_os}-e2e-integration-test-{capm3_target_branch}
   - name: metal3-centos-e2e-integration-test-release-1-11

--- a/prow/config/jobs/metal3-io/ironic-image-release-33.0.yaml
+++ b/prow/config/jobs/metal3-io/ironic-image-release-33.0.yaml
@@ -30,7 +30,7 @@ presubmits:
         env:
         - name: IS_CONTAINER
           value: "TRUE"
-        image: docker.io/pipelinecomponents/markdownlint-cli2:0.14.19@sha256:c651559a31fefc82cf864486d9472338ffa0aaa529ebf71a035d4f1d913809aa
+        image: docker.io/pipelinecomponents/markdownlint-cli2:0.12.0@sha256:a3977fba9814f10d33a1d69ae607dc808e7a6470b2ba03e84c17193c0791aac0
         imagePullPolicy: Always
   # name: {job_prefix}-{image_os}-e2e-integration-test-{capm3_target_branch}
   - name: metal3-centos-e2e-integration-test-release-1-12

--- a/prow/config/jobs/metal3-io/ironic-image-release-34.0.yaml
+++ b/prow/config/jobs/metal3-io/ironic-image-release-34.0.yaml
@@ -30,7 +30,7 @@ presubmits:
         env:
         - name: IS_CONTAINER
           value: "TRUE"
-        image: docker.io/pipelinecomponents/markdownlint-cli2:0.14.19@sha256:c651559a31fefc82cf864486d9472338ffa0aaa529ebf71a035d4f1d913809aa
+        image: docker.io/pipelinecomponents/markdownlint-cli2:0.12.0@sha256:a3977fba9814f10d33a1d69ae607dc808e7a6470b2ba03e84c17193c0791aac0
         imagePullPolicy: Always
   # name: {job_prefix}-{image_os}-e2e-integration-test-{capm3_target_branch}
   - name: metal3-centos-e2e-integration-test-release-1-12

--- a/prow/config/jobs/metal3-io/ironic-image-release-35.0.yaml
+++ b/prow/config/jobs/metal3-io/ironic-image-release-35.0.yaml
@@ -30,7 +30,7 @@ presubmits:
         env:
         - name: IS_CONTAINER
           value: "TRUE"
-        image: docker.io/pipelinecomponents/markdownlint-cli2:0.14.19@sha256:c651559a31fefc82cf864486d9472338ffa0aaa529ebf71a035d4f1d913809aa
+        image: docker.io/pipelinecomponents/markdownlint-cli2:0.12.0@sha256:a3977fba9814f10d33a1d69ae607dc808e7a6470b2ba03e84c17193c0791aac0
         imagePullPolicy: Always
   # name: {job_prefix}-{image_os}-e2e-integration-test-{capm3_target_branch}
   - name: metal3-centos-e2e-integration-test-release-1-13

--- a/prow/config/jobs/metal3-io/ironic-image-release-37.0.yaml
+++ b/prow/config/jobs/metal3-io/ironic-image-release-37.0.yaml
@@ -30,7 +30,7 @@ presubmits:
         env:
         - name: IS_CONTAINER
           value: "TRUE"
-        image: docker.io/pipelinecomponents/markdownlint-cli2:0.14.19@sha256:c651559a31fefc82cf864486d9472338ffa0aaa529ebf71a035d4f1d913809aa
+        image: docker.io/pipelinecomponents/markdownlint-cli2:0.12.0@sha256:a3977fba9814f10d33a1d69ae607dc808e7a6470b2ba03e84c17193c0791aac0
         imagePullPolicy: Always
   # name: {job_prefix}-{image_os}-e2e-integration-test-{capm3_target_branch}
   - name: metal3-centos-e2e-integration-test-release-1-13

--- a/prow/config/jobs/metal3-io/ironic-image.yaml
+++ b/prow/config/jobs/metal3-io/ironic-image.yaml
@@ -30,7 +30,7 @@ presubmits:
         env:
         - name: IS_CONTAINER
           value: "TRUE"
-        image: docker.io/pipelinecomponents/markdownlint-cli2:0.14.19@sha256:c651559a31fefc82cf864486d9472338ffa0aaa529ebf71a035d4f1d913809aa
+        image: docker.io/pipelinecomponents/markdownlint-cli2:0.12.0@sha256:a3977fba9814f10d33a1d69ae607dc808e7a6470b2ba03e84c17193c0791aac0
         imagePullPolicy: Always
   - name: renovate-config-validator
     branches:

--- a/prow/config/jobs/metal3-io/ironic-ipa-downloader.yaml
+++ b/prow/config/jobs/metal3-io/ironic-ipa-downloader.yaml
@@ -26,7 +26,7 @@ presubmits:
         env:
         - name: IS_CONTAINER
           value: "TRUE"
-        image: docker.io/pipelinecomponents/markdownlint-cli2:0.14.19@sha256:c651559a31fefc82cf864486d9472338ffa0aaa529ebf71a035d4f1d913809aa
+        image: docker.io/pipelinecomponents/markdownlint-cli2:0.12.0@sha256:a3977fba9814f10d33a1d69ae607dc808e7a6470b2ba03e84c17193c0791aac0
         imagePullPolicy: Always
   # name: {job_prefix}-{image_os}-e2e-integration-test-{capm3_target_branch}
   - name: metal3-centos-e2e-integration-test-main

--- a/prow/config/jobs/metal3-io/ironic-standalone-operator-release-0.10.yaml
+++ b/prow/config/jobs/metal3-io/ironic-standalone-operator-release-0.10.yaml
@@ -46,7 +46,7 @@ presubmits:
         env:
         - name: IS_CONTAINER
           value: "TRUE"
-        image: docker.io/pipelinecomponents/markdownlint-cli2:0.14.19@sha256:c651559a31fefc82cf864486d9472338ffa0aaa529ebf71a035d4f1d913809aa
+        image: docker.io/pipelinecomponents/markdownlint-cli2:0.12.0@sha256:a3977fba9814f10d33a1d69ae607dc808e7a6470b2ba03e84c17193c0791aac0
         imagePullPolicy: Always
   - name: manifestlint
     branches:

--- a/prow/config/jobs/metal3-io/ironic-standalone-operator-release-0.7.yaml
+++ b/prow/config/jobs/metal3-io/ironic-standalone-operator-release-0.7.yaml
@@ -46,7 +46,7 @@ presubmits:
         env:
         - name: IS_CONTAINER
           value: "TRUE"
-        image: docker.io/pipelinecomponents/markdownlint-cli2:0.14.19@sha256:c651559a31fefc82cf864486d9472338ffa0aaa529ebf71a035d4f1d913809aa
+        image: docker.io/pipelinecomponents/markdownlint-cli2:0.12.0@sha256:a3977fba9814f10d33a1d69ae607dc808e7a6470b2ba03e84c17193c0791aac0
         imagePullPolicy: Always
   - name: manifestlint
     branches:

--- a/prow/config/jobs/metal3-io/ironic-standalone-operator-release-0.8.yaml
+++ b/prow/config/jobs/metal3-io/ironic-standalone-operator-release-0.8.yaml
@@ -46,7 +46,7 @@ presubmits:
         env:
         - name: IS_CONTAINER
           value: "TRUE"
-        image: docker.io/pipelinecomponents/markdownlint-cli2:0.14.19@sha256:c651559a31fefc82cf864486d9472338ffa0aaa529ebf71a035d4f1d913809aa
+        image: docker.io/pipelinecomponents/markdownlint-cli2:0.12.0@sha256:a3977fba9814f10d33a1d69ae607dc808e7a6470b2ba03e84c17193c0791aac0
         imagePullPolicy: Always
   - name: manifestlint
     branches:

--- a/prow/config/jobs/metal3-io/ironic-standalone-operator-release-0.9.yaml
+++ b/prow/config/jobs/metal3-io/ironic-standalone-operator-release-0.9.yaml
@@ -46,7 +46,7 @@ presubmits:
         env:
         - name: IS_CONTAINER
           value: "TRUE"
-        image: docker.io/pipelinecomponents/markdownlint-cli2:0.14.19@sha256:c651559a31fefc82cf864486d9472338ffa0aaa529ebf71a035d4f1d913809aa
+        image: docker.io/pipelinecomponents/markdownlint-cli2:0.12.0@sha256:a3977fba9814f10d33a1d69ae607dc808e7a6470b2ba03e84c17193c0791aac0
         imagePullPolicy: Always
   - name: manifestlint
     branches:

--- a/prow/config/jobs/metal3-io/ironic-standalone-operator.yaml
+++ b/prow/config/jobs/metal3-io/ironic-standalone-operator.yaml
@@ -46,7 +46,7 @@ presubmits:
         env:
         - name: IS_CONTAINER
           value: "TRUE"
-        image: docker.io/pipelinecomponents/markdownlint-cli2:0.14.19@sha256:c651559a31fefc82cf864486d9472338ffa0aaa529ebf71a035d4f1d913809aa
+        image: docker.io/pipelinecomponents/markdownlint-cli2:0.12.0@sha256:a3977fba9814f10d33a1d69ae607dc808e7a6470b2ba03e84c17193c0791aac0
         imagePullPolicy: Always
   - name: manifestlint
     branches:

--- a/prow/config/jobs/metal3-io/mariadb-image.yaml
+++ b/prow/config/jobs/metal3-io/mariadb-image.yaml
@@ -26,7 +26,7 @@ presubmits:
         env:
         - name: IS_CONTAINER
           value: "TRUE"
-        image: docker.io/pipelinecomponents/markdownlint-cli2:0.14.19@sha256:c651559a31fefc82cf864486d9472338ffa0aaa529ebf71a035d4f1d913809aa
+        image: docker.io/pipelinecomponents/markdownlint-cli2:0.12.0@sha256:a3977fba9814f10d33a1d69ae607dc808e7a6470b2ba03e84c17193c0791aac0
         imagePullPolicy: Always
   # name: {job_prefix}-{image_os}-e2e-integration-test-{capm3_target_branch}
   - name: metal3-centos-e2e-integration-test-main

--- a/prow/config/jobs/metal3-io/metal3-dev-env.yaml
+++ b/prow/config/jobs/metal3-io/metal3-dev-env.yaml
@@ -26,7 +26,7 @@ presubmits:
         env:
         - name: IS_CONTAINER
           value: "TRUE"
-        image: docker.io/pipelinecomponents/markdownlint-cli2:0.14.19@sha256:c651559a31fefc82cf864486d9472338ffa0aaa529ebf71a035d4f1d913809aa
+        image: docker.io/pipelinecomponents/markdownlint-cli2:0.12.0@sha256:a3977fba9814f10d33a1d69ae607dc808e7a6470b2ba03e84c17193c0791aac0
         imagePullPolicy: Always
   - name: renovate-config-validator
     run_if_changed: '(renovate\.json|renovate-validator\.sh)$'

--- a/prow/config/jobs/metal3-io/metal3-docs.yaml
+++ b/prow/config/jobs/metal3-io/metal3-docs.yaml
@@ -12,7 +12,7 @@ presubmits:
         env:
         - name: IS_CONTAINER
           value: "TRUE"
-        image: docker.io/pipelinecomponents/markdownlint-cli2:0.14.19@sha256:c651559a31fefc82cf864486d9472338ffa0aaa529ebf71a035d4f1d913809aa
+        image: docker.io/pipelinecomponents/markdownlint-cli2:0.12.0@sha256:a3977fba9814f10d33a1d69ae607dc808e7a6470b2ba03e84c17193c0791aac0
         imagePullPolicy: Always
   - name: shellcheck
     run_if_changed: '((\.sh)|^Makefile)$'

--- a/prow/config/jobs/metal3-io/metal3-io.github.io.yaml
+++ b/prow/config/jobs/metal3-io/metal3-io.github.io.yaml
@@ -26,7 +26,7 @@ presubmits:
         env:
         - name: IS_CONTAINER
           value: "TRUE"
-        image: docker.io/pipelinecomponents/markdownlint-cli2:0.14.19@sha256:c651559a31fefc82cf864486d9472338ffa0aaa529ebf71a035d4f1d913809aa
+        image: docker.io/pipelinecomponents/markdownlint-cli2:0.12.0@sha256:a3977fba9814f10d33a1d69ae607dc808e7a6470b2ba03e84c17193c0791aac0
         imagePullPolicy: Always
   - name: spellcheck
     run_if_changed: '(\.md|spellcheck\.sh|.cspell-config.json)$'

--- a/prow/config/jobs/metal3-io/project-infra.yaml
+++ b/prow/config/jobs/metal3-io/project-infra.yaml
@@ -31,7 +31,7 @@ presubmits:
         env:
         - name: IS_CONTAINER
           value: "TRUE"
-        image: docker.io/pipelinecomponents/markdownlint-cli2:0.14.19@sha256:c651559a31fefc82cf864486d9472338ffa0aaa529ebf71a035d4f1d913809aa
+        image: docker.io/pipelinecomponents/markdownlint-cli2:0.12.0@sha256:a3977fba9814f10d33a1d69ae607dc808e7a6470b2ba03e84c17193c0791aac0
         imagePullPolicy: Always
   - name: shellcheck
     run_if_changed: '((\.sh)|^Makefile)$'

--- a/prow/config/jobs/metal3-io/utility-images.yaml
+++ b/prow/config/jobs/metal3-io/utility-images.yaml
@@ -26,5 +26,5 @@ presubmits:
         env:
         - name: IS_CONTAINER
           value: "TRUE"
-        image: docker.io/pipelinecomponents/markdownlint-cli2:0.14.19@sha256:c651559a31fefc82cf864486d9472338ffa0aaa529ebf71a035d4f1d913809aa
+        image: docker.io/pipelinecomponents/markdownlint-cli2:0.12.0@sha256:a3977fba9814f10d33a1d69ae607dc808e7a6470b2ba03e84c17193c0791aac0
         imagePullPolicy: Always


### PR DESCRIPTION
The update brought in new rules, breaking all PRs on metal3-docs, CAPM3 and potentially everywhere else.

Reverts metal3-io/project-infra#1419