### PR TITLE
Enforce pr-verifier presubmit for ipam, IrSO, capm3

### DIFF
--- a/prow/config/jobs/metal3-io/cluster-api-provider-metal3-release-1.12.yaml
+++ b/prow/config/jobs/metal3-io/cluster-api-provider-metal3-release-1.12.yaml
@@ -133,7 +133,6 @@ presubmits:
     - release-1.12
     always_run: true
     decorate: true
-    optional: true
     extra_refs:
     - org: metal3-io
       repo: project-infra

--- a/prow/config/jobs/metal3-io/cluster-api-provider-metal3-release-1.13.yaml
+++ b/prow/config/jobs/metal3-io/cluster-api-provider-metal3-release-1.13.yaml
@@ -133,7 +133,6 @@ presubmits:
     - release-1.13
     always_run: true
     decorate: true
-    optional: true
     extra_refs:
     - org: metal3-io
       repo: project-infra

--- a/prow/config/jobs/metal3-io/cluster-api-provider-metal3.yaml
+++ b/prow/config/jobs/metal3-io/cluster-api-provider-metal3.yaml
@@ -154,7 +154,6 @@ presubmits:
     - main
     always_run: true
     decorate: true
-    optional: true
     extra_refs:
     - org: metal3-io
       repo: project-infra

--- a/prow/config/jobs/metal3-io/ip-address-manager-release-1.12.yaml
+++ b/prow/config/jobs/metal3-io/ip-address-manager-release-1.12.yaml
@@ -132,7 +132,6 @@ presubmits:
     - release-1.12
     always_run: true
     decorate: true
-    optional: true
     extra_refs:
     - org: metal3-io
       repo: project-infra

--- a/prow/config/jobs/metal3-io/ip-address-manager-release-1.13.yaml
+++ b/prow/config/jobs/metal3-io/ip-address-manager-release-1.13.yaml
@@ -132,7 +132,6 @@ presubmits:
     - release-1.13
     always_run: true
     decorate: true
-    optional: true
     extra_refs:
     - org: metal3-io
       repo: project-infra

--- a/prow/config/jobs/metal3-io/ip-address-manager.yaml
+++ b/prow/config/jobs/metal3-io/ip-address-manager.yaml
@@ -132,7 +132,6 @@ presubmits:
     - main
     always_run: true
     decorate: true
-    optional: true
     extra_refs:
     - org: metal3-io
       repo: project-infra

--- a/prow/config/jobs/metal3-io/ironic-standalone-operator-release-0.10.yaml
+++ b/prow/config/jobs/metal3-io/ironic-standalone-operator-release-0.10.yaml
@@ -87,7 +87,6 @@ presubmits:
     - release-0.10
     always_run: true
     decorate: true
-    optional: true
     extra_refs:
     - org: metal3-io
       repo: project-infra

--- a/prow/config/jobs/metal3-io/ironic-standalone-operator-release-0.9.yaml
+++ b/prow/config/jobs/metal3-io/ironic-standalone-operator-release-0.9.yaml
@@ -87,7 +87,6 @@ presubmits:
     - release-0.9
     always_run: true
     decorate: true
-    optional: true
     extra_refs:
     - org: metal3-io
       repo: project-infra

--- a/prow/config/jobs/metal3-io/ironic-standalone-operator.yaml
+++ b/prow/config/jobs/metal3-io/ironic-standalone-operator.yaml
@@ -87,7 +87,6 @@ presubmits:
     - main
     always_run: true
     decorate: true
-    optional: true
     extra_refs:
     - org: metal3-io
       repo: project-infra


### PR DESCRIPTION
This pr enforces pr-verifier presubmit for ip-address-manager, ironic-standalone-operator, cluster-api-provider-metal3.


Part of https://github.com/metal3-io/project-infra/issues/1448.