### PR TITLE
Add pr-verifier Prow presubmit for cluster-api-provider-metal3

### DIFF
--- a/prow/config/jobs/metal3-io/cluster-api-provider-metal3-release-1.12.yaml
+++ b/prow/config/jobs/metal3-io/cluster-api-provider-metal3-release-1.12.yaml
@@ -128,6 +128,24 @@ presubmits:
           value: "TRUE"
         image: docker.io/golang:1.25
         imagePullPolicy: Always
+  - name: pr-verifier
+    branches:
+    - release-1.12
+    always_run: true
+    decorate: true
+    optional: true
+    extra_refs:
+    - org: metal3-io
+      repo: project-infra
+      base_ref: main
+    spec:
+      containers:
+      - args:
+        - /home/prow/go/src/github.com/metal3-io/project-infra/hack/verify-pr-title.sh
+        command:
+        - sh
+        image: docker.io/golang:1.25
+        imagePullPolicy: Always
   # name: {job_prefix}-{image_os}-e2e-basic-test-{capm3_target_branch}
   - name: metal3-centos-e2e-basic-test-release-1-12
     branches:

--- a/prow/config/jobs/metal3-io/cluster-api-provider-metal3-release-1.13.yaml
+++ b/prow/config/jobs/metal3-io/cluster-api-provider-metal3-release-1.13.yaml
@@ -128,6 +128,24 @@ presubmits:
           value: "TRUE"
         image: docker.io/golang:1.25
         imagePullPolicy: Always
+  - name: pr-verifier
+    branches:
+    - release-1.13
+    always_run: true
+    decorate: true
+    optional: true
+    extra_refs:
+    - org: metal3-io
+      repo: project-infra
+      base_ref: main
+    spec:
+      containers:
+      - args:
+        - /home/prow/go/src/github.com/metal3-io/project-infra/hack/verify-pr-title.sh
+        command:
+        - sh
+        image: docker.io/golang:1.25
+        imagePullPolicy: Always
   # name: {job_prefix}-{image_os}-e2e-basic-test-{capm3_target_branch}
   - name: metal3-centos-e2e-basic-test-release-1-13
     branches:

--- a/prow/config/jobs/metal3-io/cluster-api-provider-metal3.yaml
+++ b/prow/config/jobs/metal3-io/cluster-api-provider-metal3.yaml
@@ -149,6 +149,24 @@ presubmits:
           value: "TRUE"
         image: docker.io/golang:1.26
         imagePullPolicy: Always
+  - name: pr-verifier
+    branches:
+    - main
+    always_run: true
+    decorate: true
+    optional: true
+    extra_refs:
+    - org: metal3-io
+      repo: project-infra
+      base_ref: main
+    spec:
+      containers:
+      - args:
+        - /home/prow/go/src/github.com/metal3-io/project-infra/hack/verify-pr-title.sh
+        command:
+        - sh
+        image: docker.io/golang:1.26
+        imagePullPolicy: Always
   # name: {job_prefix}-{image_os}-e2e-basic-test-{capm3_target_branch}
   - name: metal3-centos-e2e-basic-test-main
     branches:


### PR DESCRIPTION
Moves the Pr-verifier check over to Prow for cluster-api-provider-metal3, main and every release branches.

It is optional till it passes green.
Part of https://github.com/metal3-io/project-infra/issues/1448.