### PR TITLE
Add golangci-lint presubmit for ironic-standalone-operator

### DIFF
--- a/prow/config/jobs/metal3-io/ironic-standalone-operator.yaml
+++ b/prow/config/jobs/metal3-io/ironic-standalone-operator.yaml
@@ -66,6 +66,23 @@ presubmits:
           value: "/"
         image: ghcr.io/yannh/kubeconform:v0.8.0-alpine@sha256:6b90a5f23d846140ce0194fe050b1995e546eba938f3a6bf10c039dd5e24588f
         imagePullPolicy: Always
+  - name: golangci-lint
+    branches:
+    - main
+    skip_if_only_changed: '(((^|/)OWNERS)|((^|/)OWNERS_ALIASES)|(\.md))$'
+    decorate: true
+    optional: true
+    spec:
+      containers:
+      - args:
+        - lint
+        command:
+        - make
+        env:
+        - name: IS_CONTAINER
+          value: "TRUE"
+        image: docker.io/golang:1.26
+        imagePullPolicy: Always
   # name: metal3-dev-env-integration-test-{image_os}-main
   - name: metal3-dev-env-integration-test-ubuntu-main
     branches:


### PR DESCRIPTION
Part of #1448. 
Adds a Prow golangci-lint presubmit for ironic-standalone-operator, optional for now. Once it's green the GitHub Actions workflow will be removed.