### PR TITLE
Add Loki push credential to BMO e2e job

### DIFF
--- a/jenkins/jobs/bmo_e2e_optional_tests.groovy
+++ b/jenkins/jobs/bmo_e2e_optional_tests.groovy
@@ -9,6 +9,7 @@ def refspec = '+refs/heads/' + pullBase + ':refs/remotes/origin/' + pullBase + '
 pipeline {
     environment {
         GINKGO_FOCUS = "${GINKGO_FOCUS}"
+        LOKI_URL = 'https://log.apps.staging.metal3.io/store/api/v1/push'
     }
     agent none
     stages {
@@ -48,7 +49,11 @@ pipeline {
                             ansiColor('xterm')
                         }
                         steps {
-                            withCredentials([string(credentialsId: 'metal3-clusterctl-github-token', variable: 'GITHUB_TOKEN')]) {
+                            withCredentials(
+                                [string(credentialsId: 'metal3-clusterctl-github-token', variable: 'GITHUB_TOKEN'),
+                                usernamePassword(credentialsId: 'metal3-ci-log-collector-push',
+                                usernameVariable: 'LOKI_USERNAME', passwordVariable: 'LOKI_PASSWORD'),
+                            ]) {
                                 timestamps {
                                     sh './hack/ci-e2e.sh'
                                 }


### PR DESCRIPTION
Binds the metal3-ci-log-collector-push credential in the BMO optional e2e job so ci-2e2.sh can stream e2e logs to the CI log collector (Loki).

Has no effect on its own, log streaming only starts once the BMO change is also merged.