### PR TITLE
Enforce golangci-lint presubmit for ip-address-manager

### DIFF
--- a/prow/config/jobs/metal3-io/ip-address-manager-release-1.12.yaml
+++ b/prow/config/jobs/metal3-io/ip-address-manager-release-1.12.yaml
@@ -116,7 +116,6 @@ presubmits:
     - release-1.12
     skip_if_only_changed: '(((^|/)OWNERS)|((^|/)OWNERS_ALIASES)|(\.md))$'
     decorate: true
-    optional: true
     spec:
       containers:
       - args:

--- a/prow/config/jobs/metal3-io/ip-address-manager-release-1.13.yaml
+++ b/prow/config/jobs/metal3-io/ip-address-manager-release-1.13.yaml
@@ -116,7 +116,6 @@ presubmits:
     - release-1.13
     skip_if_only_changed: '(((^|/)OWNERS)|((^|/)OWNERS_ALIASES)|(\.md))$'
     decorate: true
-    optional: true
     spec:
       containers:
       - args:

--- a/prow/config/jobs/metal3-io/ip-address-manager.yaml
+++ b/prow/config/jobs/metal3-io/ip-address-manager.yaml
@@ -116,7 +116,6 @@ presubmits:
     - main
     skip_if_only_changed: '(((^|/)OWNERS)|((^|/)OWNERS_ALIASES)|(\.md))$'
     decorate: true
-    optional: true
     spec:
       containers:
       - args:


### PR DESCRIPTION
Follow-up to #1458. golangci-lint has been running green on ip-address-manager PRs, so this makes it required .

Part of https://github.com/metal3-io/project-infra/issues/1448.