### PR TITLE
Revert "Enforce pr-verifier presubmit for ipam, IrSO, capm3"

### DIFF
--- a/prow/config/jobs/metal3-io/cluster-api-provider-metal3-release-1.12.yaml
+++ b/prow/config/jobs/metal3-io/cluster-api-provider-metal3-release-1.12.yaml
@@ -150,6 +150,7 @@ presubmits:
     - release-1.12
     always_run: true
     decorate: true
+    optional: true
     extra_refs:
     - org: metal3-io
       repo: project-infra

--- a/prow/config/jobs/metal3-io/cluster-api-provider-metal3-release-1.13.yaml
+++ b/prow/config/jobs/metal3-io/cluster-api-provider-metal3-release-1.13.yaml
@@ -150,6 +150,7 @@ presubmits:
     - release-1.13
     always_run: true
     decorate: true
+    optional: true
     extra_refs:
     - org: metal3-io
       repo: project-infra

--- a/prow/config/jobs/metal3-io/cluster-api-provider-metal3.yaml
+++ b/prow/config/jobs/metal3-io/cluster-api-provider-metal3.yaml
@@ -171,6 +171,7 @@ presubmits:
     - main
     always_run: true
     decorate: true
+    optional: true
     extra_refs:
     - org: metal3-io
       repo: project-infra

--- a/prow/config/jobs/metal3-io/ip-address-manager-release-1.12.yaml
+++ b/prow/config/jobs/metal3-io/ip-address-manager-release-1.12.yaml
@@ -132,6 +132,7 @@ presubmits:
     - release-1.12
     always_run: true
     decorate: true
+    optional: true
     extra_refs:
     - org: metal3-io
       repo: project-infra

--- a/prow/config/jobs/metal3-io/ip-address-manager-release-1.13.yaml
+++ b/prow/config/jobs/metal3-io/ip-address-manager-release-1.13.yaml
@@ -132,6 +132,7 @@ presubmits:
     - release-1.13
     always_run: true
     decorate: true
+    optional: true
     extra_refs:
     - org: metal3-io
       repo: project-infra

--- a/prow/config/jobs/metal3-io/ip-address-manager.yaml
+++ b/prow/config/jobs/metal3-io/ip-address-manager.yaml
@@ -132,6 +132,7 @@ presubmits:
     - main
     always_run: true
     decorate: true
+    optional: true
     extra_refs:
     - org: metal3-io
       repo: project-infra

--- a/prow/config/jobs/metal3-io/ironic-standalone-operator-release-0.10.yaml
+++ b/prow/config/jobs/metal3-io/ironic-standalone-operator-release-0.10.yaml
@@ -101,6 +101,7 @@ presubmits:
     - release-0.10
     always_run: true
     decorate: true
+    optional: true
     extra_refs:
     - org: metal3-io
       repo: project-infra

--- a/prow/config/jobs/metal3-io/ironic-standalone-operator-release-0.9.yaml
+++ b/prow/config/jobs/metal3-io/ironic-standalone-operator-release-0.9.yaml
@@ -101,6 +101,7 @@ presubmits:
     - release-0.9
     always_run: true
     decorate: true
+    optional: true
     extra_refs:
     - org: metal3-io
       repo: project-infra

--- a/prow/config/jobs/metal3-io/ironic-standalone-operator.yaml
+++ b/prow/config/jobs/metal3-io/ironic-standalone-operator.yaml
@@ -101,6 +101,7 @@ presubmits:
     - main
     always_run: true
     decorate: true
+    optional: true
     extra_refs:
     - org: metal3-io
       repo: project-infra


### PR DESCRIPTION
Reverts metal3-io/project-infra#1490

The pr-verifier job fails for batch jobs (when multiple PRs are merged together) since no PULL_TITLE is set for them.