### PR TITLE
Introduce new Jenkins orchestrator

### DIFF
--- a/prow/config/config.yaml
+++ b/prow/config/config.yaml
@@ -132,9 +132,18 @@ deck:
       - podinfo.json
   external_agent_logs:
   - agent: jenkins
+    selector: "!jenkins_operator"
     url_template: "http://jenkins-operator/job/{{.Spec.Job}}/{{.Status.JenkinsBuildID}}/consoleText"
+  - agent: jenkins
+    selector: "jenkins_operator=oci"
+    url_template: "http://oci-jenkins-operator/job/{{.Spec.Job}}/{{.Status.JenkinsBuildID}}/consoleText"
 
 jenkins_operators:
-- max_concurrency: 150
+- label_selector: "!jenkins_operator"
+  max_concurrency: 150
   max_goroutines: 20
   job_url_template: "https://jenkins.nordix.org/view/Metal3/job/{{.Spec.Job}}/{{.Status.JenkinsBuildID}}/"
+- label_selector: jenkins_operator=oci
+  max_concurrency: 150
+  max_goroutines: 20
+  job_url_template: "https://jenkins.apps.test.metal3.io/view/Metal3/job/{{.Spec.Job}}/{{.Status.JenkinsBuildID}}/"

--- a/prow/config/jobs/metal3-io/cluster-api-provider-metal3-release-1.12.yaml
+++ b/prow/config/jobs/metal3-io/cluster-api-provider-metal3-release-1.12.yaml
@@ -133,12 +133,16 @@ presubmits:
     branches:
     - release-1.12
     agent: jenkins
+    labels:
+      jenkins_operator: oci
     always_run: false
     optional: true
   - name: metal3-ubuntu-e2e-basic-test-release-1-12
     branches:
     - release-1.12
     agent: jenkins
+    labels:
+      jenkins_operator: oci
     always_run: false
     optional: true
   # name: {job_prefix}-{image_os}-e2e-integration-test-{capm3_target_branch}

--- a/prow/manifests/overlays/metal3/external-plugins/oci-jenkins-operator.yaml
+++ b/prow/manifests/overlays/metal3/external-plugins/oci-jenkins-operator.yaml
@@ -1,11 +1,11 @@
 apiVersion: v1
 kind: Service
 metadata:
-  name: jenkins-operator
+  name: oci-jenkins-operator
   namespace: prow
 spec:
   selector:
-    app: jenkins-operator
+    jenkins_operator: oci
   ports:
   - port: 80
     targetPort: 8080
@@ -15,9 +15,9 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   namespace: prow
-  name: jenkins-operator
+  name: oci-jenkins-operator
   labels:
-    app: jenkins-operator
+    jenkins_operator: oci
 spec:
   replicas: 1
   strategy:
@@ -27,26 +27,26 @@ spec:
       maxUnavailable: 1
   selector:
     matchLabels:
-      app: jenkins-operator
+      jenkins_operator: oci
   template:
     metadata:
       labels:
-        app: jenkins-operator
+        jenkins_operator: oci
     spec:
-      serviceAccountName: jenkins-operator
+      serviceAccountName: oci-jenkins-operator
       containers:
-      - name: jenkins-operator
+      - name: oci-jenkins-operator
         image: us-docker.pkg.dev/k8s-infra-prow/images/jenkins-operator:v20260531-24f6b2904
         args:
         - --config-path=/etc/config/config.yaml
         - --job-config-path=/etc/job-config
-        - --jenkins-url=https://jenkins.nordix.org
-        - --jenkins-user=metal3.bot@gmail.com
+        - --jenkins-url=https://jenkins.apps.test.metal3.io
+        - --jenkins-user=prow
         - --jenkins-token-file=/etc/jenkins/token
         - --github-token-path=/etc/github/token
         - --github-endpoint=http://ghproxy
         - --github-endpoint=https://api.github.com
-        - --label-selector=!jenkins_operator
+        - --label-selector=jenkins_operator=oci
         - --skip-report=false
         - --dry-run=false
         ports:
@@ -57,7 +57,7 @@ spec:
         - name: github-token
           mountPath: /etc/github
           readOnly: true
-        - name: jenkins-token
+        - name: oci-jenkins-token
           mountPath: /etc/jenkins
           readOnly: true
         - name: config
@@ -70,9 +70,9 @@ spec:
       - name: github-token
         secret:
           secretName: github-token
-      - name: jenkins-token
+      - name: oci-jenkins-token
         secret:
-          secretName: jenkins-token
+          secretName: oci-jenkins-token
       - name: config
         configMap:
           name: config
@@ -84,13 +84,13 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   namespace: prow
-  name: jenkins-operator
+  name: oci-jenkins-operator
 ---
 kind: Role
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   namespace: prow
-  name: jenkins-operator
+  name: oci-jenkins-operator
 rules:
 - apiGroups:
   - "prow.k8s.io"
@@ -107,11 +107,11 @@ kind: RoleBinding
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   namespace: prow
-  name: jenkins-operator
+  name: oci-jenkins-operator
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: Role
-  name: jenkins-operator
+  name: oci-jenkins-operator
 subjects:
 - kind: ServiceAccount
-  name: jenkins-operator
+  name: oci-jenkins-operator

--- a/prow/manifests/overlays/metal3/kustomization.yaml
+++ b/prow/manifests/overlays/metal3/kustomization.yaml
@@ -11,6 +11,7 @@ resources:
 - external-plugins/needs-rebase_service.yaml
 - external-plugins/labels_cronjob.yaml
 - external-plugins/jenkins-operator.yaml
+- external-plugins/oci-jenkins-operator.yaml
 - external-plugins/copilot-review-deployment.yaml
 - external-plugins/copilot-review-service.yaml
 - pdb.yaml
@@ -32,6 +33,7 @@ patches:
 - path: patches/cherrypicker.yaml
 - path: patches/needs-rebase.yaml
 - path: patches/jenkins-operator.yaml
+- path: patches/oci-jenkins-operator.yaml
 - path: patches/copilot-review.yaml
 # Run on infra nodes
 - path: toleration-node-selector-patch.yaml

--- a/prow/manifests/overlays/metal3/patches/oci-jenkins-operator.yaml
+++ b/prow/manifests/overlays/metal3/patches/oci-jenkins-operator.yaml
@@ -1,0 +1,14 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  namespace: prow
+  name: oci-jenkins-operator
+spec:
+  template:
+    spec:
+      containers:
+      - name: oci-jenkins-operator
+        resources:
+          requests:
+            cpu: 50m
+            memory: 50Mi

--- a/prow/manifests/overlays/metal3/prow-externalsecrets.yaml
+++ b/prow/manifests/overlays/metal3/prow-externalsecrets.yaml
@@ -99,3 +99,20 @@ spec:
     remoteRef:
       # <item-name>/[section-name/]<field-name>
       key: "prow-copilot-review-github-token/password"
+---
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: oci-jenkins-token
+  namespace: prow
+spec:
+  secretStoreRef:
+    kind: ClusterSecretStore
+    name: onepassword
+  target:
+    creationPolicy: Owner
+  data:
+  - secretKey: token
+    remoteRef:
+      # <item-name>/[section-name/]<field-name>
+      key: "prow-oci-jenkins-token/password"


### PR DESCRIPTION
This PR:
 - Introduces a new Jenkins orchestrator to prow, now prow should be able to trigger jobs on jenkins.apps.test.metal3.io
 - Extend the list of prow  ExternalSecrets with a jenkins token to facilitate API access towards the new Jenkins server
 - Modifies the trigger mechanism of CAPM3 release 1.12 PR basic release test jobs to target the new server. (Rarely executed so I choose these for testing)
 - Removes unused RBAC rules from original jenkins-operator.yaml, not needed, jenkins-operator is not using neither lease based locks nor configmap based locks.

Background:
Metal3-io project is gradually moving all of its Infra to CNCF sponsored and community managed Oracle Cloud resourced.