### PR TITLE
Add golangci-lint presubmit for cluster-api-provider-metal3

### DIFF
--- a/prow/config/jobs/metal3-io/cluster-api-provider-metal3-release-1.12.yaml
+++ b/prow/config/jobs/metal3-io/cluster-api-provider-metal3-release-1.12.yaml
@@ -112,6 +112,23 @@ presubmits:
           value: "/"
         image: ghcr.io/yannh/kubeconform:v0.8.0-alpine@sha256:6b90a5f23d846140ce0194fe050b1995e546eba938f3a6bf10c039dd5e24588f
         imagePullPolicy: Always
+  - name: golangci-lint
+    branches:
+    - release-1.12
+    skip_if_only_changed: '(((^|/)OWNERS)|((^|/)OWNERS_ALIASES)|(\.md))$'
+    decorate: true
+    optional: true
+    spec:
+      containers:
+      - args:
+        - lint
+        command:
+        - make
+        env:
+        - name: IS_CONTAINER
+          value: "TRUE"
+        image: docker.io/golang:1.25
+        imagePullPolicy: Always
   - name: build
     branches:
     - release-1.12

--- a/prow/config/jobs/metal3-io/cluster-api-provider-metal3-release-1.13.yaml
+++ b/prow/config/jobs/metal3-io/cluster-api-provider-metal3-release-1.13.yaml
@@ -112,6 +112,23 @@ presubmits:
           value: "/"
         image: ghcr.io/yannh/kubeconform:v0.8.0-alpine@sha256:6b90a5f23d846140ce0194fe050b1995e546eba938f3a6bf10c039dd5e24588f
         imagePullPolicy: Always
+  - name: golangci-lint
+    branches:
+    - release-1.13
+    skip_if_only_changed: '(((^|/)OWNERS)|((^|/)OWNERS_ALIASES)|(\.md))$'
+    decorate: true
+    optional: true
+    spec:
+      containers:
+      - args:
+        - lint
+        command:
+        - make
+        env:
+        - name: IS_CONTAINER
+          value: "TRUE"
+        image: docker.io/golang:1.25
+        imagePullPolicy: Always
   - name: build
     branches:
     - release-1.13

--- a/prow/config/jobs/metal3-io/cluster-api-provider-metal3.yaml
+++ b/prow/config/jobs/metal3-io/cluster-api-provider-metal3.yaml
@@ -112,6 +112,23 @@ presubmits:
           value: "/"
         image: ghcr.io/yannh/kubeconform:v0.8.0-alpine@sha256:6b90a5f23d846140ce0194fe050b1995e546eba938f3a6bf10c039dd5e24588f
         imagePullPolicy: Always
+  - name: golangci-lint
+    branches:
+    - main
+    skip_if_only_changed: '(((^|/)OWNERS)|((^|/)OWNERS_ALIASES)|(\.md))$'
+    decorate: true
+    optional: true
+    spec:
+      containers:
+      - args:
+        - lint
+        command:
+        - make
+        env:
+        - name: IS_CONTAINER
+          value: "TRUE"
+        image: docker.io/golang:1.26
+        imagePullPolicy: Always
   ## NOTE: This job was constantly re-running on all open PRs.
   ## We have not been able to determine the root cause. Removing it for now.
   ## We can try to add it again after cutting v1.13 for example.


### PR DESCRIPTION
Part of https://github.com/metal3-io/project-infra/issues/1448, 

Adds the golangci-lint presubmit to prow for capm3. 
Optional for now, till it passes green.