### PR TITLE
Fix broken starter-s3.yaml link

### DIFF
--- a/prow/README.md
+++ b/prow/README.md
@@ -92,7 +92,7 @@ There are multiple folders with kustomizations:
 The deployment manifests for Prow (`manifests`) are based on the
 [getting started guide](https://docs.prow.k8s.io/docs/getting-started-deploy/)
 and the
-[starter-s3.yaml](https://github.com/kubernetes/test-infra/blob/master/config/prow/cluster/starter/starter-s3.yaml)
+[starter-s3.yaml](https://github.com/kubernetes-sigs/prow/blob/main/config/prow/cluster/starter/starter-s3.yaml)
 manifests. They have been separated out into multiple files and tied together
 using kustomizations. This makes it easy to keep secrets outside of git while
 still allowing for simple one-liners for applying all of it.


### PR DESCRIPTION
The link checker flagged a 404 for the `starter-s3.yaml` reference in `prow/README.md`.

Prow moved from `kubernetes/test-infra` to `kubernetes-sigs/pro`, so the old path no longer exist.

Updated the link to the new location.

Fixes #1450