### PR TITLE
Add unit Prow presubmit for ironic-standalone-operator

### DIFF
--- a/prow/config/jobs/metal3-io/ironic-standalone-operator-release-0.10.yaml
+++ b/prow/config/jobs/metal3-io/ironic-standalone-operator-release-0.10.yaml
@@ -48,6 +48,20 @@ presubmits:
           value: "TRUE"
         image: docker.io/pipelinecomponents/markdownlint-cli2:0.12.0@sha256:a3977fba9814f10d33a1d69ae607dc808e7a6470b2ba03e84c17193c0791aac0
         imagePullPolicy: Always
+  - name: unit
+    branches:
+    - release-0.10
+    skip_if_only_changed: '(((^|/)OWNERS)|((^|/)OWNERS_ALIASES)|(\.md))$'
+    decorate: true
+    optional: true
+    spec:
+      containers:
+      - args:
+        - test
+        command:
+        - make
+        image: docker.io/golang:1.25
+        imagePullPolicy: Always
   - name: manifestlint
     branches:
     - release-0.10

--- a/prow/config/jobs/metal3-io/ironic-standalone-operator-release-0.9.yaml
+++ b/prow/config/jobs/metal3-io/ironic-standalone-operator-release-0.9.yaml
@@ -48,6 +48,20 @@ presubmits:
           value: "TRUE"
         image: docker.io/pipelinecomponents/markdownlint-cli2:0.12.0@sha256:a3977fba9814f10d33a1d69ae607dc808e7a6470b2ba03e84c17193c0791aac0
         imagePullPolicy: Always
+  - name: unit
+    branches:
+    - release-0.9
+    skip_if_only_changed: '(((^|/)OWNERS)|((^|/)OWNERS_ALIASES)|(\.md))$'
+    decorate: true
+    optional: true
+    spec:
+      containers:
+      - args:
+        - test
+        command:
+        - make
+        image: docker.io/golang:1.25
+        imagePullPolicy: Always
   - name: manifestlint
     branches:
     - release-0.9

--- a/prow/config/jobs/metal3-io/ironic-standalone-operator.yaml
+++ b/prow/config/jobs/metal3-io/ironic-standalone-operator.yaml
@@ -48,6 +48,20 @@ presubmits:
           value: "TRUE"
         image: docker.io/pipelinecomponents/markdownlint-cli2:0.12.0@sha256:a3977fba9814f10d33a1d69ae607dc808e7a6470b2ba03e84c17193c0791aac0
         imagePullPolicy: Always
+  - name: unit
+    branches:
+    - main
+    skip_if_only_changed: '(((^|/)OWNERS)|((^|/)OWNERS_ALIASES)|(\.md))$'
+    decorate: true
+    optional: true
+    spec:
+      containers:
+      - args:
+        - test
+        command:
+        - make
+        image: docker.io/golang:1.26
+        imagePullPolicy: Always
   - name: manifestlint
     branches:
     - main


### PR DESCRIPTION
This pr adds unit test to Prow for ironic-standalone-operator.

Part of https://github.com/metal3-io/project-infra/issues/1448.