### PR TITLE
Add Credentials to alloy alloy logs to be streamed in capm3

### DIFF
--- a/jenkins/jobs/capm3-e2e-tests.groovy
+++ b/jenkins/jobs/capm3-e2e-tests.groovy
@@ -105,7 +105,8 @@ pipeline {
                   submoduleCfg: [],
                   userRemoteConfigs: [[url: ci_git_url, refspec: refspec]]
                   ])
-                withCredentials([string(credentialsId: 'metal3-clusterctl-github-token', variable: 'GITHUB_TOKEN')]) {
+                withCredentials([string(credentialsId: 'metal3-clusterctl-github-token', variable: 'GITHUB_TOKEN'),
+                    usernamePassword(credentialsId: 'metal3-ci-log-collector-push', usernameVariable: 'LOKI_USERNAME', passwordVariable: 'LOKI_PASSWORD')]) {
                     ansiColor('xterm') {
                         timestamps {
                             sh './jenkins/scripts/dynamic_worker_workflow/e2e_tests.sh'


### PR DESCRIPTION
Done for https://github.com/metal3-io/cluster-api-provider-metal3/pull/3610
