### PR TITLE
make version check workflow work with other repos

### DIFF
--- a/.github/workflows/container-image-build.yml
+++ b/.github/workflows/container-image-build.yml
@@ -138,6 +138,12 @@ jobs:
           if [[ "${RESOLVED_REF}" == "refs/heads/main" ]]; then
             IMAGE_TAGS="${IMAGE_TAGS}, latest"
           fi
+          if [[ ! -f ./hack/versioncheck.sh ]]; then
+            mkdir -p hack
+            curl -fsSL https://raw.githubusercontent.com/metal3-io/project-infra/main/hack/versioncheck.sh \
+              -o hack/versioncheck.sh
+            chmod +x hack/versioncheck.sh
+          fi
           IMAGE_VERSION="$(./hack/versioncheck.sh --resolved_refname="${RESOLVED_REFNAME}" --resolved_ref="${RESOLVED_REFSHA}")"
         fi
 
@@ -165,7 +171,6 @@ jobs:
         buildArgs: ${{ inputs.image-build-args || '' }}
         labels: |
           org.opencontainers.image.version=${{ env.IMAGE_VERSION }}
-          org.opencontainers.image.revision=${{ env.IMAGE_REVISION }}
         registry: quay.io
         username: ${{ secrets.QUAY_USERNAME }} # zizmor: ignore[secrets-outside-env]
         password: ${{ secrets.QUAY_PASSWORD }} # zizmor: ignore[secrets-outside-env]


### PR DESCRIPTION
This commit:
 - Makes sure that ./hack/versioncheck.sh is present during the container-image-build execution even if it is called as a reusable workflow from an other repository.
 - Build action also seems to be buggy and does not handle the more than
   one label correctly so the revision will be removed for the time being
   until I sort out the issue

Reason:
 - Workflow breaks without the change when called from other repo's workflow pipeline.