### PR TITLE
Enforce golangci-lint presubmit for ironic-standalone-operator

### DIFF
--- a/prow/config/jobs/metal3-io/ironic-standalone-operator.yaml
+++ b/prow/config/jobs/metal3-io/ironic-standalone-operator.yaml
@@ -71,7 +71,6 @@ presubmits:
     - main
     skip_if_only_changed: '(((^|/)OWNERS)|((^|/)OWNERS_ALIASES)|(\.md))$'
     decorate: true
-    optional: true
     spec:
       containers:
       - args:


### PR DESCRIPTION
Follow-up to #1456. golangci-lint has been running green on IrSO PRs, so this makes it required (removes optional: true). Pairs with the GitHub Actions golangci removal so lint stays enforced via Prow.

Part of #1448.