### PR TITLE
Add enviromtal variable and conditional sudo in dev_env_integration_tests

### DIFF
--- a/jenkins/scripts/dynamic_worker_workflow/dev_env_integration_tests.sh
+++ b/jenkins/scripts/dynamic_worker_workflow/dev_env_integration_tests.sh
@@ -80,15 +80,27 @@ else
     git checkout "${METAL3BRANCH}"
 fi
 
+# Newer metal3-dev-env versions set METAL3_RUN_AS_ROOT=true in lib/common.sh
+# because they no longer use passwordless sudo internally and must run as root.
+# We must NOT source common.sh to read this: on those versions it performs a
+# hard root check and exits, plus it overrides HOME/USER and mutates the system.
+# Instead, statically check for the flag (we are already inside the dev-env
+# repo here). Older versions do not set it, so we keep the non-root behavior.
+if grep -qE '^\s*export\s+METAL3_RUN_AS_ROOT=true' lib/common.sh 2>/dev/null; then
+    SUDO=(sudo -E)
+else
+    SUDO=()
+fi
+
 echo "Running the tests"
 
 cleanup() {
     if [[ "${CLEANUP_AFTERWARDS:-}" == "true" ]]; then
         echo "Cleaning up the environment"
-        make clean
+        "${SUDO[@]}" make clean
     fi
 }
 trap cleanup EXIT
 
-make
-make test
+"${SUDO[@]}" make
+"${SUDO[@]}" make test

--- a/jenkins/scripts/dynamic_worker_workflow/fetch_logs.sh
+++ b/jenkins/scripts/dynamic_worker_workflow/fetch_logs.sh
@@ -3,6 +3,16 @@
 # Do not fail on error (for example k8s cluster not available)
 set -ux
 
+# Use sudo only when not already running as root. This keeps the script
+# working whether the worker runs as root or as a non-root user with sudo.
+# An array is used so that the empty (root) case expands to nothing and the
+# call sites remain shellcheck-clean (no SC2086 word-splitting).
+if (( EUID == 0 )); then
+    SUDO=()
+else
+    SUDO=(sudo)
+fi
+
 LOGS_TARBALL="logs-${BUILD_TAG}.tgz"
 LOGS_DIR="logs-${BUILD_TAG}"
 IMAGE_OS="${IMAGE_OS:-ubuntu}"
@@ -129,7 +139,7 @@ if [[ -d /tmp/"${CONTAINER_RUNTIME}" ]] && [[ -n "$(ls /tmp/"${CONTAINER_RUNTIME
 fi
 
 # Fetch k8s logs form target cluster
-target_config=$(sudo find /tmp/ -type f -name "kubeconfig*")
+target_config=$("${SUDO[@]}" find /tmp/ -type f -name "kubeconfig*")
 if [[ -n "${target_config}" ]]; then
     # fetch target cluster k8s logs
     fetch_k8s_logs "target_cluster" "${target_config}"
@@ -138,30 +148,30 @@ fi
 # Fetch Ironic containers logs after pivoting back to the source cluster
 CONTAINER_LOGS_DIR="${LOGS_DIR}/${CONTAINER_RUNTIME}/final_logs"
 mkdir -p "${CONTAINER_LOGS_DIR}"
-LOCAL_CONTAINERS="$(sudo "${CONTAINER_RUNTIME}" ps -a --format "{{.Names}}")"
+LOCAL_CONTAINERS="$("${SUDO[@]}" "${CONTAINER_RUNTIME}" ps -a --format "{{.Names}}")"
 for LOCAL_CONTAINER in ${LOCAL_CONTAINERS}; do
     mkdir -p "${CONTAINER_LOGS_DIR}/${LOCAL_CONTAINER}"
     # shellcheck disable=SC2024
-    sudo "${CONTAINER_RUNTIME}" logs "${LOCAL_CONTAINER}" > "${CONTAINER_LOGS_DIR}/${LOCAL_CONTAINER}/stdout.log" \
+    "${SUDO[@]}" "${CONTAINER_RUNTIME}" logs "${LOCAL_CONTAINER}" > "${CONTAINER_LOGS_DIR}/${LOCAL_CONTAINER}/stdout.log" \
         2> "${CONTAINER_LOGS_DIR}/${LOCAL_CONTAINER}/stderr.log"
 done
 
 mkdir -p "${LOGS_DIR}/qemu"
-sudo sh -c "cp -r /var/log/libvirt/qemu/* ${LOGS_DIR}/qemu/"
-sudo chown -R "${USER}:${USER}" "${LOGS_DIR}/qemu"
+"${SUDO[@]}" sh -c "cp -r /var/log/libvirt/qemu/* ${LOGS_DIR}/qemu/"
+"${SUDO[@]}" chown -R "${USER}:${USER}" "${LOGS_DIR}/qemu"
 
 # Fetch atop and sysstat metrics
 mkdir -p "${LOGS_DIR}/metrics/atop"
 mkdir -p "${LOGS_DIR}/metrics/sysstat"
-sudo sh -c "cp -r /var/log/atop/* ${LOGS_DIR}/metrics/atop/"
-sudo sh -c "cp -r /var/log/sysstat/* ${LOGS_DIR}/metrics/sysstat/"
-sudo chown -R "${USER}:${USER}" "${LOGS_DIR}/metrics"
+"${SUDO[@]}" sh -c "cp -r /var/log/atop/* ${LOGS_DIR}/metrics/atop/"
+"${SUDO[@]}" sh -c "cp -r /var/log/sysstat/* ${LOGS_DIR}/metrics/sysstat/"
+"${SUDO[@]}" chown -R "${USER}:${USER}" "${LOGS_DIR}/metrics"
 
 # Fetch host network interface information
 mkdir -p "${LOGS_DIR}/hostinfo/network"
 ip address > "${LOGS_DIR}/hostinfo/network/interfaces.txt"
 host -v "artifactory.nordix.org" > "${LOGS_DIR}/hostinfo/network/nordixresolve.txt"
-sudo chown -R "${USER}:${USER}" "${LOGS_DIR}/hostinfo"
+"${SUDO[@]}" chown -R "${USER}:${USER}" "${LOGS_DIR}/hostinfo"
 
 # Fetch BML log if exists
 BML_LOG_LOCATION="/tmp/BMLlog"

--- a/jenkins/scripts/dynamic_worker_workflow/run_clean.sh
+++ b/jenkins/scripts/dynamic_worker_workflow/run_clean.sh
@@ -2,6 +2,16 @@
 
 set -eux
 
+# Use sudo only when not already running as root. This keeps the script
+# working whether the worker runs as root or as a non-root user with sudo.
+# An array is used so that the empty (root) case expands to nothing and the
+# call sites remain shellcheck-clean (no SC2086 word-splitting).
+if (( EUID == 0 )); then
+    SUDO=()
+else
+    SUDO=(sudo)
+fi
+
 IMAGE_OS="${IMAGE_OS:-ubuntu}"
 
 if [[ "${IMAGE_OS}" == "ubuntu" ]]; then
@@ -20,17 +30,17 @@ else
     pushd "${HOME}/metal3"
 fi
 
-make clean
+"${SUDO[@]}" make clean
 
 # Clean up test related files and directories
-sudo rm -rf /home/metal3ci/tested_repo
-sudo rm -rf /home/metal3ci/metal3
-sudo rm -rf /opt/metal3-dev-env/*
-sudo rm -rf /home/metal3ci/go/src/github.com/metal3-io/*
-sudo rm -rf /home/metal3ci/.config/cluster-api/*
+"${SUDO[@]}" rm -rf /home/metal3ci/tested_repo
+"${SUDO[@]}" rm -rf /home/metal3ci/metal3
+"${SUDO[@]}" rm -rf /opt/metal3-dev-env/*
+"${SUDO[@]}" rm -rf /home/metal3ci/go/src/github.com/metal3-io/*
+"${SUDO[@]}" rm -rf /home/metal3ci/.config/cluster-api/*
 
 # Clean up Docker containers and images
-sudo "${CONTAINER_RUNTIME}" container prune --force
-sudo "${CONTAINER_RUNTIME}" image prune --force --all
-sudo "${CONTAINER_RUNTIME}" volume prune --force
-sudo "${CONTAINER_RUNTIME}" system prune --force --all
+"${SUDO[@]}" "${CONTAINER_RUNTIME}" container prune --force
+"${SUDO[@]}" "${CONTAINER_RUNTIME}" image prune --force --all
+"${SUDO[@]}" "${CONTAINER_RUNTIME}" volume prune --force
+"${SUDO[@]}" "${CONTAINER_RUNTIME}" system prune --force --all


### PR DESCRIPTION


Introduce a SUDO wrapper is
controlled by the METAL3_RUN_AS_ROOT environmental variable exported by metal3-dev-env.
If true commands run without sudo; otherwise sudo
is used, preserving the existing passwo behavior.

This is part of the change to let metal3-dev-env run as root instead
of requiring passwordless sudo



https://github.com/metal3-io/metal3-dev-env/pull/1716