### PR TITLE
Auto-trigger BMO e2e presubmit (keep optional)

### DIFF
--- a/prow/config/jobs/metal3-io/baremetal-operator.yaml
+++ b/prow/config/jobs/metal3-io/baremetal-operator.yaml
@@ -284,7 +284,7 @@ presubmits:
     branches:
     - main
     agent: jenkins
-    always_run: false
+    always_run: true
     optional: true
   # name: {job_prefix}-{image_os}-e2e-integration-k8s-pre-release-test-{capm3_target_branch}
   - name: metal3-centos-e2e-integration-k8s-pre-release-test-main


### PR DESCRIPTION
Set always_run: true on metal3-bmo-e2e-test-optional-pull so the Jenkins-backed BMO e2e job runs on every PR. 
Keeps optional: true — this run alongside the existing GitHub Actions e2e-test, not a merge gate yet. 

Part of #1448 (move BMO e2e off GitHub Actions).