### PR TITLE
Fix IPA builder ramdisk element path in build_ipa.sh

### DIFF
--- a/jenkins/scripts/dynamic_worker_workflow/build_ipa.sh
+++ b/jenkins/scripts/dynamic_worker_workflow/build_ipa.sh
@@ -101,7 +101,7 @@ IPA_BUILDER_COMMIT="$(git rev-parse  HEAD)"
 # IPA dependency list and this https://opendev.org/openstack/requirements/src/branch/master/upper-constraints.txt
 # shellcheck disable=SC2016
 sed -i '43i sed -i "s/oslo.log===5.0.0//" "$UPPER_CONSTRAINTS"' \
-    "${IPA_BUILD_WORKSPACE}/${IPA_BUILDER_PATH}/dib/ironic-python-agent-ramdisk/install.d/ironic-python-agent-ramdisk-source-install/60-ironic-python-agent-ramdisk-install"
+    "${IPA_BUILD_WORKSPACE}/${IPA_BUILDER_PATH}/dib/ironic-python-agent-ramdisk-base/install.d/ironic-python-agent-ramdisk-source-install/60-ironic-python-agent-ramdisk-install"
 popd
 
 # Pull IPA repository to create IPA_IDENTIFIER


### PR DESCRIPTION
ironic-python-agent-builder [split the ironic-python-agent-ramdisk element into two elmeents](https://opendev.org/openstack/ironic-python-agent-builder/commit/58a2d1a3085fcd9ae8a752d7a2fe4a1f0a86b4c1) upstream. 

Commit changes path to new address