### PR TITLE
Update prow config for ironic-image jobs to make them optional

### DIFF
--- a/prow/config/jobs/metal3-io/ironic-image-release-29.0.yaml
+++ b/prow/config/jobs/metal3-io/ironic-image-release-29.0.yaml
@@ -38,13 +38,13 @@ presubmits:
     - release-29.0
     agent: jenkins
     always_run: false
-    optional: false
+    optional: true
   - name: metal3-ubuntu-e2e-integration-test-release-1-10
     branches:
     - release-29.0
     agent: jenkins
     always_run: false
-    optional: false
+    optional: true
   - name: metal3-dev-env-integration-test-centos-release-1-10
     branches:
     - release-29.0

--- a/prow/config/jobs/metal3-io/ironic-image-release-32.0.yaml
+++ b/prow/config/jobs/metal3-io/ironic-image-release-32.0.yaml
@@ -38,13 +38,13 @@ presubmits:
     - release-32.0
     agent: jenkins
     always_run: false
-    optional: false
+    optional: true
   - name: metal3-ubuntu-e2e-integration-test-release-1-11
     branches:
     - release-32.0
     agent: jenkins
     always_run: false
-    optional: false
+    optional: true
   - name: metal3-dev-env-integration-test-centos-release-1-11
     branches:
     - release-32.0

--- a/prow/config/jobs/metal3-io/ironic-image-release-33.0.yaml
+++ b/prow/config/jobs/metal3-io/ironic-image-release-33.0.yaml
@@ -38,13 +38,13 @@ presubmits:
     - release-33.0
     agent: jenkins
     always_run: false
-    optional: false
+    optional: true
   - name: metal3-ubuntu-e2e-integration-test-release-1-12
     branches:
     - release-33.0
     agent: jenkins
     always_run: false
-    optional: false
+    optional: true
   - name: metal3-dev-env-integration-test-centos-release-1-12
     branches:
     - release-33.0

--- a/prow/config/jobs/metal3-io/ironic-image-release-34.0.yaml
+++ b/prow/config/jobs/metal3-io/ironic-image-release-34.0.yaml
@@ -38,13 +38,13 @@ presubmits:
     - release-34.0
     agent: jenkins
     always_run: false
-    optional: false
+    optional: true
   - name: metal3-ubuntu-e2e-integration-test-release-1-12
     branches:
     - release-34.0
     agent: jenkins
     always_run: false
-    optional: false
+    optional: true
   - name: metal3-dev-env-integration-test-centos-release-1-12
     branches:
     - release-34.0

--- a/prow/config/jobs/metal3-io/ironic-image-release-35.0.yaml
+++ b/prow/config/jobs/metal3-io/ironic-image-release-35.0.yaml
@@ -38,13 +38,13 @@ presubmits:
     - release-35.0
     agent: jenkins
     always_run: false
-    optional: false
+    optional: true
   - name: metal3-ubuntu-e2e-integration-test-release-1-13
     branches:
     - release-35.0
     agent: jenkins
     always_run: false
-    optional: false
+    optional: true
   - name: metal3-dev-env-integration-test-centos-release-1-13
     branches:
     - release-35.0

--- a/prow/config/jobs/metal3-io/ironic-image-release-37.0.yaml
+++ b/prow/config/jobs/metal3-io/ironic-image-release-37.0.yaml
@@ -33,25 +33,25 @@ presubmits:
         image: docker.io/pipelinecomponents/markdownlint-cli2:0.12.0@sha256:a3977fba9814f10d33a1d69ae607dc808e7a6470b2ba03e84c17193c0791aac0
         imagePullPolicy: Always
   # name: {job_prefix}-{image_os}-e2e-integration-test-{capm3_target_branch}
-  - name: metal3-centos-e2e-integration-test-release-1-14
-    branches:
-    - release-37.0
-    agent: jenkins
-    always_run: false
-    optional: false
-  - name: metal3-ubuntu-e2e-integration-test-release-1-14
-    branches:
-    - release-37.0
-    agent: jenkins
-    always_run: false
-    optional: false
-  - name: metal3-dev-env-integration-test-centos-release-1-14
+  - name: metal3-centos-e2e-integration-test-release-1-13
     branches:
     - release-37.0
     agent: jenkins
     always_run: false
     optional: true
-  - name: metal3-dev-env-integration-test-ubuntu-release-1-14
+  - name: metal3-ubuntu-e2e-integration-test-release-1-13
+    branches:
+    - release-37.0
+    agent: jenkins
+    always_run: false
+    optional: true
+  - name: metal3-dev-env-integration-test-centos-release-1-13
+    branches:
+    - release-37.0
+    agent: jenkins
+    always_run: false
+    optional: true
+  - name: metal3-dev-env-integration-test-ubuntu-release-1-13
     branches:
     - release-37.0
     agent: jenkins

--- a/prow/config/jobs/metal3-io/ironic-image-release-38.0.yaml
+++ b/prow/config/jobs/metal3-io/ironic-image-release-38.0.yaml
@@ -38,13 +38,13 @@ presubmits:
     - release-38.0
     agent: jenkins
     always_run: false
-    optional: false
+    optional: true
   - name: metal3-ubuntu-e2e-integration-test-release-1-14
     branches:
     - release-38.0
     agent: jenkins
     always_run: false
-    optional: false
+    optional: true
   - name: metal3-dev-env-integration-test-centos-release-1-14
     branches:
     - release-38.0

--- a/prow/config/jobs/metal3-io/ironic-image.yaml
+++ b/prow/config/jobs/metal3-io/ironic-image.yaml
@@ -56,7 +56,7 @@ presubmits:
     labels:
       jenkins_operator: oci
     always_run: false
-    optional: false
+    optional: true
   - name: metal3-ubuntu-e2e-integration-test-main
     branches:
     - main
@@ -64,7 +64,7 @@ presubmits:
     labels:
       jenkins_operator: oci
     always_run: false
-    optional: false
+    optional: true
   - name: metal3-dev-env-integration-test-centos-main
     branches:
     - main

--- a/prow/config/jobs/metal3-io/ironic-ipa-downloader.yaml
+++ b/prow/config/jobs/metal3-io/ironic-ipa-downloader.yaml
@@ -51,10 +51,6 @@ presubmits:
     agent: jenkins
     always_run: false
     optional: true
-  - name: metal3-centos-e2e-integration-test-release-1-10
-    agent: jenkins
-    always_run: false
-    optional: true
   - name: metal3-ubuntu-e2e-integration-test-main
     agent: jenkins
     labels:
@@ -74,10 +70,6 @@ presubmits:
     always_run: false
     optional: true
   - name: metal3-ubuntu-e2e-integration-test-release-1-11
-    agent: jenkins
-    always_run: false
-    optional: true
-  - name: metal3-ubuntu-e2e-integration-test-release-1-10
     agent: jenkins
     always_run: false
     optional: true


### PR DESCRIPTION
Update prow config for ironic-image jobs to make them optional. Also  we have reverted in release-37.0 config  to have 1-13 jobs, and removing unmaintained release-1.10 jobs in  ironic-ipa-downloader.