### PR TITLE
Fix bml test failure

### DIFF
--- a/jenkins/scripts/bare_metal_lab/bml_test/02_configure_host.sh
+++ b/jenkins/scripts/bare_metal_lab/bml_test/02_configure_host.sh
@@ -57,6 +57,8 @@ init_minikube()
             if ip link show virbr0 > /dev/null 2>&1; then
                 sudo ip link delete virbr0
             fi
+
+            ensure_default_network
         done
         sudo su -l -c "minikube stop" "${USER}"
     fi
@@ -78,6 +80,30 @@ init_minikube()
             --model virtio --source external \
             --type network --config
     fi
+}
+
+ensure_default_network()
+{
+    if ! sudo virsh net-info default > /dev/null 2>&1; then
+        sudo virsh net-define /dev/stdin <<'EOF'
+<network>
+  <name>default</name>
+  <forward mode='nat'/>
+  <bridge name='virbr0' stp='on' delay='0'/>
+  <ip address='192.168.122.1' netmask='255.255.255.0'>
+    <dhcp>
+      <range start='192.168.122.2' end='192.168.122.254'/>
+    </dhcp>
+  </ip>
+</network>
+EOF
+    fi
+
+    if [[ "$(sudo virsh net-info default | awk '/^Active:/ {print $2}')" != "yes" ]]; then
+        sudo virsh net-start default
+    fi
+
+    sudo virsh net-autostart default
 }
 
 # Crete libvirt networks
@@ -107,7 +133,7 @@ sudo ip link set ironicendpoint up
 sudo ip link set ironic-peer up
 
 # Add physical interfaces to the bridges
-sudo brctl addif provisioning eno1
+sudo brctl addif provisioning eno49
 sudo brctl addif external bmext
 
 # Create the external bridge
@@ -118,6 +144,8 @@ if ! ip a show external &>/dev/null; then
         sudo ip addr add dev external "${EXTERNAL_SUBNET_V4_HOST}/${EXTERNAL_SUBNET_V4_PREFIX}"
     sudo ip link set external up
 fi
+
+ensure_default_network
 
 minikube config set driver kvm2
 minikube config set memory 4096

--- a/jenkins/scripts/bare_metal_lab/bml_test/03_launch_bootstrap_cluster.sh
+++ b/jenkins/scripts/bare_metal_lab/bml_test/03_launch_bootstrap_cluster.sh
@@ -107,13 +107,22 @@ patch_ipam()
 start_management_cluster()
 {
     local minikube_error
+    local attempt=1
+    local max_attempts=5
 
     while /bin/true; do
         minikube_error=0
-        sudo su -l -c 'minikube start' "${USER}" || minikube_error=1
+        # Cap a single start attempt so a hung minikube can't block the job for hours.
+        sudo su -l -c 'timeout 600 minikube start' "${USER}" || minikube_error=1
         if [[ "${minikube_error}" -eq 0 ]]; then
             break
         fi
+        if [[ "${attempt}" -ge "${max_attempts}" ]]; then
+            echo "minikube start failed after ${max_attempts} attempts" >&2
+            exit 1
+        fi
+        attempt=$((attempt + 1))
+        sleep 10
     done
 
     sudo su -l -c "minikube ssh -- sudo brctl addbr ironicendpoint" "${USER}"
@@ -180,7 +189,7 @@ spec:
   images:
     deployRamdiskBranch: "master"
     deployRamdiskDownloader: "${CONTAINER_REGISTRY}/metal3-io/ironic-ipa-downloader"
-    ironic: "${CONTAINER_REGISTRY}/metal3-io/ironic:release-33.0"
+    ironic: "${CONTAINER_REGISTRY}/metal3-io/ironic:release-38.0"
     keepalived: "${CONTAINER_REGISTRY}/metal3-io/keepalived:release-0.9"
   version: "${IRSO_IRONIC_VERSION}"
   networking:
@@ -202,7 +211,14 @@ $(render_dhcp_hosts_list)
 EOF
 
     # NOTE(dtantsur): the webhook may not be ready immediately, retry if needed
+    local ironic_attempt=1
+    local ironic_max_attempts=10
     while ! kubectl create -f "${ironic}"; do
+        if [[ "${ironic_attempt}" -ge "${ironic_max_attempts}" ]]; then
+            echo "Failed to create ironic resource after ${ironic_max_attempts} attempts" >&2
+            exit 1
+        fi
+        ironic_attempt=$((ironic_attempt + 1))
         sleep 3
     done
 

--- a/jenkins/scripts/bare_metal_lab/bml_test/clean.sh
+++ b/jenkins/scripts/bare_metal_lab/bml_test/clean.sh
@@ -7,17 +7,19 @@ SCRIPTDIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 
 set -x
 
-sudo ip link delete external
-sudo ip link delete ironic-peer
-sudo ip link delete ironicendpoint
-sudo ip link delete provisioning
+sudo virsh net-destroy provisioning || true
+sudo virsh net-destroy external || true
 
-# Destroy and undefine the libvirt networks
-sudo virsh net-destroy provisioning
-sudo virsh net-destroy external
+sudo pkill -9 -f '/var/lib/libvirt/dnsmasq/external.conf' || true
+sudo pkill -9 -f '/var/lib/libvirt/dnsmasq/provisioning.conf' || true
 
-sudo virsh net-undefine provisioning
-sudo virsh net-undefine external
+sudo ip link delete external || true
+sudo ip link delete ironic-peer || true
+sudo ip link delete ironicendpoint || true
+sudo ip link delete provisioning || true
+
+sudo virsh net-undefine provisioning || true
+sudo virsh net-undefine external || true
 
 minikube delete
 

--- a/jenkins/scripts/bare_metal_lab/bml_test/lib/vars.sh
+++ b/jenkins/scripts/bare_metal_lab/bml_test/lib/vars.sh
@@ -29,7 +29,7 @@ export IPAMPATH="/home/metal3ci/go/src/github.com/metal3-io/ip-address-manager"
 export CAPI_CONFIG_DIR="/home/metal3ci/.config/cluster-api"
 
 export IRONIC_NAMESPACE="baremetal-operator-system"
-export IRSO_IRONIC_VERSION="33.0"
+export IRSO_IRONIC_VERSION="38.0"
 
 export WORKING_DIR="/opt/metal3-dev-env/"
 export IRONIC_BASE_URL="http://172.22.0.2"

--- a/jenkins/scripts/bare_metal_lab/bml_test/preload_images_minikube.sh
+++ b/jenkins/scripts/bare_metal_lab/bml_test/preload_images_minikube.sh
@@ -7,7 +7,7 @@ MAX_BACKOFF="${MAX_BACKOFF:-120}"
 
 IMAGES=(
     "registry.nordix.org/quay-io-proxy/metal3-io/baremetal-operator:main"
-    "registry.nordix.org/quay-io-proxy/metal3-io/ironic:release-33.0"
+    "registry.nordix.org/quay-io-proxy/metal3-io/ironic:release-38.0"
     "registry.nordix.org/quay-io-proxy/metal3-io/keepalived:release-0.9"
     "registry.k8s.io/cluster-api/kubeadm-bootstrap-controller:v1.13.3"
     "registry.k8s.io/cluster-api/kubeadm-control-plane-controller:v1.13.3"

--- a/jenkins/scripts/bare_metal_lab/default_vars/vars.yaml
+++ b/jenkins/scripts/bare_metal_lab/default_vars/vars.yaml
@@ -9,25 +9,25 @@ github_token: "{{ lookup('env', 'GITHUB_TOKEN') }}"
 serial_log_location: "/tmp/BMLlog"
 bare_metal_hosts:
 # - id: "03"
-#   mac: b4:b5:2f:6d:89:d8
+#   mac: 58:20:b1:ed:63:70
 #   ip: "192.168.1.24"
-#   bootMode: "legacy"
-#   rootDeviceHint: "/dev/disk/by-path/pci-0000:03:00.0-scsi-0:1:0:1"
+#   bootMode: "UEFI"
+#   rootDeviceHint: "/dev/sda"
 - id: "04"
   mac: 6c:c2:17:40:7e:b0
   ip: "192.168.1.13"
   bootMode: "UEFI"
   rootDeviceHint: "/dev/sda"
 # - id: "05"
-#   mac: 80:c1:6e:7a:5a:a8
+#   mac: 6c:c2:17:40:7c:b0
 #   ip: "192.168.1.14"
-#   bootMode: "legacy"
-#   rootDeviceHint: "/dev/disk/by-path/pci-0000:03:00.0-scsi-0:1:0:0"
+#   bootMode: "UEFI"
+#   rootDeviceHint: "/dev/sda"
 # - id: "06"
 #   mac: e4:11:5b:95:7e:98
 #   ip: "192.168.1.23"
 #   bootMode: "UEFI"
-#   rootDeviceHint: "/dev/disk/by-path/pci-0000:07:00.0-scsi-0:1:0:0"
+#   rootDeviceHint: "/dev/sda"
 - id: "07"
   mac: 5c:b9:01:98:6d:6c
   ip: "192.168.1.16"
@@ -35,16 +35,16 @@ bare_metal_hosts:
   rootDeviceHint: "/dev/sda"
 # - id: "14"
 #   mac: 6c:3b:e5:b5:03:c8
-#   ip: "192.168.1.32"
-#   bootMode: "legacy"
-#   rootDeviceHint: "/dev/disk/by-path/pci-0000:03:00.0-scsi-0:1:0:0"
+#   ip: "192.168.1.21"
+#   bootMode: "UEFI"
+#   rootDeviceHint: "/dev/sda"
 # - id: "15"
 #   mac: 10:60:4b:b4:be:00
 #   ip: "192.168.1.37"
-#   bootMode: "legacy"
-#   rootDeviceHint: "/dev/disk/by-path/pci-0000:03:00.0-scsi-0:1:0:0"
+#   bootMode: "UEFI"
+#   rootDeviceHint: "/dev/sda"
 # - id: "16"
 #   mac: b4:b5:2f:6f:01:40
 #   ip: "192.168.1.33"
-#   bootMode: "legacy"
-#   rootDeviceHint: "/dev/disk/by-path/pci-0000:03:00.0-scsi-0:1:0:0"
+#   bootMode: "UEFI"
+#   rootDeviceHint: "/dev/sda"


### PR DESCRIPTION
Fix bare metal lab (BML) test:

- limit minikube start retries in timeout 600 with a 5-attempt cap,
- add ensure_default_network() to define/start/autostart the libvirt default network;
- fix bridgde name to eno49(changed after blade change).
- fix  cleanup sequence (clean.sh): destroy networks, kill lingering dnsmasq, then delete links.
- Ironic bump to 38.0
- Update  MACs of new Gen9 blades, switch hosts to UEFI. 