### PR TITLE
Move main PR jobs to oci Jenkins

### DIFF
--- a/prow/config/jobs/metal3-io/baremetal-operator.yaml
+++ b/prow/config/jobs/metal3-io/baremetal-operator.yaml
@@ -109,12 +109,16 @@ presubmits:
     branches:
     - main
     agent: jenkins
+    labels:
+      jenkins_operator: oci
     always_run: false
     optional: true
   - name: metal3-ubuntu-e2e-basic-test-main
     branches:
     - main
     agent: jenkins
+    labels:
+      jenkins_operator: oci
     always_run: false
     optional: true
   # name: {job_prefix}-{image_os}-e2e-integration-test-{capm3_target_branch}
@@ -122,12 +126,16 @@ presubmits:
     branches:
     - main
     agent: jenkins
+    labels:
+      jenkins_operator: oci
     always_run: false
     optional: true
   - name: metal3-ubuntu-e2e-integration-test-main
     branches:
     - main
     agent: jenkins
+    labels:
+      jenkins_operator: oci
     always_run: false
     optional: true
   # name: {job_prefix}-{image_os}-e2e-feature-test-{capm3_target_job}
@@ -135,36 +143,48 @@ presubmits:
     branches:
     - main
     agent: jenkins
+    labels:
+      jenkins_operator: oci
     always_run: false
     optional: true
   - name: metal3-centos-e2e-feature-test-main-remediation
     branches:
     - main
     agent: jenkins
+    labels:
+      jenkins_operator: oci
     always_run: false
     optional: true
   - name: metal3-centos-e2e-feature-test-main-features
     branches:
     - main
     agent: jenkins
+    labels:
+      jenkins_operator: oci
     always_run: false
     optional: true
   - name: metal3-ubuntu-e2e-feature-test-main-pivoting
     branches:
     - main
     agent: jenkins
+    labels:
+      jenkins_operator: oci
     always_run: false
     optional: true
   - name: metal3-ubuntu-e2e-feature-test-main-remediation
     branches:
     - main
     agent: jenkins
+    labels:
+      jenkins_operator: oci
     always_run: false
     optional: true
   - name: metal3-ubuntu-e2e-feature-test-main-features
     branches:
     - main
     agent: jenkins
+    labels:
+      jenkins_operator: oci
     always_run: false
     optional: true
   # name: {job_prefix}-e2e-clusterctl-upgrade-test-{capm3_target_branch}
@@ -172,18 +192,24 @@ presubmits:
     branches:
     - main
     agent: jenkins
+    labels:
+      jenkins_operator: oci
     always_run: false
     optional: true
   - name: metal3-dev-env-integration-test-centos-main
     branches:
     - main
     agent: jenkins
+    labels:
+      jenkins_operator: oci
     always_run: false
     optional: true
   - name: metal3-dev-env-integration-test-ubuntu-main
     branches:
     - main
     agent: jenkins
+    labels:
+      jenkins_operator: oci
     always_run: false
     optional: true
   - name: metal3-bmo-e2e-test-optional-pull
@@ -197,11 +223,15 @@ presubmits:
     branches:
     - main
     agent: jenkins
+    labels:
+      jenkins_operator: oci
     always_run: false
     optional: true
   - name: metal3-ubuntu-e2e-integration-k8s-pre-release-test-main
     branches:
     - main
     agent: jenkins
+    labels:
+      jenkins_operator: oci
     always_run: false
     optional: true

--- a/prow/config/jobs/metal3-io/cluster-api-provider-metal3.yaml
+++ b/prow/config/jobs/metal3-io/cluster-api-provider-metal3.yaml
@@ -154,12 +154,16 @@ presubmits:
     branches:
     - main
     agent: jenkins
+    labels:
+      jenkins_operator: oci
     always_run: false
     optional: true
   - name: metal3-ubuntu-e2e-basic-test-main
     branches:
     - main
     agent: jenkins
+    labels:
+      jenkins_operator: oci
     always_run: false
     optional: true
   # name: {job_prefix}-{image_os}-e2e-integration-test-{capm3_target_branch}{suffix|} # suffix is optional
@@ -167,12 +171,16 @@ presubmits:
     branches:
     - main
     agent: jenkins
+    labels:
+      jenkins_operator: oci
     always_run: false
     optional: false
   - name: metal3-ubuntu-e2e-integration-test-main
     branches:
     - main
     agent: jenkins
+    labels:
+      jenkins_operator: oci
     always_run: false
     optional: false
   # name: {job_prefix}-{image_os}-e2e-integration-test-{capm3_target_branch}{suffix|} # suffix is optional
@@ -180,12 +188,16 @@ presubmits:
     branches:
     - main
     agent: jenkins
+    labels:
+      jenkins_operator: oci
     always_run: false
     optional: true
   - name: metal3-ubuntu-e2e-integration-test-main-capi-nightly-build
     branches:
     - main
     agent: jenkins
+    labels:
+      jenkins_operator: oci
     always_run: false
     optional: true
   # name: {job_prefix}-{image_os}-e2e-feature-test-{capm3_target_job}
@@ -193,42 +205,56 @@ presubmits:
     branches:
     - main
     agent: jenkins
+    labels:
+      jenkins_operator: oci
     always_run: false
     optional: true
   - name: metal3-centos-e2e-feature-test-main-remediation
     branches:
     - main
     agent: jenkins
+    labels:
+      jenkins_operator: oci
     always_run: false
     optional: true
   - name: metal3-centos-e2e-feature-test-main-features
     branches:
     - main
     agent: jenkins
+    labels:
+      jenkins_operator: oci
     always_run: false
     optional: true
   - name: metal3-ubuntu-e2e-feature-test-main-pivoting
     branches:
     - main
     agent: jenkins
+    labels:
+      jenkins_operator: oci
     always_run: false
     optional: true
   - name: metal3-ubuntu-e2e-feature-test-main-remediation
     branches:
     - main
     agent: jenkins
+    labels:
+      jenkins_operator: oci
     always_run: false
     optional: true
   - name: metal3-ubuntu-e2e-feature-test-main-features
     branches:
     - main
     agent: jenkins
+    labels:
+      jenkins_operator: oci
     always_run: false
     optional: true
   - name: metal3-centos-e2e-feature-test-main-scalability
     branches:
     - main
     agent: jenkins
+    labels:
+      jenkins_operator: oci
     always_run: false
     optional: true
   # name: {job_prefix}-e2e-clusterctl-upgrade-test-{capm3_target_branch}
@@ -236,6 +262,8 @@ presubmits:
     branches:
     - main
     agent: jenkins
+    labels:
+      jenkins_operator: oci
     always_run: false
     optional: true
   # name: {job_prefix}-e2e-{k8s_versions}-upgrade-test-{capm3_target_branch}
@@ -243,6 +271,8 @@ presubmits:
     branches:
     - main
     agent: jenkins
+    labels:
+      jenkins_operator: oci
     always_run: false
     optional: true
   # name: {job_prefix}-{image_os}-e2e-kubernetes-n3-upgrade-{capm3_target_branch}
@@ -250,6 +280,8 @@ presubmits:
     branches:
     - main
     agent: jenkins
+    labels:
+      jenkins_operator: oci
     always_run: false
     optional: true
   # name: {job_prefix}-e2e-in-place-upgrade-test-{capm3_target_branch}
@@ -257,18 +289,24 @@ presubmits:
     branches:
     - main
     agent: jenkins
+    labels:
+      jenkins_operator: oci
     always_run: false
     optional: true
   - name: metal3-ubuntu-e2e-capi-md-test-main
     branches:
     - main
     agent: jenkins
+    labels:
+      jenkins_operator: oci
     always_run: false
     optional: true
   - name: metal3-centos-e2e-capi-md-test-main
     branches:
     - main
     agent: jenkins
+    labels:
+      jenkins_operator: oci
     always_run: false
     optional: true
   # name: {job_prefix}-e2e-conformance-test-{capm3_target_branch}
@@ -276,6 +314,8 @@ presubmits:
     branches:
     - main
     agent: jenkins
+    labels:
+      jenkins_operator: oci
     always_run: false
     optional: true
   # name: {job_prefix}-{image_os}-e2e-integration-k8s-pre-release-test-{capm3_target_branch}
@@ -283,11 +323,15 @@ presubmits:
     branches:
     - main
     agent: jenkins
+    labels:
+      jenkins_operator: oci
     always_run: false
     optional: true
   - name: metal3-ubuntu-e2e-integration-k8s-pre-release-test-main
     branches:
     - main
     agent: jenkins
+    labels:
+      jenkins_operator: oci
     always_run: false
     optional: true

--- a/prow/config/jobs/metal3-io/ip-address-manager.yaml
+++ b/prow/config/jobs/metal3-io/ip-address-manager.yaml
@@ -116,12 +116,16 @@ presubmits:
     branches:
     - main
     agent: jenkins
+    labels:
+      jenkins_operator: oci
     always_run: false
     optional: true
   - name: metal3-ubuntu-e2e-basic-test-main
     branches:
     - main
     agent: jenkins
+    labels:
+      jenkins_operator: oci
     always_run: false
     optional: true
   # name: {job_prefix}-{image_os}-e2e-integration-test-{capm3_target_branch}
@@ -129,12 +133,16 @@ presubmits:
     branches:
     - main
     agent: jenkins
+    labels:
+      jenkins_operator: oci
     always_run: false
     optional: false
   - name: metal3-ubuntu-e2e-integration-test-main
     branches:
     - main
     agent: jenkins
+    labels:
+      jenkins_operator: oci
     always_run: false
     optional: false
   # name: {job_prefix}-{image_os}-e2e-feature-test-{capm3_target_job}
@@ -142,36 +150,48 @@ presubmits:
     branches:
     - main
     agent: jenkins
+    labels:
+      jenkins_operator: oci
     always_run: false
     optional: true
   - name: metal3-centos-e2e-feature-test-main-remediation
     branches:
     - main
     agent: jenkins
+    labels:
+      jenkins_operator: oci
     always_run: false
     optional: true
   - name: metal3-centos-e2e-feature-test-main-features
     branches:
     - main
     agent: jenkins
+    labels:
+      jenkins_operator: oci
     always_run: false
     optional: true
   - name: metal3-ubuntu-e2e-feature-test-main-pivoting
     branches:
     - main
     agent: jenkins
+    labels:
+      jenkins_operator: oci
     always_run: false
     optional: true
   - name: metal3-ubuntu-e2e-feature-test-main-remediation
     branches:
     - main
     agent: jenkins
+    labels:
+      jenkins_operator: oci
     always_run: false
     optional: true
   - name: metal3-ubuntu-e2e-feature-test-main-features
     branches:
     - main
     agent: jenkins
+    labels:
+      jenkins_operator: oci
     always_run: false
     optional: true
   # name: {job_prefix}-e2e-clusterctl-upgrade-test-{capm3_target_branch}
@@ -179,6 +199,8 @@ presubmits:
     branches:
     - main
     agent: jenkins
+    labels:
+      jenkins_operator: oci
     always_run: false
     optional: true
   # name: {job_prefix}-e2e-{k8s_versions}-upgrade-test-{capm3_target_branch}
@@ -186,6 +208,8 @@ presubmits:
     branches:
     - main
     agent: jenkins
+    labels:
+      jenkins_operator: oci
     always_run: false
     optional: true
   # name: {job_prefix}-{image_os}-e2e-integration-k8s-pre-release-test-{capm3_target_branch}
@@ -193,11 +217,15 @@ presubmits:
     branches:
     - main
     agent: jenkins
+    labels:
+      jenkins_operator: oci
     always_run: false
     optional: true
   - name: metal3-ubuntu-e2e-integration-k8s-pre-release-test-main
     branches:
     - main
     agent: jenkins
+    labels:
+      jenkins_operator: oci
     always_run: false
     optional: true

--- a/prow/config/jobs/metal3-io/ironic-image.yaml
+++ b/prow/config/jobs/metal3-io/ironic-image.yaml
@@ -53,23 +53,31 @@ presubmits:
     branches:
     - main
     agent: jenkins
+    labels:
+      jenkins_operator: oci
     always_run: false
     optional: false
   - name: metal3-ubuntu-e2e-integration-test-main
     branches:
     - main
     agent: jenkins
+    labels:
+      jenkins_operator: oci
     always_run: false
     optional: false
   - name: metal3-dev-env-integration-test-centos-main
     branches:
     - main
     agent: jenkins
+    labels:
+      jenkins_operator: oci
     always_run: false
     optional: true
   - name: metal3-dev-env-integration-test-ubuntu-main
     branches:
     - main
     agent: jenkins
+    labels:
+      jenkins_operator: oci
     always_run: false
     optional: true

--- a/prow/config/jobs/metal3-io/ironic-ipa-downloader.yaml
+++ b/prow/config/jobs/metal3-io/ironic-ipa-downloader.yaml
@@ -31,6 +31,8 @@ presubmits:
   # name: {job_prefix}-{image_os}-e2e-integration-test-{capm3_target_branch}
   - name: metal3-centos-e2e-integration-test-main
     agent: jenkins
+    labels:
+      jenkins_operator: oci
     always_run: false
     optional: false
   - name: metal3-centos-e2e-integration-test-release-1-13
@@ -51,6 +53,8 @@ presubmits:
     optional: true
   - name: metal3-ubuntu-e2e-integration-test-main
     agent: jenkins
+    labels:
+      jenkins_operator: oci
     always_run: false
     optional: true
   - name: metal3-ubuntu-e2e-integration-test-release-1-13

--- a/prow/config/jobs/metal3-io/ironic-standalone-operator.yaml
+++ b/prow/config/jobs/metal3-io/ironic-standalone-operator.yaml
@@ -71,11 +71,15 @@ presubmits:
     branches:
     - main
     agent: jenkins
+    labels:
+      jenkins_operator: oci
     always_run: false
     optional: true
   - name: metal3-dev-env-integration-test-centos-main
     branches:
     - main
     agent: jenkins
+    labels:
+      jenkins_operator: oci
     always_run: false
     optional: true

--- a/prow/config/jobs/metal3-io/metal3-dev-env.yaml
+++ b/prow/config/jobs/metal3-io/metal3-dev-env.yaml
@@ -45,6 +45,8 @@ presubmits:
   # name: {job_prefix}-{image_os}-e2e-basic-test-{capm3_target_branch}
   - name: metal3-centos-e2e-basic-test-main
     agent: jenkins
+    labels:
+      jenkins_operator: oci
     always_run: false
     optional: true
   - name: metal3-centos-e2e-basic-test-release-1-13
@@ -65,6 +67,8 @@ presubmits:
     optional: true
   - name: metal3-ubuntu-e2e-basic-test-main
     agent: jenkins
+    labels:
+      jenkins_operator: oci
     always_run: false
     optional: true
   - name: metal3-ubuntu-e2e-basic-test-release-1-13
@@ -86,6 +90,8 @@ presubmits:
   # name: {job_prefix}-{image_os}-e2e-integration-test-{capm3_target_branch}
   - name: metal3-centos-e2e-integration-test-main
     agent: jenkins
+    labels:
+      jenkins_operator: oci
     always_run: false
     optional: true
   - name: metal3-centos-e2e-integration-test-release-1-13
@@ -106,6 +112,8 @@ presubmits:
     optional: true
   - name: metal3-ubuntu-e2e-integration-test-main
     agent: jenkins
+    labels:
+      jenkins_operator: oci
     always_run: false
     optional: true
   - name: metal3-ubuntu-e2e-integration-test-release-1-13
@@ -127,6 +135,8 @@ presubmits:
   # name: {job_prefix}-{image_os}-e2e-feature-test-{capm3_target_job}
   - name: metal3-centos-e2e-feature-test-main-pivoting
     agent: jenkins
+    labels:
+      jenkins_operator: oci
     always_run: false
     optional: true
   - name: metal3-centos-e2e-feature-test-release-1-13-pivoting
@@ -147,6 +157,8 @@ presubmits:
     optional: true
   - name: metal3-centos-e2e-feature-test-main-remediation
     agent: jenkins
+    labels:
+      jenkins_operator: oci
     always_run: false
     optional: true
   - name: metal3-centos-e2e-feature-test-release-1-13-remediation
@@ -167,6 +179,8 @@ presubmits:
     optional: true
   - name: metal3-centos-e2e-feature-test-main-features
     agent: jenkins
+    labels:
+      jenkins_operator: oci
     always_run: false
     optional: true
   - name: metal3-centos-e2e-feature-test-release-1-13-features
@@ -187,6 +201,8 @@ presubmits:
     optional: true
   - name: metal3-ubuntu-e2e-feature-test-main-pivoting
     agent: jenkins
+    labels:
+      jenkins_operator: oci
     always_run: false
     optional: true
   - name: metal3-ubuntu-e2e-feature-test-release-1-13-pivoting
@@ -207,6 +223,8 @@ presubmits:
     optional: true
   - name: metal3-ubuntu-e2e-feature-test-main-remediation
     agent: jenkins
+    labels:
+      jenkins_operator: oci
     always_run: false
     optional: true
   - name: metal3-ubuntu-e2e-feature-test-release-1-13-remediation
@@ -227,6 +245,8 @@ presubmits:
     optional: true
   - name: metal3-ubuntu-e2e-feature-test-main-features
     agent: jenkins
+    labels:
+      jenkins_operator: oci
     always_run: false
     optional: true
   - name: metal3-ubuntu-e2e-feature-test-release-1-13-features
@@ -248,6 +268,8 @@ presubmits:
   # name: {job_prefix}-e2e-clusterctl-upgrade-test-{capm3_target_branch}
   - name: metal3-e2e-clusterctl-upgrade-test-main
     agent: jenkins
+    labels:
+      jenkins_operator: oci
     always_run: false
     optional: true
   - name: metal3-e2e-clusterctl-upgrade-test-release-1-13
@@ -269,6 +291,8 @@ presubmits:
   # name: {job_prefix}-e2e-{k8s_versions}-upgrade-test-{capm3_target_branch}
   - name: metal3-e2e-1-35-1-36-upgrade-test-main
     agent: jenkins
+    labels:
+      jenkins_operator: oci
     always_run: false
     optional: true
   - name: metal3-e2e-1-35-1-36-upgrade-test-release-1-13
@@ -285,6 +309,8 @@ presubmits:
     optional: true
   - name: metal3-dev-env-integration-test-centos-main
     agent: jenkins
+    labels:
+      jenkins_operator: oci
     always_run: false
     optional: true
   - name: metal3-dev-env-integration-test-centos-release-1-13
@@ -305,6 +331,8 @@ presubmits:
     optional: true
   - name: metal3-dev-env-integration-test-ubuntu-main
     agent: jenkins
+    labels:
+      jenkins_operator: oci
     always_run: false
     optional: false
   - name: metal3-dev-env-integration-test-ubuntu-release-1-13
@@ -330,23 +358,33 @@ presubmits:
     optional: true
   - name: metal3-ubuntu-e2e-capi-md-test-main
     agent: jenkins
+    labels:
+      jenkins_operator: oci
     always_run: false
     optional: true
   - name: metal3-centos-e2e-capi-md-test-main
     agent: jenkins
+    labels:
+      jenkins_operator: oci
     always_run: false
     optional: true
   # name: {job_prefix}-e2e-conformance-test-{capm3_target_branch}
   - name: metal3-e2e-conformance-test-main
     agent: jenkins
+    labels:
+      jenkins_operator: oci
     always_run: false
     optional: true
   # name: {job_prefix}-{image_os}-e2e-integration-k8s-pre-release-test-{capm3_target_branch}
   - name: metal3-centos-e2e-integration-k8s-pre-release-test-main
     agent: jenkins
+    labels:
+      jenkins_operator: oci
     always_run: false
     optional: true
   - name: metal3-ubuntu-e2e-integration-k8s-pre-release-test-main
     agent: jenkins
+    labels:
+      jenkins_operator: oci
     always_run: false
     optional: true

--- a/prow/config/jobs/metal3-io/project-infra.yaml
+++ b/prow/config/jobs/metal3-io/project-infra.yaml
@@ -92,6 +92,8 @@ presubmits:
   # name: {job_prefix}-{image_os}-e2e-basic-test-{capm3_target_branch}
   - name: metal3-centos-e2e-basic-test-main
     agent: jenkins
+    labels:
+      jenkins_operator: oci
     always_run: false
     optional: true
   - name: metal3-centos-e2e-basic-test-release-1-11
@@ -104,6 +106,8 @@ presubmits:
     optional: true
   - name: metal3-ubuntu-e2e-basic-test-main
     agent: jenkins
+    labels:
+      jenkins_operator: oci
     always_run: false
     optional: true
   - name: metal3-ubuntu-e2e-basic-test-release-1-11
@@ -117,6 +121,8 @@ presubmits:
   # name: {job_prefix}-{image_os}-e2e-integration-test-{capm3_target_branch}
   - name: metal3-centos-e2e-integration-test-main
     agent: jenkins
+    labels:
+      jenkins_operator: oci
     always_run: false
     optional: true
   - name: metal3-centos-e2e-integration-test-release-1-11
@@ -129,6 +135,8 @@ presubmits:
     optional: true
   - name: metal3-ubuntu-e2e-integration-test-main
     agent: jenkins
+    labels:
+      jenkins_operator: oci
     always_run: false
     optional: false
   - name: metal3-ubuntu-e2e-integration-test-release-1-11
@@ -142,6 +150,8 @@ presubmits:
   # name: {job_prefix}-{image_os}-e2e-feature-test-{capm3_target_job}
   - name: metal3-centos-e2e-feature-test-main-pivoting
     agent: jenkins
+    labels:
+      jenkins_operator: oci
     always_run: false
     optional: true
   - name: metal3-centos-e2e-feature-test-release-1-11-pivoting
@@ -154,6 +164,8 @@ presubmits:
     optional: true
   - name: metal3-centos-e2e-feature-test-main-remediation
     agent: jenkins
+    labels:
+      jenkins_operator: oci
     always_run: false
     optional: true
   - name: metal3-centos-e2e-feature-test-release-1-11-remediation
@@ -166,6 +178,8 @@ presubmits:
     optional: true
   - name: metal3-centos-e2e-feature-test-main-features
     agent: jenkins
+    labels:
+      jenkins_operator: oci
     always_run: false
     optional: true
   - name: metal3-centos-e2e-feature-test-release-1-11-features
@@ -178,6 +192,8 @@ presubmits:
     optional: true
   - name: metal3-ubuntu-e2e-feature-test-main-pivoting
     agent: jenkins
+    labels:
+      jenkins_operator: oci
     always_run: false
     optional: true
   - name: metal3-ubuntu-e2e-feature-test-release-1-11-pivoting
@@ -190,6 +206,8 @@ presubmits:
     optional: true
   - name: metal3-ubuntu-e2e-feature-test-main-remediation
     agent: jenkins
+    labels:
+      jenkins_operator: oci
     always_run: false
     optional: true
   - name: metal3-ubuntu-e2e-feature-test-release-1-11-remediation
@@ -202,6 +220,8 @@ presubmits:
     optional: true
   - name: metal3-ubuntu-e2e-feature-test-main-features
     agent: jenkins
+    labels:
+      jenkins_operator: oci
     always_run: false
     optional: true
   - name: metal3-ubuntu-e2e-feature-test-release-1-11-features
@@ -215,6 +235,8 @@ presubmits:
   # name: {job_prefix}-e2e-clusterctl-upgrade-test-{capm3_target_branch}
   - name: metal3-e2e-clusterctl-upgrade-test-main
     agent: jenkins
+    labels:
+      jenkins_operator: oci
     always_run: false
     optional: true
   - name: metal3-e2e-clusterctl-upgrade-test-release-1-11
@@ -228,6 +250,8 @@ presubmits:
   # name: {job_prefix}-e2e-{k8s_versions}-upgrade-test-{capm3_target_branch}
   - name: metal3-e2e-1-35-1-36-upgrade-test-main
     agent: jenkins
+    labels:
+      jenkins_operator: oci
     always_run: false
     optional: true
   - name: metal3-e2e-1-33-1-34-upgrade-test-release-1-11
@@ -236,6 +260,8 @@ presubmits:
     optional: true
   - name: metal3-dev-env-integration-test-centos-main
     agent: jenkins
+    labels:
+      jenkins_operator: oci
     always_run: false
     optional: true
   - name: metal3-dev-env-integration-test-centos-release-1-11
@@ -248,6 +274,8 @@ presubmits:
     optional: true
   - name: metal3-dev-env-integration-test-ubuntu-main
     agent: jenkins
+    labels:
+      jenkins_operator: oci
     always_run: false
     optional: true
   - name: metal3-dev-env-integration-test-ubuntu-release-1-11
@@ -279,23 +307,33 @@ presubmits:
     optional: true
   - name: metal3-ubuntu-e2e-capi-md-test-main
     agent: jenkins
+    labels:
+      jenkins_operator: oci
     always_run: false
     optional: true
   - name: metal3-centos-e2e-capi-md-test-main
     agent: jenkins
+    labels:
+      jenkins_operator: oci
     always_run: false
     optional: true
   # name: {job_prefix}-e2e-conformance-test-{capm3_target_branch}
   - name: metal3-e2e-conformance-test-main
     agent: jenkins
+    labels:
+      jenkins_operator: oci
     always_run: false
     optional: true
   # name: {job_prefix}-{image_os}-e2e-integration-k8s-pre-release-test-{capm3_target_branch}
   - name: metal3-centos-e2e-integration-k8s-pre-release-test-main
     agent: jenkins
+    labels:
+      jenkins_operator: oci
     always_run: false
     optional: true
   - name: metal3-ubuntu-e2e-integration-k8s-pre-release-test-main
     agent: jenkins
+    labels:
+      jenkins_operator: oci
     always_run: false
     optional: true


### PR DESCRIPTION
This PR:

  - move main PR jobs to be triggered on the new Metal3 community Jenkins opposed to the Nordix Jenkins

This PR is part of the effort that aims to build a self hosted CNCF sponsored and Metal3 community maintained vendor neutral CI for the project.