### PR TITLE
Add golangci-lint presubmit for baremetal-operator release branches

### DIFF
--- a/prow/config/jobs/metal3-io/baremetal-operator-release-0.12.yaml
+++ b/prow/config/jobs/metal3-io/baremetal-operator-release-0.12.yaml
@@ -119,6 +119,23 @@ presubmits:
           value: "/"
         image: ghcr.io/yannh/kubeconform:v0.8.0-alpine@sha256:6b90a5f23d846140ce0194fe050b1995e546eba938f3a6bf10c039dd5e24588f
         imagePullPolicy: Always
+  - name: golangci-lint
+    branches:
+    - release-0.12
+    skip_if_only_changed: '(((^|/)OWNERS)|((^|/)OWNERS_ALIASES)|(\.md))$'
+    decorate: true
+    optional: true
+    spec:
+      containers:
+      - args:
+        - lint
+        command:
+        - make
+        env:
+        - name: IS_CONTAINER
+          value: "TRUE"
+        image: quay.io/metal3-io/basic-checks:golang-1.25
+        imagePullPolicy: Always
   - name: pr-verifier
     branches:
     - release-0.12

--- a/prow/config/jobs/metal3-io/baremetal-operator-release-0.13.yaml
+++ b/prow/config/jobs/metal3-io/baremetal-operator-release-0.13.yaml
@@ -120,6 +120,23 @@ presubmits:
           value: "/"
         image: ghcr.io/yannh/kubeconform:v0.8.0-alpine@sha256:6b90a5f23d846140ce0194fe050b1995e546eba938f3a6bf10c039dd5e24588f
         imagePullPolicy: Always
+  - name: golangci-lint
+    branches:
+    - release-0.13
+    skip_if_only_changed: '(((^|/)OWNERS)|((^|/)OWNERS_ALIASES)|(\.md))$'
+    decorate: true
+    optional: true
+    spec:
+      containers:
+      - args:
+        - lint
+        command:
+        - make
+        env:
+        - name: IS_CONTAINER
+          value: "TRUE"
+        image: quay.io/metal3-io/basic-checks:golang-1.25
+        imagePullPolicy: Always
   - name: pr-verifier
     branches:
     - release-0.13


### PR DESCRIPTION
Part of #1448, follow-up to the BMO main-branch golangci-lint job. Adds the golangci-lint presubmit to baremetal-operator release-0.12 and release-0.13.
Optional for now, matching the main-branch job.