### PR TITLE
Enforce golangci-lint presubmit for ironic-standalone-operator release branches

### DIFF
--- a/prow/config/jobs/metal3-io/ironic-standalone-operator-release-0.10.yaml
+++ b/prow/config/jobs/metal3-io/ironic-standalone-operator-release-0.10.yaml
@@ -71,7 +71,6 @@ presubmits:
     - release-0.10
     skip_if_only_changed: '(((^|/)OWNERS)|((^|/)OWNERS_ALIASES)|(\.md))$'
     decorate: true
-    optional: true
     spec:
       containers:
       - args:

--- a/prow/config/jobs/metal3-io/ironic-standalone-operator-release-0.9.yaml
+++ b/prow/config/jobs/metal3-io/ironic-standalone-operator-release-0.9.yaml
@@ -71,7 +71,6 @@ presubmits:
     - release-0.9
     skip_if_only_changed: '(((^|/)OWNERS)|((^|/)OWNERS_ALIASES)|(\.md))$'
     decorate: true
-    optional: true
     spec:
       containers:
       - args:


### PR DESCRIPTION
part of https://github.com/metal3-io/project-infra/issues/1448

This pr enforces golangci-lint presubmit for ironic-standalone-operator release branches.