### PR TITLE
Add pr verifier to prow for ironic-standalone-operator 

### DIFF
--- a/prow/config/jobs/metal3-io/ironic-standalone-operator-release-0.10.yaml
+++ b/prow/config/jobs/metal3-io/ironic-standalone-operator-release-0.10.yaml
@@ -83,6 +83,24 @@ presubmits:
           value: "TRUE"
         image: docker.io/golang:1.25
         imagePullPolicy: Always
+  - name: pr-verifier
+    branches:
+    - release-0.10
+    always_run: true
+    decorate: true
+    optional: true
+    extra_refs:
+    - org: metal3-io
+      repo: project-infra
+      base_ref: main
+    spec:
+      containers:
+      - args:
+        - /home/prow/go/src/github.com/metal3-io/project-infra/hack/verify-pr-title.sh
+        command:
+        - sh
+        image: docker.io/golang:1.25
+        imagePullPolicy: Always
   #NOTE(elfosardo): commented out until metal3-dev-env starts using IrSO
   # name: metal3-dev-env-integration-test-{image_os}-release-1-11
   # - name: metal3-dev-env-integration-test-ubuntu-release-1-11

--- a/prow/config/jobs/metal3-io/ironic-standalone-operator-release-0.9.yaml
+++ b/prow/config/jobs/metal3-io/ironic-standalone-operator-release-0.9.yaml
@@ -83,6 +83,24 @@ presubmits:
           value: "TRUE"
         image: docker.io/golang:1.25
         imagePullPolicy: Always
+  - name: pr-verifier
+    branches:
+    - release-0.9
+    always_run: true
+    decorate: true
+    optional: true
+    extra_refs:
+    - org: metal3-io
+      repo: project-infra
+      base_ref: main
+    spec:
+      containers:
+      - args:
+        - /home/prow/go/src/github.com/metal3-io/project-infra/hack/verify-pr-title.sh
+        command:
+        - sh
+        image: docker.io/golang:1.25
+        imagePullPolicy: Always
   #NOTE(elfosardo): commented out until metal3-dev-env starts using IrSO
   # name: metal3-dev-env-integration-test-{image_os}-release-1-11
   # - name: metal3-dev-env-integration-test-ubuntu-release-1-11

--- a/prow/config/jobs/metal3-io/ironic-standalone-operator.yaml
+++ b/prow/config/jobs/metal3-io/ironic-standalone-operator.yaml
@@ -82,6 +82,24 @@ presubmits:
           value: "TRUE"
         image: docker.io/golang:1.26
         imagePullPolicy: Always
+  - name: pr-verifier
+    branches:
+    - main
+    always_run: true
+    decorate: true
+    optional: true
+    extra_refs:
+    - org: metal3-io
+      repo: project-infra
+      base_ref: main
+    spec:
+      containers:
+      - args:
+        - /home/prow/go/src/github.com/metal3-io/project-infra/hack/verify-pr-title.sh
+        command:
+        - sh
+        image: docker.io/golang:1.26
+        imagePullPolicy: Always
   # name: metal3-dev-env-integration-test-{image_os}-main
   - name: metal3-dev-env-integration-test-ubuntu-main
     branches:


### PR DESCRIPTION
Moves the Pr-verifier check over to Prow for ironic-standalone-operator, main and every release branches.

It is optional till it passes green.
Part of https://github.com/metal3-io/project-infra/issues/1448.