### PR TITLE
Prow: Update nameservers and pin coredns

### DIFF
--- a/prow/capo-cluster/kubeadmcontrolplane.yaml
+++ b/prow/capo-cluster/kubeadmcontrolplane.yaml
@@ -5,6 +5,8 @@ metadata:
 spec:
   kubeadmConfigSpec:
     clusterConfiguration:
+      dns:
+        imageTag: v1.14.6
       controllerManager:
         extraArgs:
           cloud-provider: external

--- a/prow/capo-cluster/openstackcluster.yaml
+++ b/prow/capo-cluster/openstackcluster.yaml
@@ -38,8 +38,9 @@ spec:
   managedSubnets:
   - cidr: 10.6.0.0/24
     dnsNameservers:
+    - 129.192.80.4
+    - 129.192.80.5
     - 8.8.8.8
-    - 1.1.1.1
   bastion:
     enabled: true
     spec:


### PR DESCRIPTION
This updates the nameservers for the managed subnet and pins the coredns version. Without pinning the version, CAPI does not manage it at all. It is just initialized at the default kubeadm version and then left to run.