### PR TITLE
Prow: Upgrade Traefik to v3.7.9

### DIFF
--- a/prow/infra/traefik/kustomization.yaml
+++ b/prow/infra/traefik/kustomization.yaml
@@ -2,5 +2,5 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
 - https://github.com/kubernetes-sigs/gateway-api/releases/download/v1.5.1/standard-install.yaml
-- https://github.com/traefik/traefik-helm-chart/traefik/crds?ref=v41.0.0
+- https://github.com/traefik/traefik-helm-chart/traefik/crds?ref=v41.0.2
 - resources.yaml

--- a/prow/infra/traefik/resources.yaml
+++ b/prow/infra/traefik/resources.yaml
@@ -3,7 +3,7 @@
 # Generate like this:
 # helm repo add traefik https://traefik.github.io/charts
 # helm repo update
-# helm template traefik traefik/traefik --version 41.0.0 \
+# helm template traefik traefik/traefik --version 41.0.2 \
 #   --namespace traefik \
 #   --api-versions policy/v1/PodDisruptionBudget \
 #   --values infra/traefik/traefik-values.yaml > infra/traefik/resources.yaml
@@ -16,7 +16,7 @@ metadata:
   labels:
     app.kubernetes.io/name: traefik
     app.kubernetes.io/instance: traefik-traefik
-    helm.sh/chart: traefik-41.0.0
+    helm.sh/chart: traefik-41.0.2
     app.kubernetes.io/managed-by: Helm
 spec:
   selector:
@@ -34,7 +34,7 @@ metadata:
   labels:
     app.kubernetes.io/name: traefik
     app.kubernetes.io/instance: traefik-traefik
-    helm.sh/chart: traefik-41.0.0
+    helm.sh/chart: traefik-41.0.2
     app.kubernetes.io/managed-by: Helm
   annotations:
 automountServiceAccountToken: false
@@ -47,7 +47,7 @@ metadata:
   labels:
     app.kubernetes.io/name: traefik
     app.kubernetes.io/instance: traefik-traefik
-    helm.sh/chart: traefik-41.0.0
+    helm.sh/chart: traefik-41.0.2
     app.kubernetes.io/managed-by: Helm
 rules:
 - apiGroups:
@@ -150,7 +150,7 @@ metadata:
   labels:
     app.kubernetes.io/name: traefik
     app.kubernetes.io/instance: traefik-traefik
-    helm.sh/chart: traefik-41.0.0
+    helm.sh/chart: traefik-41.0.2
     app.kubernetes.io/managed-by: Helm
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -170,7 +170,7 @@ metadata:
   labels:
     app.kubernetes.io/name: traefik
     app.kubernetes.io/instance: traefik-traefik
-    helm.sh/chart: traefik-41.0.0
+    helm.sh/chart: traefik-41.0.2
     app.kubernetes.io/managed-by: Helm
   annotations:
     loadbalancer.openstack.org/keep-floatingip: "true"
@@ -200,7 +200,7 @@ metadata:
   labels:
     app.kubernetes.io/name: traefik
     app.kubernetes.io/instance: traefik-traefik
-    helm.sh/chart: traefik-41.0.0
+    helm.sh/chart: traefik-41.0.2
     app.kubernetes.io/managed-by: Helm
   annotations:
 spec:
@@ -226,7 +226,7 @@ spec:
         app.kubernetes.io/instance: traefik-traefik
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: traefik
-        helm.sh/chart: traefik-41.0.0
+        helm.sh/chart: traefik-41.0.2
     spec:
       automountServiceAccountToken: true
       containers:
@@ -257,7 +257,7 @@ spec:
               fieldPath: metadata.namespace
         - name: USER
           value: traefik
-        image: docker.io/traefik:v3.7.5
+        image: docker.io/traefik:v3.7.9
         imagePullPolicy: IfNotPresent
         lifecycle: null
         livenessProbe:
@@ -336,7 +336,7 @@ metadata:
   labels:
     app.kubernetes.io/name: traefik
     app.kubernetes.io/instance: traefik-traefik
-    helm.sh/chart: traefik-41.0.0
+    helm.sh/chart: traefik-41.0.2
     app.kubernetes.io/managed-by: Helm
   name: traefik
 spec:
@@ -351,7 +351,7 @@ metadata:
   labels:
     app.kubernetes.io/name: traefik
     app.kubernetes.io/instance: traefik-traefik
-    helm.sh/chart: traefik-41.0.0
+    helm.sh/chart: traefik-41.0.2
     app.kubernetes.io/managed-by: Helm
 spec:
   gatewayClassName: traefik
@@ -389,7 +389,7 @@ metadata:
   labels:
     app.kubernetes.io/name: traefik
     app.kubernetes.io/instance: traefik-traefik
-    helm.sh/chart: traefik-41.0.0
+    helm.sh/chart: traefik-41.0.2
     app.kubernetes.io/managed-by: Helm
 spec:
   controllerName: traefik.io/gateway-controller

--- a/prow/infra/traefik/traefik-values.yaml
+++ b/prow/infra/traefik/traefik-values.yaml
@@ -1,5 +1,5 @@
 image:
-  tag: v3.7.5
+  tag: v3.7.9
 
 providers:
   kubernetesIngress:


### PR DESCRIPTION
This is just to stay up to date. There are some security fixes also included, but nothing that looks serious for our use-case.