### PR TITLE
add log collector dashboard to jenkins jobs

### DIFF
--- a/jenkins/jobs/bml_integration_tests.groovy
+++ b/jenkins/jobs/bml_integration_tests.groovy
@@ -1,6 +1,7 @@
 // Global variables
 def TIMEOUT = 14400, ci_git_url, ci_git_branch, ci_git_base, refspec
-def CURRENT_START_TIME, CURRENT_END_TIME
+def CURRENT_START_TIME, CURRENT_END_TIME, GRAFANA_VIEW
+def LOG_URL = 'https://log.apps.staging.metal3.io/view/?orgId=1&timezone=browser&kiosk'
 
 script {
     ci_git_url = 'https://github.com/metal3-io/project-infra.git'
@@ -16,6 +17,10 @@ script {
     }
     echo "Checkout ${ci_git_url} branch ${ci_git_branch}"
 }
+
+def START_TIME = currentBuild.getStartTimeInMillis()
+GRAFANA_VIEW = """${LOG_URL}&from=${START_TIME}&to=now&var-pipeline=${env.JOB_NAME}&var-build=${BUILD_NUMBER}"""
+currentBuild.description = """<a href='${GRAFANA_VIEW}'>View in log collector</a>"""
 
 pipeline {
   /* In the BML we always run on the same machine so concurrency must be disabled */
@@ -139,10 +144,17 @@ pipeline {
                     echo 'Failed due to timeout'
                     currentBuild.result = 'FAILURE'
                 }
+                // Dynamic build info generation if logfetching would fail
+                GRAFANA_VIEW = """${LOG_URL}&from=${START_TIME}&to=${CURRENT_END_TIME}&var-pipeline=${env.JOB_NAME}&var-build=${BUILD_NUMBER}"""
+                currentBuild.description = """<a href='${GRAFANA_VIEW}'>View in log collector</a>"""
                 timestamps {
                     sh './jenkins/scripts/dynamic_worker_workflow/fetch_logs.sh'
                     archiveArtifacts "logs-${env.BUILD_TAG}.tgz"
                 }
+                CURRENT_END_TIME = System.currentTimeMillis()
+                // Dynamic build info generation, adjust log window if log fetching succeeds
+                GRAFANA_VIEW = """${LOG_URL}&from=${START_TIME}&to=${CURRENT_END_TIME}&var-pipeline=${env.JOB_NAME}&var-build=${BUILD_NUMBER}"""
+                currentBuild.description = """<a href='${GRAFANA_VIEW}'>View in log collector</a>"""
             }
         }
         success {

--- a/jenkins/jobs/bmo_e2e_optional_tests.groovy
+++ b/jenkins/jobs/bmo_e2e_optional_tests.groovy
@@ -1,10 +1,18 @@
-def TIMEOUT = 10800, CURRENT_START_TIME, CURRENT_END_TIME
+def TIMEOUT = 10800, CURRENT_START_TIME, CURRENT_END_TIME, GRAFANA_VIEW
+def LOG_URL = 'https://log.apps.test.metal3.io/view/?orgId=1&timezone=browser&kiosk'
 // Set defaults for non-PR jobs
 def pullSha = (env.PULL_PULL_SHA) ?: 'main'
 def pullBase = (env.PULL_BASE_REF) ?: 'main'
 def repoUrl = 'https://github.com/metal3-io/baremetal-operator.git'
 // Fetch the base branch and the pullSha, nothing else
 def refspec = '+refs/heads/' + pullBase + ':refs/remotes/origin/' + pullBase + ' ' + pullSha
+// Dynamic build info generation
+// In matrix jobs "axis" have their individual start and finish times.
+// Global "build" start time has to be determined before the matrix is
+// constructed
+def START_TIME = currentBuild.getStartTimeInMillis()
+GRAFANA_VIEW = """${LOG_URL}&from=${START_TIME}&to=now&var-pipeline=${env.JOB_NAME}&var-build=${BUILD_NUMBER}"""
+currentBuild.description = """<a href='${GRAFANA_VIEW}'>View in log collector</a>"""
 
 pipeline {
     environment {
@@ -72,6 +80,16 @@ pipeline {
                         }
                     }
                 }
+            }
+        }
+    }
+    post {
+        always {
+            script {
+                CURRENT_END_TIME = System.currentTimeMillis()
+                // Dynamic build info generation
+                GRAFANA_VIEW = """${LOG_URL}&from=${START_TIME}&to=${CURRENT_END_TIME}&var-pipeline=${env.JOB_NAME}&var-build=${BUILD_NUMBER}"""
+                currentBuild.description = """<a href='${GRAFANA_VIEW}'>View in log collector</a>"""
             }
         }
     }

--- a/jenkins/jobs/capm3-e2e-tests.groovy
+++ b/jenkins/jobs/capm3-e2e-tests.groovy
@@ -1,7 +1,8 @@
 // Global variables
 // Set default TIMEOUT to 10800 (3h)
 def TIMEOUT = 10800, ci_git_url, ci_git_branch, ci_git_base, refspec, agent_label
-def UPDATED_REPO, BUILD_TAG, GINKGO_SKIP, CURRENT_START_TIME, CURRENT_END_TIME
+def UPDATED_REPO, BUILD_TAG, GINKGO_SKIP, CURRENT_START_TIME, CURRENT_END_TIME, GRAFANA_VIEW
+def LOG_URL = 'https://log.apps.test.metal3.io/view/?orgId=1&timezone=browser&kiosk'
 
 script {
     UPDATED_REPO = "https://github.com/${env.REPO_OWNER}/${env.REPO_NAME}.git"
@@ -48,6 +49,10 @@ script {
         GINKGO_SKIP = 'pivoting remediation' // Allow non pivoting features
     }
 }
+
+def START_TIME = currentBuild.getStartTimeInMillis()
+GRAFANA_VIEW = """${LOG_URL}&from=${START_TIME}&to=now&var-pipeline=${env.JOB_NAME}&var-build=${BUILD_NUMBER}"""
+currentBuild.description = """<a href='${GRAFANA_VIEW}'>View in log collector</a>"""
 
 pipeline {
     agent { label agent_label }
@@ -129,6 +134,16 @@ pipeline {
                         }
                     }
                 }
+            }
+        }
+    }
+    post {
+        always {
+            script {
+                CURRENT_END_TIME = System.currentTimeMillis()
+                // Dynamic build info generation
+                GRAFANA_VIEW = """${LOG_URL}&from=${START_TIME}&to=${CURRENT_END_TIME}&var-pipeline=${env.JOB_NAME}&var-build=${BUILD_NUMBER}"""
+                currentBuild.description = """<a href='${GRAFANA_VIEW}'>View in log collector</a>"""
             }
         }
     }

--- a/jenkins/jobs/clean_resources.groovy
+++ b/jenkins/jobs/clean_resources.groovy
@@ -1,11 +1,17 @@
 // Global variables
 def TIMEOUT = 600, ci_git_url, ci_git_branch, refspec
+def CURRENT_START_TIME, CURRENT_END_TIME, GRAFANA_VIEW
+def LOG_URL = 'https://log.apps.staging.metal3.io/view/?orgId=1&timezone=browser&kiosk'
 
 script {
     ci_git_url   = 'https://github.com/metal3-io/project-infra.git'
     ci_git_branch = 'main'
     refspec = '+refs/heads/*:refs/remotes/origin/*'
 }
+
+def START_TIME = currentBuild.getStartTimeInMillis()
+GRAFANA_VIEW = """${LOG_URL}&from=${START_TIME}&to=now&var-pipeline=${env.JOB_NAME}&var-build=${BUILD_NUMBER}"""
+currentBuild.description = """<a href='${GRAFANA_VIEW}'>View in log collector</a>"""
 
 pipeline {
     agent { label 'metal3ci-4c16gb-ubuntu-jnlp' }
@@ -50,6 +56,16 @@ pipeline {
                         }
                     }
                 }
+            }
+        }
+    }
+    post {
+        always {
+            script {
+                CURRENT_END_TIME = System.currentTimeMillis()
+                // Dynamic build info generation
+                GRAFANA_VIEW = """${LOG_URL}&from=${START_TIME}&to=${CURRENT_END_TIME}&var-pipeline=${env.JOB_NAME}&var-build=${BUILD_NUMBER}"""
+                currentBuild.description = """<a href='${GRAFANA_VIEW}'>View in log collector</a>"""
             }
         }
     }

--- a/jenkins/jobs/dev_env_integration_tests.groovy
+++ b/jenkins/jobs/dev_env_integration_tests.groovy
@@ -1,6 +1,7 @@
 // Global variables
 def TIMEOUT = 10800, ci_git_url, ci_git_branch, ci_git_base, refspec, agent_label
-def UPDATED_REPO, BUILD_TAG, CURRENT_START_TIME, CURRENT_END_TIME
+def UPDATED_REPO, BUILD_TAG, CURRENT_START_TIME, CURRENT_END_TIME, GRAFANA_VIEW
+def LOG_URL = 'https://log.apps.test.metal3.io/view/?orgId=1&timezone=browser&kiosk'
 
 script {
     UPDATED_REPO = "https://github.com/${env.REPO_OWNER}/${env.REPO_NAME}.git"
@@ -18,6 +19,10 @@ script {
     }
     agent_label = "metal3ci-8c32gb-${IMAGE_OS}-oci"
 }
+
+def START_TIME = currentBuild.getStartTimeInMillis()
+GRAFANA_VIEW = """${LOG_URL}&from=${START_TIME}&to=now&var-pipeline=${env.JOB_NAME}&var-build=${BUILD_NUMBER}"""
+currentBuild.description = """<a href='${GRAFANA_VIEW}'>View in log collector</a>"""
 
 pipeline {
     agent { label agent_label }
@@ -97,6 +102,16 @@ pipeline {
                         }
                     }
                 }
+            }
+        }
+    }
+    post {
+        always {
+            script {
+                CURRENT_END_TIME = System.currentTimeMillis()
+                // Dynamic build info generation
+                GRAFANA_VIEW = """${LOG_URL}&from=${START_TIME}&to=${CURRENT_END_TIME}&var-pipeline=${env.JOB_NAME}&var-build=${BUILD_NUMBER}"""
+                currentBuild.description = """<a href='${GRAFANA_VIEW}'>View in log collector</a>"""
             }
         }
     }

--- a/jenkins/jobs/dynamic_fullstack_building.groovy
+++ b/jenkins/jobs/dynamic_fullstack_building.groovy
@@ -1,6 +1,7 @@
 // Global variables
 def TIMEOUT = 5400, ci_git_url, ci_git_branch, ci_git_base, refspec, agent_label
-def UPDATED_REPO, BUILD_TAG, GINKGO_SKIP, CURRENT_START_TIME, CURRENT_END_TIME
+def UPDATED_REPO, BUILD_TAG, GINKGO_SKIP, CURRENT_START_TIME, CURRENT_END_TIME, GRAFANA_VIEW
+def LOG_URL = 'https://log.apps.test.metal3.io/view/?orgId=1&timezone=browser&kiosk'
 
 script {
     UPDATED_REPO = "https://github.com/${env.REPO_OWNER}/${env.REPO_NAME}.git"
@@ -18,6 +19,10 @@ script {
     }
     echo "Checkout ${ci_git_url} branch ${ci_git_branch}"
 }
+
+def START_TIME = currentBuild.getStartTimeInMillis()
+GRAFANA_VIEW = """${LOG_URL}&from=${START_TIME}&to=now&var-pipeline=${env.JOB_NAME}&var-build=${BUILD_NUMBER}"""
+currentBuild.description = """<a href='${GRAFANA_VIEW}'>View in log collector</a>"""
 
 pipeline {
     agent { label 'metal3ci-8c32gb-ubuntu-oci' }
@@ -90,11 +95,18 @@ pipeline {
                     echo 'Failed due to timeout'
                     currentBuild.result = 'FAILURE'
                 }
-            }
-            timestamps {
-                /* Collect the logs */
-                sh './jenkins/scripts/dynamic_worker_workflow/fetch_logs.sh'
-                archiveArtifacts "logs-${env.BUILD_TAG}.tgz"
+                // Dynamic build info generation if logfetching would fail
+                GRAFANA_VIEW = """${LOG_URL}&from=${START_TIME}&to=${CURRENT_END_TIME}&var-pipeline=${env.JOB_NAME}&var-build=${BUILD_NUMBER}"""
+                currentBuild.description = """<a href='${GRAFANA_VIEW}'>View in log collector</a>"""
+                timestamps {
+                    /* Collect the logs */
+                    sh './jenkins/scripts/dynamic_worker_workflow/fetch_logs.sh'
+                    archiveArtifacts "logs-${env.BUILD_TAG}.tgz"
+                }
+                CURRENT_END_TIME = System.currentTimeMillis()
+                // Dynamic build info generation, adjust log window if log fetching succeeds
+                GRAFANA_VIEW = """${LOG_URL}&from=${START_TIME}&to=${CURRENT_END_TIME}&var-pipeline=${env.JOB_NAME}&var-build=${BUILD_NUMBER}"""
+                currentBuild.description = """<a href='${GRAFANA_VIEW}'>View in log collector</a>"""
             }
         }
         cleanup {

--- a/jenkins/jobs/image_building.groovy
+++ b/jenkins/jobs/image_building.groovy
@@ -1,5 +1,7 @@
 // Global variables
 def ci_git_url, ci_git_branch, ci_git_base, refspec
+def CURRENT_END_TIME, GRAFANA_VIEW
+def LOG_URL = 'https://log.apps.test.metal3.io/view/?orgId=1&timezone=browser&kiosk'
 
 script {
     ci_git_url   = 'https://github.com/metal3-io/project-infra.git'
@@ -7,6 +9,10 @@ script {
     ci_git_base = (env.PULL_BASE_REF) ?: 'main'
     refspec = '+refs/heads/' + ci_git_base + ':refs/remotes/origin/' + ci_git_base + ' ' + ci_git_branch
 }
+
+def START_TIME = currentBuild.getStartTimeInMillis()
+GRAFANA_VIEW = """${LOG_URL}&from=${START_TIME}&to=now&var-pipeline=${env.JOB_NAME}&var-build=${BUILD_NUMBER}"""
+currentBuild.description = """<a href='${GRAFANA_VIEW}'>View in log collector</a>"""
 
 pipeline {
     options {
@@ -207,6 +213,15 @@ pipeline {
                         }
                     }
                 }
+            }
+        }
+    }
+    post {
+        always {
+            script {
+                CURRENT_END_TIME = System.currentTimeMillis()
+                GRAFANA_VIEW = """${LOG_URL}&from=${START_TIME}&to=${CURRENT_END_TIME}&var-pipeline=${env.JOB_NAME}&var-build=${BUILD_NUMBER}"""
+                currentBuild.description = """<a href='${GRAFANA_VIEW}'>View in log collector</a>"""
             }
         }
     }

--- a/jenkins/jobs/osv_scanner_metal3.groovy
+++ b/jenkins/jobs/osv_scanner_metal3.groovy
@@ -2,6 +2,8 @@
 
 // Global variables
 def ci_git_url, ci_git_branch, ci_git_base, refspec, agent_label
+def CURRENT_END_TIME, GRAFANA_VIEW
+def LOG_URL = 'https://log.apps.test.metal3.io/view/?orgId=1&timezone=browser&kiosk'
 
 script {
     ci_git_branch = (env.PULL_PULL_SHA) ?: 'main'
@@ -176,6 +178,10 @@ def runOsvScan = { String repoName, String refType, String ref, String repoUrl, 
 }
 
 script { agent_label = 'metal3ci-8c32gb-ubuntu-oci' }
+
+def START_TIME = currentBuild.getStartTimeInMillis()
+GRAFANA_VIEW = """${LOG_URL}&from=${START_TIME}&to=now&var-pipeline=${env.JOB_NAME}&var-build=${BUILD_NUMBER}"""
+currentBuild.description = """<a href='${GRAFANA_VIEW}'>View in log collector</a>"""
 
 pipeline {
     agent { label agent_label }
@@ -476,6 +482,9 @@ pipeline {
     post {
         always {
             script {
+                CURRENT_END_TIME = System.currentTimeMillis()
+                GRAFANA_VIEW = """${LOG_URL}&from=${START_TIME}&to=${CURRENT_END_TIME}&var-pipeline=${env.JOB_NAME}&var-build=${BUILD_NUMBER}"""
+                currentBuild.description = """<a href='${GRAFANA_VIEW}'>View in log collector</a>"""
                 archiveArtifacts artifacts: 'results/*.txt', allowEmptyArchive: true
             }
         }

--- a/jenkins/jobs/pre_release_tests.groovy
+++ b/jenkins/jobs/pre_release_tests.groovy
@@ -1,6 +1,7 @@
 // Global variables
 def TIMEOUT = 1800, ci_git_url, ci_git_branch, ci_git_base, refspec
-def UPDATED_REPO, agent_label, BUILD_TAG, GINKGO_SKIP, CURRENT_START_TIME, CURRENT_END_TIME
+def UPDATED_REPO, agent_label, BUILD_TAG, GINKGO_SKIP, CURRENT_START_TIME, CURRENT_END_TIME, GRAFANA_VIEW
+def LOG_URL = 'https://log.apps.test.metal3.io/view/?orgId=1&timezone=browser&kiosk'
 
 script {
     UPDATED_REPO = "https://github.com/${env.REPO_OWNER}/${env.REPO_NAME}.git"
@@ -21,6 +22,10 @@ script {
 
     agent_label = "metal3ci-8c32gb-${IMAGE_OS}-oci"
 }
+
+def START_TIME = currentBuild.getStartTimeInMillis()
+GRAFANA_VIEW = """${LOG_URL}&from=${START_TIME}&to=now&var-pipeline=${env.JOB_NAME}&var-build=${BUILD_NUMBER}"""
+currentBuild.description = """<a href='${GRAFANA_VIEW}'>View in log collector</a>"""
 
 pipeline {
     agent { label agent_label }
@@ -132,6 +137,16 @@ pipeline {
                         }
                     }
                 }
+            }
+        }
+    }
+    post {
+        always {
+            script {
+                CURRENT_END_TIME = System.currentTimeMillis()
+                // Dynamic build info generation
+                GRAFANA_VIEW = """${LOG_URL}&from=${START_TIME}&to=${CURRENT_END_TIME}&var-pipeline=${env.JOB_NAME}&var-build=${BUILD_NUMBER}"""
+                currentBuild.description = """<a href='${GRAFANA_VIEW}'>View in log collector</a>"""
             }
         }
     }


### PR DESCRIPTION
This commit:

- Adds dynamic Grafana log collector links to individual build contexts for all Jenkins pipeline jobs. The link is set immediately when the build starts (pointing to live view with to=now) and updated in the pipeline-level post block with the actual end time once the build completes.

Reason for this commit is to improve the user experience of the CI log collector and the test pipelines.