### PR TITLE
Add golangci-lint presubmit for ironic-standalone-operator release branches

### DIFF
--- a/prow/config/jobs/metal3-io/ironic-standalone-operator-release-0.10.yaml
+++ b/prow/config/jobs/metal3-io/ironic-standalone-operator-release-0.10.yaml
@@ -66,6 +66,23 @@ presubmits:
           value: "/"
         image: ghcr.io/yannh/kubeconform:v0.8.0-alpine@sha256:6b90a5f23d846140ce0194fe050b1995e546eba938f3a6bf10c039dd5e24588f
         imagePullPolicy: Always
+  - name: golangci-lint
+    branches:
+    - release-0.10
+    skip_if_only_changed: '(((^|/)OWNERS)|((^|/)OWNERS_ALIASES)|(\.md))$'
+    decorate: true
+    optional: true
+    spec:
+      containers:
+      - args:
+        - lint
+        command:
+        - make
+        env:
+        - name: IS_CONTAINER
+          value: "TRUE"
+        image: docker.io/golang:1.25
+        imagePullPolicy: Always
   #NOTE(elfosardo): commented out until metal3-dev-env starts using IrSO
   # name: metal3-dev-env-integration-test-{image_os}-release-1-11
   # - name: metal3-dev-env-integration-test-ubuntu-release-1-11

--- a/prow/config/jobs/metal3-io/ironic-standalone-operator-release-0.9.yaml
+++ b/prow/config/jobs/metal3-io/ironic-standalone-operator-release-0.9.yaml
@@ -66,6 +66,23 @@ presubmits:
           value: "/"
         image: ghcr.io/yannh/kubeconform:v0.8.0-alpine@sha256:6b90a5f23d846140ce0194fe050b1995e546eba938f3a6bf10c039dd5e24588f
         imagePullPolicy: Always
+  - name: golangci-lint
+    branches:
+    - release-0.9
+    skip_if_only_changed: '(((^|/)OWNERS)|((^|/)OWNERS_ALIASES)|(\.md))$'
+    decorate: true
+    optional: true
+    spec:
+      containers:
+      - args:
+        - lint
+        command:
+        - make
+        env:
+        - name: IS_CONTAINER
+          value: "TRUE"
+        image: docker.io/golang:1.25
+        imagePullPolicy: Always
   #NOTE(elfosardo): commented out until metal3-dev-env starts using IrSO
   # name: metal3-dev-env-integration-test-{image_os}-release-1-11
   # - name: metal3-dev-env-integration-test-ubuntu-release-1-11


### PR DESCRIPTION
Part of #1448, follow-up to #1456. Adds the golangci-lint presubmit to ironic-standalone-operator release-0.9 and release-0.10, matching the main-branch job in #1456. 