### PR TITLE
Move release 1.12/0.12 jobs to oci jenkins

### DIFF
--- a/prow/config/jobs/metal3-io/baremetal-operator-release-0.12.yaml
+++ b/prow/config/jobs/metal3-io/baremetal-operator-release-0.12.yaml
@@ -108,84 +108,112 @@ presubmits:
     branches:
     - release-0.12
     agent: jenkins
+    labels:
+      jenkins_operator: oci
     always_run: false
     optional: true
   - name: metal3-ubuntu-e2e-basic-test-release-1-12
     branches:
     - release-0.12
     agent: jenkins
+    labels:
+      jenkins_operator: oci
     always_run: false
     optional: true
   - name: metal3-centos-e2e-integration-test-release-1-12
     branches:
     - release-0.12
     agent: jenkins
+    labels:
+      jenkins_operator: oci
     always_run: false
     optional: true
   - name: metal3-ubuntu-e2e-integration-test-release-1-12
     branches:
     - release-0.12
     agent: jenkins
+    labels:
+      jenkins_operator: oci
     always_run: false
     optional: true
   - name: metal3-centos-e2e-feature-test-release-1-12-pivoting
     branches:
     - release-0.12
     agent: jenkins
+    labels:
+      jenkins_operator: oci
     always_run: false
     optional: true
   - name: metal3-centos-e2e-feature-test-release-1-12-remediation
     branches:
     - release-0.12
     agent: jenkins
+    labels:
+      jenkins_operator: oci
     always_run: false
     optional: true
   - name: metal3-centos-e2e-feature-test-release-1-12-features
     branches:
     - release-0.12
     agent: jenkins
+    labels:
+      jenkins_operator: oci
     always_run: false
     optional: true
   - name: metal3-ubuntu-e2e-feature-test-release-1-12-pivoting
     branches:
     - release-0.12
     agent: jenkins
+    labels:
+      jenkins_operator: oci
     always_run: false
     optional: true
   - name: metal3-ubuntu-e2e-feature-test-release-1-12-remediation
     branches:
     - release-0.12
     agent: jenkins
+    labels:
+      jenkins_operator: oci
     always_run: false
     optional: true
   - name: metal3-ubuntu-e2e-feature-test-release-1-12-features
     branches:
     - release-0.12
     agent: jenkins
+    labels:
+      jenkins_operator: oci
     always_run: false
     optional: true
   - name: metal3-e2e-clusterctl-upgrade-test-release-1-12
     branches:
     - release-0.12
     agent: jenkins
+    labels:
+      jenkins_operator: oci
     always_run: false
     optional: true
   - name: metal3-dev-env-integration-test-centos-release-1-12
     branches:
     - release-0.12
     agent: jenkins
+    labels:
+      jenkins_operator: oci
     always_run: false
     optional: true
   - name: metal3-dev-env-integration-test-ubuntu-release-1-12
     branches:
     - release-0.12
     agent: jenkins
+    labels:
+      jenkins_operator: oci
     always_run: false
     optional: true
   - name: metal3-bmo-e2e-test-optional-pull
     branches:
     - release-0.12
     agent: jenkins
+    labels:
+      jenkins_operator: oci
     always_run: false
     optional: true
   # name: {job_prefix}-{image_os}-e2e-integration-k8s-pre-release-test-{capm3_target_branch}
@@ -193,11 +221,15 @@ presubmits:
     branches:
     - release-0.12
     agent: jenkins
+    labels:
+      jenkins_operator: oci
     always_run: false
     optional: true
   - name: metal3-ubuntu-e2e-integration-k8s-pre-release-test-release-1-12
     branches:
     - release-0.12
     agent: jenkins
+    labels:
+      jenkins_operator: oci
     always_run: false
     optional: true

--- a/prow/config/jobs/metal3-io/cluster-api-provider-metal3-release-1.12.yaml
+++ b/prow/config/jobs/metal3-io/cluster-api-provider-metal3-release-1.12.yaml
@@ -150,12 +150,16 @@ presubmits:
     branches:
     - release-1.12
     agent: jenkins
+    labels:
+      jenkins_operator: oci
     always_run: false
     optional: false
   - name: metal3-ubuntu-e2e-integration-test-release-1-12
     branches:
     - release-1.12
     agent: jenkins
+    labels:
+      jenkins_operator: oci
     always_run: false
     optional: true
   # name: {job_prefix}-{image_os}-e2e-feature-test-{capm3_target_job}
@@ -163,42 +167,56 @@ presubmits:
     branches:
     - release-1.12
     agent: jenkins
+    labels:
+      jenkins_operator: oci
     always_run: false
     optional: true
   - name: metal3-centos-e2e-feature-test-release-1-12-remediation
     branches:
     - release-1.12
     agent: jenkins
+    labels:
+      jenkins_operator: oci
     always_run: false
     optional: true
   - name: metal3-centos-e2e-feature-test-release-1-12-features
     branches:
     - release-1.12
     agent: jenkins
+    labels:
+      jenkins_operator: oci
     always_run: false
     optional: true
   - name: metal3-ubuntu-e2e-feature-test-release-1-12-pivoting
     branches:
     - release-1.12
     agent: jenkins
+    labels:
+      jenkins_operator: oci
     always_run: false
     optional: true
   - name: metal3-ubuntu-e2e-feature-test-release-1-12-remediation
     branches:
     - release-1.12
     agent: jenkins
+    labels:
+      jenkins_operator: oci
     always_run: false
     optional: true
   - name: metal3-ubuntu-e2e-feature-test-release-1-12-features
     branches:
     - release-1.12
     agent: jenkins
+    labels:
+      jenkins_operator: oci
     always_run: false
     optional: true
   - name: metal3-centos-e2e-feature-test-release-1-12-scalability
     branches:
     - release-1.12
     agent: jenkins
+    labels:
+      jenkins_operator: oci
     always_run: false
     optional: true
   # name: {job_prefix}-e2e-clusterctl-upgrade-test-{capm3_target_branch}
@@ -206,6 +224,8 @@ presubmits:
     branches:
     - release-1.12
     agent: jenkins
+    labels:
+      jenkins_operator: oci
     always_run: false
     optional: true
   # name: {job_prefix}-e2e-{k8s_versions}-upgrade-test-{capm3_target_branch}
@@ -213,18 +233,24 @@ presubmits:
     branches:
     - release-1.12
     agent: jenkins
+    labels:
+      jenkins_operator: oci
     always_run: false
     optional: true
   - name: metal3-ubuntu-e2e-capi-md-test-release-1-12
     branches:
     - release-1.12
     agent: jenkins
+    labels:
+      jenkins_operator: oci
     always_run: false
     optional: true
   - name: metal3-centos-e2e-capi-md-test-release-1-12
     branches:
     - release-1.12
     agent: jenkins
+    labels:
+      jenkins_operator: oci
     always_run: false
     optional: true
   # name: {job_prefix}-e2e-conformance-test-{capm3_target_branch}
@@ -232,5 +258,7 @@ presubmits:
     branches:
     - release-1.12
     agent: jenkins
+    labels:
+      jenkins_operator: oci
     always_run: false
     optional: true

--- a/prow/config/jobs/metal3-io/ip-address-manager-release-1.12.yaml
+++ b/prow/config/jobs/metal3-io/ip-address-manager-release-1.12.yaml
@@ -116,72 +116,96 @@ presubmits:
     branches:
     - release-1.12
     agent: jenkins
+    labels:
+      jenkins_operator: oci
     always_run: false
     optional: true
   - name: metal3-ubuntu-e2e-basic-test-release-1-12
     branches:
     - release-1.12
     agent: jenkins
+    labels:
+      jenkins_operator: oci
     always_run: false
     optional: true
   - name: metal3-centos-e2e-integration-test-release-1-12
     branches:
     - release-1.12
     agent: jenkins
+    labels:
+      jenkins_operator: oci
     always_run: false
     optional: false
   - name: metal3-ubuntu-e2e-integration-test-release-1-12
     branches:
     - release-1.12
     agent: jenkins
+    labels:
+      jenkins_operator: oci
     always_run: false
     optional: true
   - name: metal3-centos-e2e-feature-test-release-1-12-pivoting
     branches:
     - release-1.12
     agent: jenkins
+    labels:
+      jenkins_operator: oci
     always_run: false
     optional: true
   - name: metal3-centos-e2e-feature-test-release-1-12-remediation
     branches:
     - release-1.12
     agent: jenkins
+    labels:
+      jenkins_operator: oci
     always_run: false
     optional: true
   - name: metal3-centos-e2e-feature-test-release-1-12-features
     branches:
     - release-1.12
     agent: jenkins
+    labels:
+      jenkins_operator: oci
     always_run: false
     optional: true
   - name: metal3-ubuntu-e2e-feature-test-release-1-12-pivoting
     branches:
     - release-1.12
     agent: jenkins
+    labels:
+      jenkins_operator: oci
     always_run: false
     optional: true
   - name: metal3-ubuntu-e2e-feature-test-release-1-12-remediation
     branches:
     - release-1.12
     agent: jenkins
+    labels:
+      jenkins_operator: oci
     always_run: false
     optional: true
   - name: metal3-ubuntu-e2e-feature-test-release-1-12-features
     branches:
     - release-1.12
     agent: jenkins
+    labels:
+      jenkins_operator: oci
     always_run: false
     optional: true
   - name: metal3-e2e-clusterctl-upgrade-test-release-1-12
     branches:
     - release-1.12
     agent: jenkins
+    labels:
+      jenkins_operator: oci
     always_run: false
     optional: true
   - name: metal3-e2e-1-34-1-35-upgrade-test-release-1-12
     branches:
     - release-1.12
     agent: jenkins
+    labels:
+      jenkins_operator: oci
     always_run: false
     optional: true
   # name: {job_prefix}-{image_os}-e2e-integration-k8s-pre-release-test-{capm3_target_branch}
@@ -189,11 +213,15 @@ presubmits:
     branches:
     - release-1.12
     agent: jenkins
+    labels:
+      jenkins_operator: oci
     always_run: false
     optional: true
   - name: metal3-ubuntu-e2e-integration-k8s-pre-release-test-release-1.12
     branches:
     - release-1.12
     agent: jenkins
+    labels:
+      jenkins_operator: oci
     always_run: false
     optional: true


### PR DESCRIPTION
This PR:
  - move release-1.12/0.12 PR jobs to be triggered on the new Metal3
    community Jenkins opposed to the Nordix Jenkins

This PR is part of the effort that aims to build a self hosted CNCF
sponsored and Metal3 community maintained vendor neutral CI for the project.