### PR TITLE
prow: do not run pr verifier in batch jobs

### DIFF
--- a/hack/verify-pr-title.sh
+++ b/hack/verify-pr-title.sh
@@ -2,6 +2,12 @@
 
 set -eu
 
+# Batch jobs test multiple PRs together and have no single PULL_TITLE to verify.
+if [ "${JOB_TYPE:-}" = "batch" ]; then
+    echo "Skipping PR title verification for batch job."
+    exit 0
+fi
+
 WIP_REGEX='^\W?WIP\W'
 TAG_REGEX='^\[[[:alnum:]\._-]*\]'
 


### PR DESCRIPTION
In batch jobs verifier test cannot retrieve PR title and fails the PR verifier test. Since it is already testing in individual PR level, we do not necessarily need to test  it before merge. 