### PR TITLE
introduce 1.26 go based basic checks for prow

### DIFF
--- a/.github/workflows/build-images-action.yml
+++ b/.github/workflows/build-images-action.yml
@@ -20,7 +20,7 @@ jobs:
     uses: ./.github/workflows/container-image-build.yml
     with:
       image-name: 'basic-checks'
-      image-tag: 'golang-1.25'
+      image-tag: 'golang-1.26'
       dockerfile-directory: 'prow/container-images/basic-checks'
       pushImage: true
       generate-sbom: true

--- a/prow/config/jobs/metal3-io/baremetal-operator.yaml
+++ b/prow/config/jobs/metal3-io/baremetal-operator.yaml
@@ -14,7 +14,7 @@ presubmits:
         env:
         - name: IS_CONTAINER
           value: "TRUE"
-        image: quay.io/metal3-io/basic-checks:golang-1.25
+        image: quay.io/metal3-io/basic-checks:golang-1.26
         imagePullPolicy: Always
   - name: markdownlint
     branches:
@@ -70,7 +70,7 @@ presubmits:
           value: "http://localhost:6385/v1/"
         - name: IRONIC_INSPECTOR_ENDPOINT
           value: "http://localhost:5050/v1/"
-        image: quay.io/metal3-io/basic-checks:golang-1.25
+        image: quay.io/metal3-io/basic-checks:golang-1.26
         imagePullPolicy: Always
   # NOTE: The test jobs are for verifying Makefile and hack/* script changes only
   - name: test
@@ -84,7 +84,7 @@ presubmits:
         - test
         command:
         - make
-        image: quay.io/metal3-io/basic-checks:golang-1.25
+        image: quay.io/metal3-io/basic-checks:golang-1.26
         imagePullPolicy: Always
   - name: manifestlint
     branches:

--- a/prow/container-images/basic-checks/Dockerfile
+++ b/prow/container-images/basic-checks/Dockerfile
@@ -1,4 +1,4 @@
-ARG GO_VERSION=1.25.7@sha256:85c0ab0b73087fda36bf8692efe2cf67c54a06d7ca3b49c489bbff98c9954d64
+ARG GO_VERSION=1.26.5@sha256:3aff6657219a4d9c14e27fb1d8976c49c29fddb70ba835014f477e1c70636647
 FROM docker.io/golang:${GO_VERSION}
 
 # Install additional packages not present in regular golang image


### PR DESCRIPTION
This commit:
 - Bumps the go version of the basic check container used in prow tests.
 - Enables the use of the new basic check container for BMO main branch

Background:
 - BMO main is transitioning to require at minimum go 1.26.