### PR TITLE
Move remaining Jenkins e2e jobs to the OCI jenkins operator

### DIFF
--- a/prow/config/jobs/metal3-io/baremetal-operator-release-0.11.yaml
+++ b/prow/config/jobs/metal3-io/baremetal-operator-release-0.11.yaml
@@ -108,84 +108,112 @@ presubmits:
     branches:
     - release-0.11
     agent: jenkins
+    labels:
+      jenkins_operator: oci
     always_run: false
     optional: true
   - name: metal3-ubuntu-e2e-basic-test-release-1-11
     branches:
     - release-0.11
     agent: jenkins
+    labels:
+      jenkins_operator: oci
     always_run: false
     optional: true
   - name: metal3-centos-e2e-integration-test-release-1-11
     branches:
     - release-0.11
     agent: jenkins
+    labels:
+      jenkins_operator: oci
     always_run: false
     optional: true
   - name: metal3-ubuntu-e2e-integration-test-release-1-11
     branches:
     - release-0.11
     agent: jenkins
+    labels:
+      jenkins_operator: oci
     always_run: false
     optional: true
   - name: metal3-centos-e2e-feature-test-release-1-11-pivoting
     branches:
     - release-0.11
     agent: jenkins
+    labels:
+      jenkins_operator: oci
     always_run: false
     optional: true
   - name: metal3-centos-e2e-feature-test-release-1-11-remediation
     branches:
     - release-0.11
     agent: jenkins
+    labels:
+      jenkins_operator: oci
     always_run: false
     optional: true
   - name: metal3-centos-e2e-feature-test-release-1-11-features
     branches:
     - release-0.11
     agent: jenkins
+    labels:
+      jenkins_operator: oci
     always_run: false
     optional: true
   - name: metal3-ubuntu-e2e-feature-test-release-1-11-pivoting
     branches:
     - release-0.11
     agent: jenkins
+    labels:
+      jenkins_operator: oci
     always_run: false
     optional: true
   - name: metal3-ubuntu-e2e-feature-test-release-1-11-remediation
     branches:
     - release-0.11
     agent: jenkins
+    labels:
+      jenkins_operator: oci
     always_run: false
     optional: true
   - name: metal3-ubuntu-e2e-feature-test-release-1-11-features
     branches:
     - release-0.11
     agent: jenkins
+    labels:
+      jenkins_operator: oci
     always_run: false
     optional: true
   - name: metal3-e2e-clusterctl-upgrade-test-release-1-11
     branches:
     - release-0.11
     agent: jenkins
+    labels:
+      jenkins_operator: oci
     always_run: false
     optional: true
   - name: metal3-dev-env-integration-test-centos-release-1-11
     branches:
     - release-0.11
     agent: jenkins
+    labels:
+      jenkins_operator: oci
     always_run: false
     optional: true
   - name: metal3-dev-env-integration-test-ubuntu-release-1-11
     branches:
     - release-0.11
     agent: jenkins
+    labels:
+      jenkins_operator: oci
     always_run: false
     optional: true
   - name: metal3-bmo-e2e-test-optional-pull
     branches:
     - release-0.11
     agent: jenkins
+    labels:
+      jenkins_operator: oci
     always_run: false
     optional: true
   # name: {job_prefix}-{image_os}-e2e-integration-k8s-pre-release-test-{capm3_target_branch}
@@ -193,11 +221,15 @@ presubmits:
     branches:
     - release-0.11
     agent: jenkins
+    labels:
+      jenkins_operator: oci
     always_run: false
     optional: true
   - name: metal3-ubuntu-e2e-integration-k8s-pre-release-test-release-1-11
     branches:
     - release-0.11
     agent: jenkins
+    labels:
+      jenkins_operator: oci
     always_run: false
     optional: true

--- a/prow/config/jobs/metal3-io/baremetal-operator.yaml
+++ b/prow/config/jobs/metal3-io/baremetal-operator.yaml
@@ -284,6 +284,8 @@ presubmits:
     branches:
     - main
     agent: jenkins
+    labels:
+      jenkins_operator: oci
     always_run: false
     optional: true
   # name: {job_prefix}-{image_os}-e2e-integration-k8s-pre-release-test-{capm3_target_branch}

--- a/prow/config/jobs/metal3-io/cluster-api-provider-metal3-release-1.11.yaml
+++ b/prow/config/jobs/metal3-io/cluster-api-provider-metal3-release-1.11.yaml
@@ -133,12 +133,16 @@ presubmits:
     branches:
     - release-1.11
     agent: jenkins
+    labels:
+      jenkins_operator: oci
     always_run: false
     optional: true
   - name: metal3-ubuntu-e2e-basic-test-release-1-11
     branches:
     - release-1.11
     agent: jenkins
+    labels:
+      jenkins_operator: oci
     always_run: false
     optional: true
   # name: {job_prefix}-{image_os}-e2e-integration-test-{capm3_target_branch}
@@ -146,12 +150,16 @@ presubmits:
     branches:
     - release-1.11
     agent: jenkins
+    labels:
+      jenkins_operator: oci
     always_run: false
     optional: false
   - name: metal3-ubuntu-e2e-integration-test-release-1-11
     branches:
     - release-1.11
     agent: jenkins
+    labels:
+      jenkins_operator: oci
     always_run: false
     optional: true
   # name: {job_prefix}-{image_os}-e2e-feature-test-{capm3_target_job}
@@ -159,42 +167,56 @@ presubmits:
     branches:
     - release-1.11
     agent: jenkins
+    labels:
+      jenkins_operator: oci
     always_run: false
     optional: true
   - name: metal3-centos-e2e-feature-test-release-1-11-remediation
     branches:
     - release-1.11
     agent: jenkins
+    labels:
+      jenkins_operator: oci
     always_run: false
     optional: true
   - name: metal3-centos-e2e-feature-test-release-1-11-features
     branches:
     - release-1.11
     agent: jenkins
+    labels:
+      jenkins_operator: oci
     always_run: false
     optional: true
   - name: metal3-ubuntu-e2e-feature-test-release-1-11-pivoting
     branches:
     - release-1.11
     agent: jenkins
+    labels:
+      jenkins_operator: oci
     always_run: false
     optional: true
   - name: metal3-ubuntu-e2e-feature-test-release-1-11-remediation
     branches:
     - release-1.11
     agent: jenkins
+    labels:
+      jenkins_operator: oci
     always_run: false
     optional: true
   - name: metal3-ubuntu-e2e-feature-test-release-1-11-features
     branches:
     - release-1.11
     agent: jenkins
+    labels:
+      jenkins_operator: oci
     always_run: false
     optional: true
   - name: metal3-centos-e2e-feature-test-release-1-11-scalability
     branches:
     - release-1.11
     agent: jenkins
+    labels:
+      jenkins_operator: oci
     always_run: false
     optional: true
   # name: {job_prefix}-e2e-clusterctl-upgrade-test-{capm3_target_branch}
@@ -202,6 +224,8 @@ presubmits:
     branches:
     - release-1.11
     agent: jenkins
+    labels:
+      jenkins_operator: oci
     always_run: false
     optional: true
   # name: {job_prefix}-e2e-{k8s_versions}-upgrade-test-{capm3_target_branch}
@@ -209,18 +233,24 @@ presubmits:
     branches:
     - release-1.11
     agent: jenkins
+    labels:
+      jenkins_operator: oci
     always_run: false
     optional: true
   - name: metal3-ubuntu-e2e-capi-md-test-release-1-11
     branches:
     - release-1.11
     agent: jenkins
+    labels:
+      jenkins_operator: oci
     always_run: false
     optional: true
   - name: metal3-centos-e2e-capi-md-test-release-1-11
     branches:
     - release-1.11
     agent: jenkins
+    labels:
+      jenkins_operator: oci
     always_run: false
     optional: true
   # name: {job_prefix}-e2e-conformance-test-{capm3_target_branch}
@@ -228,5 +258,7 @@ presubmits:
     branches:
     - release-1.11
     agent: jenkins
+    labels:
+      jenkins_operator: oci
     always_run: false
     optional: true

--- a/prow/config/jobs/metal3-io/ip-address-manager-release-1.11.yaml
+++ b/prow/config/jobs/metal3-io/ip-address-manager-release-1.11.yaml
@@ -116,72 +116,96 @@ presubmits:
     branches:
     - release-1.11
     agent: jenkins
+    labels:
+      jenkins_operator: oci
     always_run: false
     optional: true
   - name: metal3-ubuntu-e2e-basic-test-release-1-11
     branches:
     - release-1.11
     agent: jenkins
+    labels:
+      jenkins_operator: oci
     always_run: false
     optional: true
   - name: metal3-centos-e2e-integration-test-release-1-11
     branches:
     - release-1.11
     agent: jenkins
+    labels:
+      jenkins_operator: oci
     always_run: false
     optional: false
   - name: metal3-ubuntu-e2e-integration-test-release-1-11
     branches:
     - release-1.11
     agent: jenkins
+    labels:
+      jenkins_operator: oci
     always_run: false
     optional: true
   - name: metal3-centos-e2e-feature-test-release-1-11-pivoting
     branches:
     - release-1.11
     agent: jenkins
+    labels:
+      jenkins_operator: oci
     always_run: false
     optional: true
   - name: metal3-centos-e2e-feature-test-release-1-11-remediation
     branches:
     - release-1.11
     agent: jenkins
+    labels:
+      jenkins_operator: oci
     always_run: false
     optional: true
   - name: metal3-centos-e2e-feature-test-release-1-11-features
     branches:
     - release-1.11
     agent: jenkins
+    labels:
+      jenkins_operator: oci
     always_run: false
     optional: true
   - name: metal3-ubuntu-e2e-feature-test-release-1-11-pivoting
     branches:
     - release-1.11
     agent: jenkins
+    labels:
+      jenkins_operator: oci
     always_run: false
     optional: true
   - name: metal3-ubuntu-e2e-feature-test-release-1-11-remediation
     branches:
     - release-1.11
     agent: jenkins
+    labels:
+      jenkins_operator: oci
     always_run: false
     optional: true
   - name: metal3-ubuntu-e2e-feature-test-release-1-11-features
     branches:
     - release-1.11
     agent: jenkins
+    labels:
+      jenkins_operator: oci
     always_run: false
     optional: true
   - name: metal3-e2e-clusterctl-upgrade-test-release-1-11
     branches:
     - release-1.11
     agent: jenkins
+    labels:
+      jenkins_operator: oci
     always_run: false
     optional: true
   - name: metal3-e2e-1-33-1-34-upgrade-test-release-1-11
     branches:
     - release-1.11
     agent: jenkins
+    labels:
+      jenkins_operator: oci
     always_run: false
     optional: true
   # name: {job_prefix}-{image_os}-e2e-integration-k8s-pre-release-test-{capm3_target_branch}
@@ -189,11 +213,15 @@ presubmits:
     branches:
     - release-1.11
     agent: jenkins
+    labels:
+      jenkins_operator: oci
     always_run: false
     optional: true
   - name: metal3-ubuntu-e2e-integration-k8s-pre-release-test-release-1.11
     branches:
     - release-1.11
     agent: jenkins
+    labels:
+      jenkins_operator: oci
     always_run: false
     optional: true

--- a/prow/config/jobs/metal3-io/ironic-image-release-29.0.yaml
+++ b/prow/config/jobs/metal3-io/ironic-image-release-29.0.yaml
@@ -37,23 +37,31 @@ presubmits:
     branches:
     - release-29.0
     agent: jenkins
+    labels:
+      jenkins_operator: oci
     always_run: false
     optional: true
   - name: metal3-ubuntu-e2e-integration-test-release-1-10
     branches:
     - release-29.0
     agent: jenkins
+    labels:
+      jenkins_operator: oci
     always_run: false
     optional: true
   - name: metal3-dev-env-integration-test-centos-release-1-10
     branches:
     - release-29.0
     agent: jenkins
+    labels:
+      jenkins_operator: oci
     always_run: false
     optional: true
   - name: metal3-dev-env-integration-test-ubuntu-release-1-10
     branches:
     - release-29.0
     agent: jenkins
+    labels:
+      jenkins_operator: oci
     always_run: false
     optional: true

--- a/prow/config/jobs/metal3-io/ironic-image-release-32.0.yaml
+++ b/prow/config/jobs/metal3-io/ironic-image-release-32.0.yaml
@@ -37,23 +37,31 @@ presubmits:
     branches:
     - release-32.0
     agent: jenkins
+    labels:
+      jenkins_operator: oci
     always_run: false
     optional: true
   - name: metal3-ubuntu-e2e-integration-test-release-1-11
     branches:
     - release-32.0
     agent: jenkins
+    labels:
+      jenkins_operator: oci
     always_run: false
     optional: true
   - name: metal3-dev-env-integration-test-centos-release-1-11
     branches:
     - release-32.0
     agent: jenkins
+    labels:
+      jenkins_operator: oci
     always_run: false
     optional: true
   - name: metal3-dev-env-integration-test-ubuntu-release-1-11
     branches:
     - release-32.0
     agent: jenkins
+    labels:
+      jenkins_operator: oci
     always_run: false
     optional: true

--- a/prow/config/jobs/metal3-io/ironic-image-release-33.0.yaml
+++ b/prow/config/jobs/metal3-io/ironic-image-release-33.0.yaml
@@ -37,23 +37,31 @@ presubmits:
     branches:
     - release-33.0
     agent: jenkins
+    labels:
+      jenkins_operator: oci
     always_run: false
     optional: true
   - name: metal3-ubuntu-e2e-integration-test-release-1-12
     branches:
     - release-33.0
     agent: jenkins
+    labels:
+      jenkins_operator: oci
     always_run: false
     optional: true
   - name: metal3-dev-env-integration-test-centos-release-1-12
     branches:
     - release-33.0
     agent: jenkins
+    labels:
+      jenkins_operator: oci
     always_run: false
     optional: true
   - name: metal3-dev-env-integration-test-ubuntu-release-1-12
     branches:
     - release-33.0
     agent: jenkins
+    labels:
+      jenkins_operator: oci
     always_run: false
     optional: true

--- a/prow/config/jobs/metal3-io/ironic-image-release-34.0.yaml
+++ b/prow/config/jobs/metal3-io/ironic-image-release-34.0.yaml
@@ -37,23 +37,31 @@ presubmits:
     branches:
     - release-34.0
     agent: jenkins
+    labels:
+      jenkins_operator: oci
     always_run: false
     optional: true
   - name: metal3-ubuntu-e2e-integration-test-release-1-12
     branches:
     - release-34.0
     agent: jenkins
+    labels:
+      jenkins_operator: oci
     always_run: false
     optional: true
   - name: metal3-dev-env-integration-test-centos-release-1-12
     branches:
     - release-34.0
     agent: jenkins
+    labels:
+      jenkins_operator: oci
     always_run: false
     optional: true
   - name: metal3-dev-env-integration-test-ubuntu-release-1-12
     branches:
     - release-34.0
     agent: jenkins
+    labels:
+      jenkins_operator: oci
     always_run: false
     optional: true

--- a/prow/config/jobs/metal3-io/ironic-image-release-35.0.yaml
+++ b/prow/config/jobs/metal3-io/ironic-image-release-35.0.yaml
@@ -37,23 +37,31 @@ presubmits:
     branches:
     - release-35.0
     agent: jenkins
+    labels:
+      jenkins_operator: oci
     always_run: false
     optional: true
   - name: metal3-ubuntu-e2e-integration-test-release-1-13
     branches:
     - release-35.0
     agent: jenkins
+    labels:
+      jenkins_operator: oci
     always_run: false
     optional: true
   - name: metal3-dev-env-integration-test-centos-release-1-13
     branches:
     - release-35.0
     agent: jenkins
+    labels:
+      jenkins_operator: oci
     always_run: false
     optional: true
   - name: metal3-dev-env-integration-test-ubuntu-release-1-13
     branches:
     - release-35.0
     agent: jenkins
+    labels:
+      jenkins_operator: oci
     always_run: false
     optional: true

--- a/prow/config/jobs/metal3-io/ironic-image-release-37.0.yaml
+++ b/prow/config/jobs/metal3-io/ironic-image-release-37.0.yaml
@@ -37,23 +37,31 @@ presubmits:
     branches:
     - release-37.0
     agent: jenkins
+    labels:
+      jenkins_operator: oci
     always_run: false
     optional: true
   - name: metal3-ubuntu-e2e-integration-test-release-1-13
     branches:
     - release-37.0
     agent: jenkins
+    labels:
+      jenkins_operator: oci
     always_run: false
     optional: true
   - name: metal3-dev-env-integration-test-centos-release-1-13
     branches:
     - release-37.0
     agent: jenkins
+    labels:
+      jenkins_operator: oci
     always_run: false
     optional: true
   - name: metal3-dev-env-integration-test-ubuntu-release-1-13
     branches:
     - release-37.0
     agent: jenkins
+    labels:
+      jenkins_operator: oci
     always_run: false
     optional: true

--- a/prow/config/jobs/metal3-io/ironic-image-release-38.0.yaml
+++ b/prow/config/jobs/metal3-io/ironic-image-release-38.0.yaml
@@ -37,23 +37,31 @@ presubmits:
     branches:
     - release-38.0
     agent: jenkins
+    labels:
+      jenkins_operator: oci
     always_run: false
     optional: true
   - name: metal3-ubuntu-e2e-integration-test-release-1-14
     branches:
     - release-38.0
     agent: jenkins
+    labels:
+      jenkins_operator: oci
     always_run: false
     optional: true
   - name: metal3-dev-env-integration-test-centos-release-1-14
     branches:
     - release-38.0
     agent: jenkins
+    labels:
+      jenkins_operator: oci
     always_run: false
     optional: true
   - name: metal3-dev-env-integration-test-ubuntu-release-1-14
     branches:
     - release-38.0
     agent: jenkins
+    labels:
+      jenkins_operator: oci
     always_run: false
     optional: true

--- a/prow/config/jobs/metal3-io/ironic-ipa-downloader.yaml
+++ b/prow/config/jobs/metal3-io/ironic-ipa-downloader.yaml
@@ -37,18 +37,26 @@ presubmits:
     optional: false
   - name: metal3-centos-e2e-integration-test-release-1-14
     agent: jenkins
+    labels:
+      jenkins_operator: oci
     always_run: false
     optional: true
   - name: metal3-centos-e2e-integration-test-release-1-13
     agent: jenkins
+    labels:
+      jenkins_operator: oci
     always_run: false
     optional: true
   - name: metal3-centos-e2e-integration-test-release-1-12
     agent: jenkins
+    labels:
+      jenkins_operator: oci
     always_run: false
     optional: true
   - name: metal3-centos-e2e-integration-test-release-1-11
     agent: jenkins
+    labels:
+      jenkins_operator: oci
     always_run: false
     optional: true
   - name: metal3-ubuntu-e2e-integration-test-main
@@ -59,17 +67,25 @@ presubmits:
     optional: true
   - name: metal3-ubuntu-e2e-integration-test-release-1-14
     agent: jenkins
+    labels:
+      jenkins_operator: oci
     always_run: false
     optional: true
   - name: metal3-ubuntu-e2e-integration-test-release-1-13
     agent: jenkins
+    labels:
+      jenkins_operator: oci
     always_run: false
     optional: true
   - name: metal3-ubuntu-e2e-integration-test-release-1-12
     agent: jenkins
+    labels:
+      jenkins_operator: oci
     always_run: false
     optional: true
   - name: metal3-ubuntu-e2e-integration-test-release-1-11
     agent: jenkins
+    labels:
+      jenkins_operator: oci
     always_run: false
     optional: true

--- a/prow/config/jobs/metal3-io/metal3-dev-env.yaml
+++ b/prow/config/jobs/metal3-io/metal3-dev-env.yaml
@@ -51,18 +51,26 @@ presubmits:
     optional: true
   - name: metal3-centos-e2e-basic-test-release-1-14
     agent: jenkins
+    labels:
+      jenkins_operator: oci
     always_run: false
     optional: true
   - name: metal3-centos-e2e-basic-test-release-1-13
     agent: jenkins
+    labels:
+      jenkins_operator: oci
     always_run: false
     optional: true
   - name: metal3-centos-e2e-basic-test-release-1-12
     agent: jenkins
+    labels:
+      jenkins_operator: oci
     always_run: false
     optional: true
   - name: metal3-centos-e2e-basic-test-release-1-11
     agent: jenkins
+    labels:
+      jenkins_operator: oci
     always_run: false
     optional: true
   - name: metal3-centos-e2e-basic-test-release-1-10
@@ -77,18 +85,26 @@ presubmits:
     optional: true
   - name: metal3-ubuntu-e2e-basic-test-release-1-14
     agent: jenkins
+    labels:
+      jenkins_operator: oci
     always_run: false
     optional: true
   - name: metal3-ubuntu-e2e-basic-test-release-1-13
     agent: jenkins
+    labels:
+      jenkins_operator: oci
     always_run: false
     optional: true
   - name: metal3-ubuntu-e2e-basic-test-release-1-12
     agent: jenkins
+    labels:
+      jenkins_operator: oci
     always_run: false
     optional: true
   - name: metal3-ubuntu-e2e-basic-test-release-1-11
     agent: jenkins
+    labels:
+      jenkins_operator: oci
     always_run: false
     optional: true
   - name: metal3-ubuntu-e2e-basic-test-release-1-10
@@ -104,18 +120,26 @@ presubmits:
     optional: true
   - name: metal3-centos-e2e-integration-test-release-1-14
     agent: jenkins
+    labels:
+      jenkins_operator: oci
     always_run: false
     optional: false
   - name: metal3-centos-e2e-integration-test-release-1-13
     agent: jenkins
+    labels:
+      jenkins_operator: oci
     always_run: false
     optional: false
   - name: metal3-centos-e2e-integration-test-release-1-12
     agent: jenkins
+    labels:
+      jenkins_operator: oci
     always_run: false
     optional: true
   - name: metal3-centos-e2e-integration-test-release-1-11
     agent: jenkins
+    labels:
+      jenkins_operator: oci
     always_run: false
     optional: true
   - name: metal3-centos-e2e-integration-test-release-1-10
@@ -130,18 +154,26 @@ presubmits:
     optional: true
   - name: metal3-ubuntu-e2e-integration-test-release-1-14
     agent: jenkins
+    labels:
+      jenkins_operator: oci
     always_run: false
     optional: true
   - name: metal3-ubuntu-e2e-integration-test-release-1-13
     agent: jenkins
+    labels:
+      jenkins_operator: oci
     always_run: false
     optional: true
   - name: metal3-ubuntu-e2e-integration-test-release-1-12
     agent: jenkins
+    labels:
+      jenkins_operator: oci
     always_run: false
     optional: true
   - name: metal3-ubuntu-e2e-integration-test-release-1-11
     agent: jenkins
+    labels:
+      jenkins_operator: oci
     always_run: false
     optional: true
   - name: metal3-ubuntu-e2e-integration-test-release-1-10
@@ -157,18 +189,26 @@ presubmits:
     optional: true
   - name: metal3-centos-e2e-feature-test-release-1-14-pivoting
     agent: jenkins
+    labels:
+      jenkins_operator: oci
     always_run: false
     optional: true
   - name: metal3-centos-e2e-feature-test-release-1-13-pivoting
     agent: jenkins
+    labels:
+      jenkins_operator: oci
     always_run: false
     optional: true
   - name: metal3-centos-e2e-feature-test-release-1-12-pivoting
     agent: jenkins
+    labels:
+      jenkins_operator: oci
     always_run: false
     optional: true
   - name: metal3-centos-e2e-feature-test-release-1-11-pivoting
     agent: jenkins
+    labels:
+      jenkins_operator: oci
     always_run: false
     optional: true
   - name: metal3-centos-e2e-feature-test-release-1-10-pivoting
@@ -183,18 +223,26 @@ presubmits:
     optional: true
   - name: metal3-centos-e2e-feature-test-release-1-14-remediation
     agent: jenkins
+    labels:
+      jenkins_operator: oci
     always_run: false
     optional: true
   - name: metal3-centos-e2e-feature-test-release-1-13-remediation
     agent: jenkins
+    labels:
+      jenkins_operator: oci
     always_run: false
     optional: true
   - name: metal3-centos-e2e-feature-test-release-1-12-remediation
     agent: jenkins
+    labels:
+      jenkins_operator: oci
     always_run: false
     optional: true
   - name: metal3-centos-e2e-feature-test-release-1-11-remediation
     agent: jenkins
+    labels:
+      jenkins_operator: oci
     always_run: false
     optional: true
   - name: metal3-centos-e2e-feature-test-release-1-10-remediation
@@ -209,18 +257,26 @@ presubmits:
     optional: true
   - name: metal3-centos-e2e-feature-test-release-1-14-features
     agent: jenkins
+    labels:
+      jenkins_operator: oci
     always_run: false
     optional: true
   - name: metal3-centos-e2e-feature-test-release-1-13-features
     agent: jenkins
+    labels:
+      jenkins_operator: oci
     always_run: false
     optional: true
   - name: metal3-centos-e2e-feature-test-release-1-12-features
     agent: jenkins
+    labels:
+      jenkins_operator: oci
     always_run: false
     optional: true
   - name: metal3-centos-e2e-feature-test-release-1-11-features
     agent: jenkins
+    labels:
+      jenkins_operator: oci
     always_run: false
     optional: true
   - name: metal3-centos-e2e-feature-test-release-1-10-features
@@ -235,18 +291,26 @@ presubmits:
     optional: true
   - name: metal3-ubuntu-e2e-feature-test-release-1-14-pivoting
     agent: jenkins
+    labels:
+      jenkins_operator: oci
     always_run: false
     optional: true
   - name: metal3-ubuntu-e2e-feature-test-release-1-13-pivoting
     agent: jenkins
+    labels:
+      jenkins_operator: oci
     always_run: false
     optional: true
   - name: metal3-ubuntu-e2e-feature-test-release-1-12-pivoting
     agent: jenkins
+    labels:
+      jenkins_operator: oci
     always_run: false
     optional: true
   - name: metal3-ubuntu-e2e-feature-test-release-1-11-pivoting
     agent: jenkins
+    labels:
+      jenkins_operator: oci
     always_run: false
     optional: true
   - name: metal3-ubuntu-e2e-feature-test-release-1-10-pivoting
@@ -261,18 +325,26 @@ presubmits:
     optional: true
   - name: metal3-ubuntu-e2e-feature-test-release-1-14-remediation
     agent: jenkins
+    labels:
+      jenkins_operator: oci
     always_run: false
     optional: true
   - name: metal3-ubuntu-e2e-feature-test-release-1-13-remediation
     agent: jenkins
+    labels:
+      jenkins_operator: oci
     always_run: false
     optional: true
   - name: metal3-ubuntu-e2e-feature-test-release-1-12-remediation
     agent: jenkins
+    labels:
+      jenkins_operator: oci
     always_run: false
     optional: true
   - name: metal3-ubuntu-e2e-feature-test-release-1-11-remediation
     agent: jenkins
+    labels:
+      jenkins_operator: oci
     always_run: false
     optional: true
   - name: metal3-ubuntu-e2e-feature-test-release-1-10-remediation
@@ -287,18 +359,26 @@ presubmits:
     optional: true
   - name: metal3-ubuntu-e2e-feature-test-release-1-14-features
     agent: jenkins
+    labels:
+      jenkins_operator: oci
     always_run: false
     optional: true
   - name: metal3-ubuntu-e2e-feature-test-release-1-13-features
     agent: jenkins
+    labels:
+      jenkins_operator: oci
     always_run: false
     optional: true
   - name: metal3-ubuntu-e2e-feature-test-release-1-12-features
     agent: jenkins
+    labels:
+      jenkins_operator: oci
     always_run: false
     optional: true
   - name: metal3-ubuntu-e2e-feature-test-release-1-11-features
     agent: jenkins
+    labels:
+      jenkins_operator: oci
     always_run: false
     optional: true
   - name: metal3-ubuntu-e2e-feature-test-release-1-10-features
@@ -314,18 +394,26 @@ presubmits:
     optional: true
   - name: metal3-e2e-clusterctl-upgrade-test-release-1-14
     agent: jenkins
+    labels:
+      jenkins_operator: oci
     always_run: false
     optional: true
   - name: metal3-e2e-clusterctl-upgrade-test-release-1-13
     agent: jenkins
+    labels:
+      jenkins_operator: oci
     always_run: false
     optional: true
   - name: metal3-e2e-clusterctl-upgrade-test-release-1-12
     agent: jenkins
+    labels:
+      jenkins_operator: oci
     always_run: false
     optional: true
   - name: metal3-e2e-clusterctl-upgrade-test-release-1-11
     agent: jenkins
+    labels:
+      jenkins_operator: oci
     always_run: false
     optional: true
   - name: metal3-e2e-clusterctl-upgrade-test-release-1-10
@@ -341,18 +429,26 @@ presubmits:
     optional: true
   - name: metal3-e2e-1-35-1-36-upgrade-test-release-1-14
     agent: jenkins
+    labels:
+      jenkins_operator: oci
     always_run: false
     optional: true
   - name: metal3-e2e-1-35-1-36-upgrade-test-release-1-13
     agent: jenkins
+    labels:
+      jenkins_operator: oci
     always_run: false
     optional: true
   - name: metal3-e2e-1-34-1-35-upgrade-test-release-1-12
     agent: jenkins
+    labels:
+      jenkins_operator: oci
     always_run: false
     optional: true
   - name: metal3-e2e-1-33-1-34-upgrade-test-release-1-11
     agent: jenkins
+    labels:
+      jenkins_operator: oci
     always_run: false
     optional: true
   - name: metal3-dev-env-integration-test-centos-main
@@ -363,18 +459,26 @@ presubmits:
     optional: true
   - name: metal3-dev-env-integration-test-centos-release-1-14
     agent: jenkins
+    labels:
+      jenkins_operator: oci
     always_run: false
     optional: true
   - name: metal3-dev-env-integration-test-centos-release-1-13
     agent: jenkins
+    labels:
+      jenkins_operator: oci
     always_run: false
     optional: true
   - name: metal3-dev-env-integration-test-centos-release-1-12
     agent: jenkins
+    labels:
+      jenkins_operator: oci
     always_run: false
     optional: true
   - name: metal3-dev-env-integration-test-centos-release-1-11
     agent: jenkins
+    labels:
+      jenkins_operator: oci
     always_run: false
     optional: true
   - name: metal3-dev-env-integration-test-centos-release-1-10
@@ -389,18 +493,26 @@ presubmits:
     optional: false
   - name: metal3-dev-env-integration-test-ubuntu-release-1-14
     agent: jenkins
+    labels:
+      jenkins_operator: oci
     always_run: false
     optional: true
   - name: metal3-dev-env-integration-test-ubuntu-release-1-13
     agent: jenkins
+    labels:
+      jenkins_operator: oci
     always_run: false
     optional: true
   - name: metal3-dev-env-integration-test-ubuntu-release-1-12
     agent: jenkins
+    labels:
+      jenkins_operator: oci
     always_run: false
     optional: true
   - name: metal3-dev-env-integration-test-ubuntu-release-1-11
     agent: jenkins
+    labels:
+      jenkins_operator: oci
     always_run: false
     optional: true
   - name: metal3-dev-env-integration-test-ubuntu-release-1-10

--- a/prow/config/jobs/metal3-io/project-infra.yaml
+++ b/prow/config/jobs/metal3-io/project-infra.yaml
@@ -98,6 +98,8 @@ presubmits:
     optional: true
   - name: metal3-centos-e2e-basic-test-release-1-11
     agent: jenkins
+    labels:
+      jenkins_operator: oci
     always_run: false
     optional: true
   - name: metal3-centos-e2e-basic-test-release-1-10
@@ -112,6 +114,8 @@ presubmits:
     optional: true
   - name: metal3-ubuntu-e2e-basic-test-release-1-11
     agent: jenkins
+    labels:
+      jenkins_operator: oci
     always_run: false
     optional: true
   - name: metal3-ubuntu-e2e-basic-test-release-1-10
@@ -127,6 +131,8 @@ presubmits:
     optional: true
   - name: metal3-centos-e2e-integration-test-release-1-11
     agent: jenkins
+    labels:
+      jenkins_operator: oci
     always_run: false
     optional: true
   - name: metal3-centos-e2e-integration-test-release-1-10
@@ -141,6 +147,8 @@ presubmits:
     optional: false
   - name: metal3-ubuntu-e2e-integration-test-release-1-11
     agent: jenkins
+    labels:
+      jenkins_operator: oci
     always_run: false
     optional: true
   - name: metal3-ubuntu-e2e-integration-test-release-1-10
@@ -156,6 +164,8 @@ presubmits:
     optional: true
   - name: metal3-centos-e2e-feature-test-release-1-11-pivoting
     agent: jenkins
+    labels:
+      jenkins_operator: oci
     always_run: false
     optional: true
   - name: metal3-centos-e2e-feature-test-release-1-10-pivoting
@@ -170,6 +180,8 @@ presubmits:
     optional: true
   - name: metal3-centos-e2e-feature-test-release-1-11-remediation
     agent: jenkins
+    labels:
+      jenkins_operator: oci
     always_run: false
     optional: true
   - name: metal3-centos-e2e-feature-test-release-1-10-remediation
@@ -184,6 +196,8 @@ presubmits:
     optional: true
   - name: metal3-centos-e2e-feature-test-release-1-11-features
     agent: jenkins
+    labels:
+      jenkins_operator: oci
     always_run: false
     optional: true
   - name: metal3-centos-e2e-feature-test-release-1-10-features
@@ -198,6 +212,8 @@ presubmits:
     optional: true
   - name: metal3-ubuntu-e2e-feature-test-release-1-11-pivoting
     agent: jenkins
+    labels:
+      jenkins_operator: oci
     always_run: false
     optional: true
   - name: metal3-ubuntu-e2e-feature-test-release-1-10-pivoting
@@ -212,6 +228,8 @@ presubmits:
     optional: true
   - name: metal3-ubuntu-e2e-feature-test-release-1-11-remediation
     agent: jenkins
+    labels:
+      jenkins_operator: oci
     always_run: false
     optional: true
   - name: metal3-ubuntu-e2e-feature-test-release-1-10-remediation
@@ -226,6 +244,8 @@ presubmits:
     optional: true
   - name: metal3-ubuntu-e2e-feature-test-release-1-11-features
     agent: jenkins
+    labels:
+      jenkins_operator: oci
     always_run: false
     optional: true
   - name: metal3-ubuntu-e2e-feature-test-release-1-10-features
@@ -241,6 +261,8 @@ presubmits:
     optional: true
   - name: metal3-e2e-clusterctl-upgrade-test-release-1-11
     agent: jenkins
+    labels:
+      jenkins_operator: oci
     always_run: false
     optional: true
   - name: metal3-e2e-clusterctl-upgrade-test-release-1-10
@@ -256,6 +278,8 @@ presubmits:
     optional: true
   - name: metal3-e2e-1-33-1-34-upgrade-test-release-1-11
     agent: jenkins
+    labels:
+      jenkins_operator: oci
     always_run: false
     optional: true
   - name: metal3-dev-env-integration-test-centos-main
@@ -266,6 +290,8 @@ presubmits:
     optional: true
   - name: metal3-dev-env-integration-test-centos-release-1-11
     agent: jenkins
+    labels:
+      jenkins_operator: oci
     always_run: false
     optional: true
   - name: metal3-dev-env-integration-test-centos-release-1-10
@@ -280,6 +306,8 @@ presubmits:
     optional: true
   - name: metal3-dev-env-integration-test-ubuntu-release-1-11
     agent: jenkins
+    labels:
+      jenkins_operator: oci
     always_run: false
     optional: true
   - name: metal3-dev-env-integration-test-ubuntu-release-1-10


### PR DESCRIPTION
This PR moves remaining Jenkins e2e jobs to the OCI jenkins operator