### PR TITLE
improve standard OCI version label generation

### DIFF
--- a/.github/workflows/container-image-build.yml
+++ b/.github/workflows/container-image-build.yml
@@ -106,6 +106,7 @@ jobs:
       with:
         ref: ${{ env.RESOLVED_REF }}
         persist-credentials: false
+        fetch-depth: ${{ inputs.image-tag != '' && 1 || 0 }}
 
     - name: Set resolved ref SHA after checkout
       id: set_refsha
@@ -123,21 +124,26 @@ jobs:
         STEPS_DATE_OUTPUTS_CURRENT_DATE: ${{ steps.date.outputs.current_date }}
         INPUTS_IMAGE_TAG: ${{ inputs.image-tag }}
       run: |
-        BASE_TAG=$(echo "${RESOLVED_REFNAME}" | sed 's/\//_/')
+        set -euo pipefail
+
+        # Image tag generation
+        BASE_TAG="${RESOLVED_REFNAME//\//_}"
         IMAGE_TAGS="${BASE_TAG}, ${BASE_TAG}_${STEPS_DATE_OUTPUTS_CURRENT_DATE}_${RESOLVED_REFSHA}"
 
         if [[ -n "${INPUTS_IMAGE_TAG}" ]]; then
+          # Tag and version are coming from the caller
           IMAGE_TAGS="${INPUTS_IMAGE_TAG}"
           IMAGE_VERSION="${INPUTS_IMAGE_TAG}"
-        elif [[ "${RESOLVED_REF}" == "refs/heads/main" ]]; then
-          IMAGE_TAGS="${IMAGE_TAGS}, latest"
-          IMAGE_VERSION="latest"
         else
-          IMAGE_VERSION="${RESOLVED_REFNAME}"
+          if [[ "${RESOLVED_REF}" == "refs/heads/main" ]]; then
+            IMAGE_TAGS="${IMAGE_TAGS}, latest"
+          fi
+          IMAGE_VERSION="$(./hack/versioncheck.sh --resolved_refname="${RESOLVED_REFNAME}" --resolved_ref="${RESOLVED_REFSHA}")"
         fi
 
         echo "IMAGE_TAGS=${IMAGE_TAGS}" >> "${GITHUB_ENV}"
         echo "IMAGE_VERSION=${IMAGE_VERSION}" >> "${GITHUB_ENV}"
+        echo "IMAGE_REVISION=${RESOLVED_REFSHA}" >> "${GITHUB_ENV}"
 
     - name: Download artifact
       id: download-artifact
@@ -159,6 +165,7 @@ jobs:
         buildArgs: ${{ inputs.image-build-args || '' }}
         labels: |
           org.opencontainers.image.version=${{ env.IMAGE_VERSION }}
+          org.opencontainers.image.revision=${{ env.IMAGE_REVISION }}
         registry: quay.io
         username: ${{ secrets.QUAY_USERNAME }} # zizmor: ignore[secrets-outside-env]
         password: ${{ secrets.QUAY_PASSWORD }} # zizmor: ignore[secrets-outside-env]

--- a/hack/versioncheck.md
+++ b/hack/versioncheck.md
@@ -1,0 +1,90 @@
+# Version checker script user guide
+
+Generates SemVer-compliant version strings for the Metal3 project based on
+the current Git branch, tags, and commit distance. Designed for CI pipelines
+where container images and artifacts need meaningful, sortable version labels.
+
+This script expects release tags to follow the SemVer format (e.g., `v1.2.3`).
+It only generates SemVer-compliant versions on `main` and `release-*` branches.
+All other branches fall back to `SHORTSHA_branchname` (7-char SHA prefix,
+slashes replaced with dashes).
+
+## Usage
+
+```bash
+./versioncheck.sh [OPTIONS]
+```
+
+## Options
+
+| Option | Description |
+|--------|-------------|
+| `--debug` | Print debug information to stderr |
+| `--nogtag` | Ignore global tags for version calculation. Useful for forks with custom tag strings. Falls back to `SHORTSHA_refname` when tags outside of HEAD's branch are irrelevant or have no common ancestry with the latest tag's branch |
+| `--resolved_refname=<name>` | Override the branch/ref name (default: current branch from `git rev-parse --abbrev-ref HEAD`) |
+| `--resolved_ref=<sha>` | Override the commit SHA (default: current HEAD from `git rev-parse HEAD`) |
+
+Options can be provided in any order.
+
+## Examples
+
+```bash
+# Auto-detect branch and ref
+./versioncheck.sh
+
+# With debug output
+./versioncheck.sh --debug
+
+# Simulate running on main branch
+./versioncheck.sh --resolved_refname=main
+
+# Simulate a release branch
+./versioncheck.sh --resolved_refname=release-1.2
+
+# Fork with non-standard tags
+./versioncheck.sh --nogtag
+```
+
+## Version Output by Use Case
+
+| # | Scenario | Output | SemVer |
+|---|----------|--------|--------|
+| 1 | `main`, ahead of latest tag | `MAJOR.(MINOR+1).0-dev.N+SHA` | ✅ |
+| 2 | `main`, at merge-base (0 distance) | `MAJOR.MINOR.PATCH` | ✅ |
+| 3 | `main` + `--nogtag` | `a1b2c3d_main` | fallback |
+| 4 | `release-X.Y`, tag matches, ahead of tag | `MAJOR.MINOR.(PATCH+1)-dev.N+SHA` | ✅ |
+| 5 | `release-X.Y`, exactly on tag | `MAJOR.MINOR.PATCH` | ✅ |
+| 6 | `release-X.Y.Z` (3-segment branch name) | Strips patch → same as #4/#5 | ✅ |
+| 7 | `release-X.Y`, tag minor ≠ branch minor | `X.Y.0-dev.N+SHA` | ✅ |
+| 8 | `release-X.Y`, tag mismatch + `--nogtag` | `a1b2c3d_release-X.Y` | fallback |
+| 9 | `release-*`, no tags on branch and no reachable ancestor with latest tag | `a1b2c3d_release-X.Y` | fallback |
+| 10 | No common ancestor with latest tag in the repo (`--nogtag` avoids this issue) | Error + exit 1 | N/A |
+| 11 | Feature / other branch (e.g. `feature/foo`) | `a1b2c3d_feature-foo` | fallback |
+| 12 | No tags in repo (without `--nogtag`) | Error + exit 1 | N/A |
+| 13 | No tags in repo + `--nogtag` | `a1b2c3d_branchname` | fallback |
+
+Rows marked **fallback** produce a non-SemVer `SHORTSHA_branchname` identifier
+(7-char SHA, slashes replaced with dashes) for traceability when a proper
+version cannot be determined.
+
+## SemVer Compliance
+
+Output follows [SemVer 2.0.0](https://semver.org/) format:
+`MAJOR.MINOR.PATCH[-PRERELEASE][+BUILDMETADATA]`
+
+- **Pre-release** (`-dev.N`): commit count from base, ensures correct sort
+  order between dev builds
+- **Build metadata** (`+SHA`): short commit hash for traceability, ignored
+  for precedence
+- **Precedence**: `1.2.0 < 1.3.0-dev.5+abc123 < 1.3.0`
+
+## Requirements
+
+- Git repository with at least one SemVer tag (e.g., `v1.0.0`) unless
+  `--nogtag` is used
+- Full clone (not shallow) for accurate commit counts and `merge-base`
+- In all cases, generating SemVer for a main or release branch requires:
+   - A tag reachable on the branch as an ancestor of the HEAD
+   - OR a common ancestor between the HEAD and the latest tag in the repo
+- `--nogtag` bypasses the tag existence requirement, producing a
+  fallback version instead of an error for repos that lack tags completely

--- a/hack/versioncheck.sh
+++ b/hack/versioncheck.sh
@@ -1,0 +1,114 @@
+#!/bin/bash
+set -euo pipefail
+
+debug() {
+    if [[ "${DEBUG}" == true ]]; then
+        echo "[DEBUG] $*" >&2
+    fi
+}
+
+distance_from_base() {
+    local BASE="$1"
+    local COUNT; COUNT=$(git rev-list --count "${BASE}"..HEAD)
+    if [[ "${COUNT}" -gt 0 ]]; then
+        local SHORT; SHORT=$(git rev-parse --short HEAD)
+        echo "-dev.${COUNT}+${SHORT}"
+    fi
+}
+
+DEBUG=false
+IGNORE_GTAGS=false
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        --debug)              DEBUG=true ;;
+        --nogtag)             IGNORE_GTAGS=true ;;
+        --resolved_refname=*) RESOLVED_REFNAME="${1#--resolved_refname=}" ;;
+        --resolved_ref=*)     RESOLVED_REF="${1#--resolved_ref=}" ;;
+        *)                    echo "ERROR: Unknown option: $1" >&2; exit 1 ;;
+    esac
+    shift
+done
+
+RESOLVED_REFNAME="${RESOLVED_REFNAME:-$(git rev-parse --abbrev-ref HEAD)}"
+RESOLVED_REF="${RESOLVED_REF:-$(git rev-parse HEAD)}"
+# Defaults to short ref combined with parser friendly branch name
+RETURN_VAL="${RESOLVED_REF:0:7}_${RESOLVED_REFNAME//\//-}"
+
+if [[ "${IGNORE_GTAGS}" == false ]]; then
+    # Determine the Git tag with the highest version number in the repo
+    LATEST_GTAG=$(git tag --sort=-version:refname | head -1)
+    if [[ -z "${LATEST_GTAG}" ]]; then
+        echo "ERROR: No tags found in repository" >&2
+        exit 1
+    fi
+    LATEST_GTAG_VERSION="${LATEST_GTAG#v}"
+    debug "LATEST_GTAG_VERSION=${LATEST_GTAG_VERSION}"
+    # Next expected version based on heuristic
+    IFS='.' read -r MAJOR MINOR PATCH <<< "${LATEST_GTAG_VERSION}"
+    NEXT_MINOR="${MAJOR}.$((MINOR + 1)).0"
+    debug "NEXT EXPECTED GLOBAL MINOR=${NEXT_MINOR}"
+    # Determine common ancestor with latest Git tag
+    BASE="$(git merge-base HEAD "${LATEST_GTAG}")" || {
+        echo "ERROR: current branch and latest tag have no common ancestor" >&2
+        exit 1
+    }
+    debug "COMMON BASE WITH NEXT EXPECTED MINOR=${BASE}"
+fi
+
+if [[ "${RESOLVED_REFNAME}" == "main" ]]; then
+    # Main branches are generally not tagged
+    debug "Main branch detected!"
+    if [[ "${IGNORE_GTAGS}" == false ]]; then
+        DELTA="$(distance_from_base "${BASE}")"
+        if [[ -n "${DELTA}" ]]; then
+            RETURN_VAL="${NEXT_MINOR}${DELTA}"
+        else
+            RETURN_VAL="${LATEST_GTAG_VERSION}"
+        fi
+    fi
+elif [[ "${RESOLVED_REFNAME}" =~ ^release- ]]; then
+    # Release branches have proper tags
+    debug "Release branch detected!"
+    BRANCH_MINOR="${RESOLVED_REFNAME#release-}"
+    debug "Release branch version: ${BRANCH_MINOR}"
+    if [[ "${BRANCH_MINOR}" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+        BRANCH_MINOR="${BRANCH_MINOR%.[0-9]*}"
+    fi
+    debug "Branch minor: ${BRANCH_MINOR}"
+    CURRENT_TAG="$(git describe --tags --abbrev=0)" || {
+        debug "No tags on release branch: ${RESOLVED_REFNAME}"
+        CURRENT_TAG="NOTAG"
+    }
+    TAG_MINOR="${CURRENT_TAG#v}"
+    TAG_MINOR="${TAG_MINOR%.[0-9]*}"
+    debug "Tag minor: ${TAG_MINOR}"
+
+    if [[ "${CURRENT_TAG}" != "NOTAG" ]] && [[ "${IGNORE_GTAGS}" == "false" ]];
+    then
+        if [[ "${BRANCH_MINOR}" == "${TAG_MINOR}" ]]; then
+            # Pre release of a patch, counted from last tag on branch
+            IFS='.' read -r MAJOR MINOR PATCH <<< "${CURRENT_TAG#v}"
+            debug "PARSED BRANCH TAG VERSION=${MAJOR}.${MINOR}.${PATCH}"
+            NEXT_PATCH="${MAJOR}.${MINOR}.$((PATCH + 1))"
+            PATCH_BASE="$(git merge-base HEAD "${CURRENT_TAG}")"
+            DELTA="$(distance_from_base "${PATCH_BASE}")"
+            if [[ -n "${DELTA}" ]]; then
+                RETURN_VAL="${NEXT_PATCH}${DELTA}"
+            else
+                RETURN_VAL="${CURRENT_TAG#v}"
+            fi
+        else
+            # Pre release of minor, counted from common base with latest tag
+            # This is very similar to what main branch would produce with
+            # different distance because the HEAD is on a release branch
+            RETURN_VAL="${BRANCH_MINOR}.0$(distance_from_base "${BASE}")"
+        fi
+    fi
+fi
+
+# Final fallback option:
+# script was called on a branch other than main or release branch
+# --nogtag was used but there were no local tags on target branch
+# repo has no tags at all
+echo "${RETURN_VAL}"
+


### PR DESCRIPTION
This PR:
- Add hack/versioncheck.sh for git-based version generation
- Add hack/versioncheck.md documenting all version output cases
- Replace static "latest"/branch name with SemVer in IMAGE_VERSION in container-image-build.yml reusable workflow
- Introduce org.opencontainers.image.revision label (commit SHA) in container-image-build.yml reusable workflow
- Add conditional fetch-depth (full clone only when needed) in image build workflow
- Add set -euo pipefail to image tag generation step
- Graceful fallback (SHORTSHA_branch) when tags are unavailable

Reason for the change:

Previously, IMAGE_VERSION was set to "latest" on main and the bare branch name on other branches. This provided no traceability, no sorting capability, and violated the intent of OCI version annotations.

The new version script produces proper SemVer pre-release strings (e.g., 0.8.0-dev.5+abc1234) based on commit distance from tags, enabling automated version comparisons and unique identification of every build. The revision label adds exact commit provenance, which strengthens the supply chain integrity alongside the existing SBOM generation and Cosign attestation steps in this workflow.

The new versioncheck.sh can be used in a standalone mode too.
