### PR TITLE
Add pr verifier to prow for baremetal-operator

### DIFF
--- a/hack/verify-pr-title.sh
+++ b/hack/verify-pr-title.sh
@@ -1,0 +1,35 @@
+#!/bin/sh
+
+set -eu
+
+WIP_REGEX='^\W?WIP\W'
+TAG_REGEX='^\[[[:alnum:]\._-]*\]'
+
+trimmed_title=$(echo "$PULL_TITLE" | sed -E "s/${WIP_REGEX}//" | sed -E "s/${TAG_REGEX}//" | xargs)
+
+trimmed_title=$(echo "$trimmed_title" | sed -E "s/:warning:/⚠/g")
+trimmed_title=$(echo "$trimmed_title" | sed -E "s/:sparkles:/✨/g")
+trimmed_title=$(echo "$trimmed_title" | sed -E "s/:bug:/🐛/g")
+trimmed_title=$(echo "$trimmed_title" | sed -E "s/:book:/📖/g")
+trimmed_title=$(echo "$trimmed_title" | sed -E "s/:rocket:/🚀/g")
+trimmed_title=$(echo "$trimmed_title" | sed -E "s/:seedling:/🌱/g")
+
+if echo "$trimmed_title" | grep -Eq '^(⚠|✨|🐛|📖|🚀|🌱)'; then
+    echo "PR title is valid: $trimmed_title"
+else
+    echo "Error: No matching PR type indicator found in title."
+    echo "You need to have one of these as the prefix of your PR title:"
+    echo "- Breaking change: ⚠ (:warning:)"
+    echo "- Non-breaking feature: ✨ (:sparkles:)"
+    echo "- Patch fix: 🐛 (:bug:)"
+    echo "- Docs: 📖 (:book:)"
+    echo "- Release: 🚀 (:rocket:)"
+    echo "- Infra/Tests/Other: 🌱 (:seedling:)"
+    exit 1
+fi
+
+if echo "$trimmed_title" | grep -Eq '#[0-9]+'; then
+    echo "Error: PR title should not contain issue or PR number."
+    echo "Issue numbers belong in the PR body as either \"Fixes #XYZ\" (if it closes the issue or PR), or something like \"Related to #XYZ\" (if it's just related)."
+    exit 1
+fi

--- a/prow/config/jobs/metal3-io/baremetal-operator-release-0.12.yaml
+++ b/prow/config/jobs/metal3-io/baremetal-operator-release-0.12.yaml
@@ -104,6 +104,24 @@ presubmits:
           value: "/"
         image: ghcr.io/yannh/kubeconform:v0.8.0-alpine@sha256:6b90a5f23d846140ce0194fe050b1995e546eba938f3a6bf10c039dd5e24588f
         imagePullPolicy: Always
+  - name: pr-verifier
+    branches:
+    - release-0.12
+    always_run: true
+    decorate: true
+    optional: true
+    extra_refs:
+    - org: metal3-io
+      repo: project-infra
+      base_ref: main
+    spec:
+      containers:
+      - args:
+        - /home/prow/go/src/github.com/metal3-io/project-infra/hack/verify-pr-title.sh
+        command:
+        - sh
+        image: quay.io/metal3-io/basic-checks:golang-1.25
+        imagePullPolicy: Always
   - name: metal3-centos-e2e-basic-test-release-1-12
     branches:
     - release-0.12

--- a/prow/config/jobs/metal3-io/baremetal-operator-release-0.13.yaml
+++ b/prow/config/jobs/metal3-io/baremetal-operator-release-0.13.yaml
@@ -104,6 +104,24 @@ presubmits:
           value: "/"
         image: ghcr.io/yannh/kubeconform:v0.8.0-alpine@sha256:6b90a5f23d846140ce0194fe050b1995e546eba938f3a6bf10c039dd5e24588f
         imagePullPolicy: Always
+  - name: pr-verifier
+    branches:
+    - release-0.13
+    always_run: true
+    decorate: true
+    optional: true
+    extra_refs:
+    - org: metal3-io
+      repo: project-infra
+      base_ref: main
+    spec:
+      containers:
+      - args:
+        - /home/prow/go/src/github.com/metal3-io/project-infra/hack/verify-pr-title.sh
+        command:
+        - sh
+        image: quay.io/metal3-io/basic-checks:golang-1.25
+        imagePullPolicy: Always
   - name: metal3-centos-e2e-basic-test-release-1-13
     branches:
     - release-0.13

--- a/prow/config/jobs/metal3-io/baremetal-operator.yaml
+++ b/prow/config/jobs/metal3-io/baremetal-operator.yaml
@@ -120,6 +120,24 @@ presubmits:
           value: "TRUE"
         image: quay.io/metal3-io/basic-checks:golang-1.26
         imagePullPolicy: Always
+  - name: pr-verifier
+    branches:
+    - main
+    always_run: true
+    decorate: true
+    optional: true
+    extra_refs:
+    - org: metal3-io
+      repo: project-infra
+      base_ref: main
+    spec:
+      containers:
+      - args:
+        - /home/prow/go/src/github.com/metal3-io/project-infra/hack/verify-pr-title.sh
+        command:
+        - sh
+        image: quay.io/metal3-io/basic-checks:golang-1.26
+        imagePullPolicy: Always
   # name: {job_prefix}-{image_os}-e2e-basic-test-{capm3_target_branch}
   - name: metal3-centos-e2e-basic-test-main
     branches:


### PR DESCRIPTION
Moves the PR-title check over to Prow for baremetal-operator.  
This job runs on all branches, not just main. The title rule is the
same everywhere, main and every release branch

It is optional till it passes green.
Part of #1448.