### PR TITLE
Make resource cleanup run in OCI

### DIFF
--- a/jenkins/jobs/clean_resources.groovy
+++ b/jenkins/jobs/clean_resources.groovy
@@ -14,7 +14,7 @@ GRAFANA_VIEW = """${LOG_URL}&from=${START_TIME}&to=now&var-pipeline=${env.JOB_NA
 currentBuild.description = """<a href='${GRAFANA_VIEW}'>View in log collector</a>"""
 
 pipeline {
-    agent { label 'metal3ci-4c16gb-ubuntu-jnlp' }
+    agent { label 'metal3ci-8c32gb-ubuntu-oci' }
     stages {
         stage('SCM') {
             options {


### PR DESCRIPTION
Historically these jobs were run in Xerces, against Xerces. They have recently been made to run against OCI, but still run in Xerces. Adjust labels so that they will run in  OCI.