### PR TITLE
Pass kubernetes version in node image verification

### DIFF
--- a/jenkins/image_building/build-image.sh
+++ b/jenkins/image_building/build-image.sh
@@ -90,7 +90,7 @@ fi
 if [[ "${IMAGE_TYPE}" == "node" ]]; then
   # Set the default data source for cloud-init
   export DIB_CLOUD_INIT_DATASOURCES="ConfigDrive,OpenStack,Oracle"
-  export KUBERNETES_VERSION="${KUBERNETES_VERSION:-"v1.36.2"}"
+  export KUBERNETES_VERSION="${KUBERNETES_VERSION:?KUBERNETES_VERSION must be set}"
 
   if [[ "${PRE_RELEASE:-}" == "true" ]]; then
     # Extract minor version (e.g., "1.34" from "v1.34.1")
@@ -102,8 +102,8 @@ if [[ "${IMAGE_TYPE}" == "node" ]]; then
   fi
 
 
-  export CRIO_VERSION="${CRIO_VERSION:-"v1.36.1"}"
-  export CRICTL_VERSION="${CRICTL_VERSION:-"v1.36.0"}"
+  export CRIO_VERSION="${CRIO_VERSION:?CRIO_VERSION must be set}"
+  export CRICTL_VERSION="${CRICTL_VERSION:?CRICTL_VERSION must be set}"
   img_name="${IMAGE_OS^^}_${numeric_release}_NODE_IMAGE_K8S_${KUBERNETES_VERSION}"
   # enable predictable interface names
   export DIB_BOOTLOADER_DEFAULT_CMDLINE="net.ifnames=1"

--- a/jenkins/image_building/build-image.sh
+++ b/jenkins/image_building/build-image.sh
@@ -90,7 +90,7 @@ fi
 if [[ "${IMAGE_TYPE}" == "node" ]]; then
   # Set the default data source for cloud-init
   export DIB_CLOUD_INIT_DATASOURCES="ConfigDrive,OpenStack,Oracle"
-  export KUBERNETES_VERSION="${KUBERNETES_VERSION:-"v1.37.0"}"
+  export KUBERNETES_VERSION="${KUBERNETES_VERSION:?KUBERNETES_VERSION must be set}"
 
   if [[ "${PRE_RELEASE:-}" == "true" ]]; then
     # Extract minor version (e.g., "1.34" from "v1.34.1")
@@ -101,9 +101,9 @@ if [[ "${IMAGE_TYPE}" == "node" ]]; then
     export KUBERNETES_VERSION="${FETCHED_VERSION}"
   fi
 
-  # TODO: Uplift crio to v1.37 when it's officially released
-  export CRIO_VERSION="${CRIO_VERSION:-"v1.36.4"}"
-  export CRICTL_VERSION="${CRICTL_VERSION:-"v1.36.0"}"
+
+  export CRIO_VERSION="${CRIO_VERSION:?CRIO_VERSION must be set}"
+  export CRICTL_VERSION="${CRICTL_VERSION:?CRICTL_VERSION must be set}"
   img_name="${IMAGE_OS^^}_${numeric_release}_NODE_IMAGE_K8S_${KUBERNETES_VERSION}"
   # enable predictable interface names
   export DIB_BOOTLOADER_DEFAULT_CMDLINE="net.ifnames=1"

--- a/jenkins/image_building/verify-node-image.sh
+++ b/jenkins/image_building/verify-node-image.sh
@@ -31,6 +31,10 @@ verify_node_image() {
 
     export IRONIC_INSTALL_TYPE="rpm"
 
+    export KUBERNETES_VERSION="${KUBERNETES_VERSION}"
+    export CRIO_VERSION="${CRIO_VERSION}"
+    export CRICTL_VERSION="${CRICTL_VERSION}"
+
     "${current_dir}/../scripts/dynamic_worker_workflow/dev_env_integration_tests.sh"
 }
 


### PR DESCRIPTION
The node image building pipeline builds images with a specific k8s version, but the verification step was not passing that version to metal3-dev-env.
Export KUBERNETES_VERSION, CRIO_VERSION, and CRICTL_VERSION in verify-node-image.sh so the test validates the actual built image.

It also removes defaults from build-image.sh to make the JJB the only source.