### PR TITLE
Enforce golangci-lint presubmit for baremetal-operator

### DIFF
--- a/prow/config/jobs/metal3-io/baremetal-operator.yaml
+++ b/prow/config/jobs/metal3-io/baremetal-operator.yaml
@@ -109,7 +109,6 @@ presubmits:
     - main
     skip_if_only_changed: '(((^|/)OWNERS)|((^|/)OWNERS_ALIASES)|(\.md))$'
     decorate: true
-    optional: true
     spec:
       containers:
       - args:


### PR DESCRIPTION
Follow-up to #1453. golangci-lint has been running green on BMO PRs, so this makes it required by removing optional: true. Complements https://github.com/metal3-io/baremetal-operator/pull/3481, which removes the GitHub Actions golangci-lint,  this keeps lint enforced via Prow.

