### PR TITLE
Bump checkout action to v7

### DIFF
--- a/.github/workflows/container-image-build.yml
+++ b/.github/workflows/container-image-build.yml
@@ -122,7 +122,7 @@ jobs:
         echo "RESOLVED_REFNAME=${REF_NAME}" >> "${GITHUB_ENV}"
         echo "Using RESOLVED REFNAME: ${REF_NAME}"
 
-    - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6.1.0
+    - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       with:
         ref: ${{ env.RESOLVED_REF }}
         persist-credentials: false

--- a/.github/workflows/pr-link-check.yml
+++ b/.github/workflows/pr-link-check.yml
@@ -22,7 +22,7 @@ jobs:
 
     steps:
     - name: Clone repository
-      uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6.1.0
+      uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       with:
         fetch-depth: 0
         ref: ${{github.event.pull_request.head.ref}}

--- a/.github/workflows/scheduled-fuzz.yml
+++ b/.github/workflows/scheduled-fuzz.yml
@@ -26,7 +26,7 @@ jobs:
       issues: write
     steps:
     - name: Checkout code
-      uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6.1.0
+      uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       with:
         persist-credentials: false
 

--- a/.github/workflows/scheduled-link-check.yml
+++ b/.github/workflows/scheduled-link-check.yml
@@ -20,7 +20,7 @@ jobs:
       issues: write
 
     steps:
-    - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6.1.0
+    - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       with:
         persist-credentials: false
 

--- a/.github/workflows/validate-security-insights.yml
+++ b/.github/workflows/validate-security-insights.yml
@@ -12,7 +12,7 @@ jobs:
     permissions:
       contents: read
     steps:
-    - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6.1.0
+    - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       with:
         persist-credentials: false
 

--- a/.github/workflows/yamllint.yaml
+++ b/.github/workflows/yamllint.yaml
@@ -25,7 +25,7 @@ jobs:
     - name: Install yamllint
       run: sudo apt-get update && sudo apt-get install -y yamllint
 
-    - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6.1.0
+    - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       with:
         persist-credentials: false
 

--- a/.github/workflows/zizmor.yml
+++ b/.github/workflows/zizmor.yml
@@ -21,7 +21,7 @@ jobs:
       security-events: write
     steps:
     - name: Checkout repository
-      uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6.1.0
+      uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       with:
         persist-credentials: false
     # Upload SARIF to Security tab on push to main


### PR DESCRIPTION
Major version bumps has to be done manually since dependabot is configured to ignore them.