### PR TITLE
Bump golang version to 1.26 for release-1.14 jobs

### DIFF
--- a/prow/config/jobs/metal3-io/baremetal-operator-release-0.14.yaml
+++ b/prow/config/jobs/metal3-io/baremetal-operator-release-0.14.yaml
@@ -14,7 +14,7 @@ presubmits:
         env:
         - name: IS_CONTAINER
           value: "TRUE"
-        image: quay.io/metal3-io/basic-checks:golang-1.25
+        image: quay.io/metal3-io/basic-checks:golang-1.26
         imagePullPolicy: Always
   - name: markdownlint
     branches:
@@ -70,7 +70,7 @@ presubmits:
           value: "http://localhost:6385/v1/"
         - name: IRONIC_INSPECTOR_ENDPOINT
           value: "http://localhost:5050/v1/"
-        image: quay.io/metal3-io/basic-checks:golang-1.25
+        image: quay.io/metal3-io/basic-checks:golang-1.26
         imagePullPolicy: Always
   # NOTE: The test jobs are for verifying Makefile and hack/* script changes only
   - name: test
@@ -84,7 +84,7 @@ presubmits:
         - test
         command:
         - make
-        image: quay.io/metal3-io/basic-checks:golang-1.25
+        image: quay.io/metal3-io/basic-checks:golang-1.26
         imagePullPolicy: Always
   - name: manifestlint
     branches:

--- a/prow/config/jobs/metal3-io/cluster-api-provider-metal3-release-1.14.yaml
+++ b/prow/config/jobs/metal3-io/cluster-api-provider-metal3-release-1.14.yaml
@@ -14,7 +14,7 @@ presubmits:
         env:
         - name: IS_CONTAINER
           value: "TRUE"
-        image: docker.io/golang:1.25
+        image: docker.io/golang:1.26
         imagePullPolicy: Always
   # NOTE: The test jobs are for verifying Makefile and hack/* script changes only
   - name: test
@@ -28,7 +28,7 @@ presubmits:
         - test
         command:
         - make
-        image: docker.io/golang:1.25
+        image: docker.io/golang:1.26
         imagePullPolicy: Always
   - name: markdownlint
     branches:
@@ -76,7 +76,7 @@ presubmits:
         env:
         - name: IS_CONTAINER
           value: "TRUE"
-        image: docker.io/golang:1.25
+        image: docker.io/golang:1.26
         imagePullPolicy: Always
   - name: unit
     branches:
@@ -92,7 +92,7 @@ presubmits:
         env:
         - name: IS_CONTAINER
           value: "TRUE"
-        image: docker.io/golang:1.25
+        image: docker.io/golang:1.26
         imagePullPolicy: Always
   - name: manifestlint
     branches:
@@ -126,7 +126,7 @@ presubmits:
         env:
         - name: IS_CONTAINER
           value: "TRUE"
-        image: docker.io/golang:1.25
+        image: docker.io/golang:1.26
         imagePullPolicy: Always
   # name: {job_prefix}-{image_os}-e2e-basic-test-{capm3_target_branch}
   - name: metal3-centos-e2e-basic-test-release-1-14

--- a/prow/config/jobs/metal3-io/ip-address-manager-release-1.14.yaml
+++ b/prow/config/jobs/metal3-io/ip-address-manager-release-1.14.yaml
@@ -14,7 +14,7 @@ presubmits:
         env:
         - name: IS_CONTAINER
           value: "TRUE"
-        image: docker.io/golang:1.25
+        image: docker.io/golang:1.26
         imagePullPolicy: Always
   # NOTE: The test jobs are for verifying the Makefile and hack/* scripts only
   - name: test
@@ -28,7 +28,7 @@ presubmits:
         - test
         command:
         - make
-        image: docker.io/golang:1.25
+        image: docker.io/golang:1.26
         imagePullPolicy: Always
   - name: markdownlint
     branches:
@@ -76,7 +76,7 @@ presubmits:
         env:
         - name: IS_CONTAINER
           value: "TRUE"
-        image: docker.io/golang:1.25
+        image: docker.io/golang:1.26
   - name: generate
     branches:
     - release-1.14
@@ -91,7 +91,7 @@ presubmits:
         env:
         - name: IS_CONTAINER
           value: "TRUE"
-        image: docker.io/golang:1.25
+        image: docker.io/golang:1.26
         imagePullPolicy: Always
   - name: manifestlint
     branches:


### PR DESCRIPTION
Bump golang version to 1.26 for release-1.14 jobs