### PR TITLE
Add golangci-lint presubmit for ip-address-manager release branches

### DIFF
--- a/prow/config/jobs/metal3-io/ip-address-manager-release-1.12.yaml
+++ b/prow/config/jobs/metal3-io/ip-address-manager-release-1.12.yaml
@@ -111,6 +111,23 @@ presubmits:
           value: "/"
         image: ghcr.io/yannh/kubeconform:v0.8.0-alpine@sha256:6b90a5f23d846140ce0194fe050b1995e546eba938f3a6bf10c039dd5e24588f
         imagePullPolicy: Always
+  - name: golangci-lint
+    branches:
+    - release-1.12
+    skip_if_only_changed: '(((^|/)OWNERS)|((^|/)OWNERS_ALIASES)|(\.md))$'
+    decorate: true
+    optional: true
+    spec:
+      containers:
+      - args:
+        - lint
+        command:
+        - make
+        env:
+        - name: IS_CONTAINER
+          value: "TRUE"
+        image: docker.io/golang:1.25
+        imagePullPolicy: Always
   # name: {job_prefix}-{image_os}-e2e-basic-test-{capm3_target_branch}
   - name: metal3-centos-e2e-basic-test-release-1-12
     branches:

--- a/prow/config/jobs/metal3-io/ip-address-manager-release-1.13.yaml
+++ b/prow/config/jobs/metal3-io/ip-address-manager-release-1.13.yaml
@@ -111,6 +111,23 @@ presubmits:
           value: "/"
         image: ghcr.io/yannh/kubeconform:v0.8.0-alpine@sha256:6b90a5f23d846140ce0194fe050b1995e546eba938f3a6bf10c039dd5e24588f
         imagePullPolicy: Always
+  - name: golangci-lint
+    branches:
+    - release-1.13
+    skip_if_only_changed: '(((^|/)OWNERS)|((^|/)OWNERS_ALIASES)|(\.md))$'
+    decorate: true
+    optional: true
+    spec:
+      containers:
+      - args:
+        - lint
+        command:
+        - make
+        env:
+        - name: IS_CONTAINER
+          value: "TRUE"
+        image: docker.io/golang:1.25
+        imagePullPolicy: Always
   # name: {job_prefix}-{image_os}-e2e-basic-test-{capm3_target_branch}
   - name: metal3-centos-e2e-basic-test-release-1-13
     branches:


### PR DESCRIPTION
Part of #1448, follow-up to the IPAM main-branch golangci-lint job. Adds the golangci-lint presubmit to ip-address-manager release-1.12 and release-1.13. Optional for now, matching the main-branch job.