### PR TITLE
Remove MariaDB parameters from dev-env integration test job

### DIFF
--- a/jenkins/jobs/dev_env_integration_tests.groovy
+++ b/jenkins/jobs/dev_env_integration_tests.groovy
@@ -36,8 +36,6 @@ pipeline {
         BMORELEASEBRANCH = "${params.bmo_release_branch}"
         NUM_NODES = 2
         IRONIC_INSTALL_TYPE = "${params.IRONIC_INSTALL_TYPE}"
-        IRONIC_USE_MARIADB = "${params.IRONIC_USE_MARIADB}"
-        BUILD_MARIADB_IMAGE_LOCALLY = "${params.BUILD_MARIADB_IMAGE_LOCALLY}"
         USE_IRSO = "${params.USE_IRSO}"
         CNI_NAME = "${params.CNI_NAME}"
     }


### PR DESCRIPTION
Removes the `IRONIC_USE_MARIADB` (removed in [#1710](https://github.com/metal3-io/metal3-dev-env/pull/1710)) and `BUILD_MARIADB_IMAGE_LOCALLY` (removed in [#1698](https://github.com/metal3-io/metal3-dev-env/pull/1698)) environment passthroughs from the dev-env integration test Jenkins job. Both variables were removed from metal3-dev-env, so passing them here has no effect.