### PR TITLE
Add yamllint Prow presubmit for baremetal-operator

### DIFF
--- a/prow/config/jobs/metal3-io/baremetal-operator.yaml
+++ b/prow/config/jobs/metal3-io/baremetal-operator.yaml
@@ -156,6 +156,23 @@ presubmits:
         - sh
         image: quay.io/metal3-io/basic-checks:golang-1.26
         imagePullPolicy: Always
+  - name: yamllint
+    branches:
+    - main
+    run_if_changed: '((\.ya?ml)|(\.md)|(hack/yamllint\.sh))$'
+    decorate: true
+    optional: true
+    spec:
+      containers:
+      - args:
+        - ./hack/yamllint.sh
+        command:
+        - sh
+        env:
+        - name: IS_CONTAINER
+          value: "TRUE"
+        image: docker.io/pipelinecomponents/yamllint:0.35.13@sha256:5ab5eb7da0ed5e606b07c1723fc8b275e925189f70ac259b26b7329cb5f8f44d
+        imagePullPolicy: Always
   # name: {job_prefix}-{image_os}-e2e-basic-test-{capm3_target_branch}
   - name: metal3-centos-e2e-basic-test-main
     branches:


### PR DESCRIPTION
Moves the yamllint  check over to Prow for bmo.

It is optional till it passes green.
Part of https://github.com/metal3-io/project-infra/issues/1448.