### PR TITLE
Add BMO e2e fixture test Prow presubmit (Jenkins)

### DIFF
--- a/jenkins/jobs/bmo_e2e_fixture_test.groovy
+++ b/jenkins/jobs/bmo_e2e_fixture_test.groovy
@@ -1,0 +1,48 @@
+// Set defaults for non-PR jobs
+def pullSha = (env.PULL_PULL_SHA) ?: 'main'
+def pullBase = (env.PULL_BASE_REF) ?: 'main'
+def repoUrl = 'https://github.com/metal3-io/baremetal-operator.git'
+// Fetch the base branch and the pullSha, nothing else
+def refspec = '+refs/heads/' + pullBase + ':refs/remotes/origin/' + pullBase + ' ' + pullSha
+
+pipeline {
+    agent { label 'metal3ci-8c32gb-ubuntu-oci' }
+    environment {
+        E2E_CONF_FILE = "${WORKSPACE}/test/e2e/config/fixture.yaml"
+        GINKGO_NODES = '1'
+        IMG = 'quay.io/metal3-io/baremetal-operator'
+        IMG_TAG = 'e2e'
+    }
+    stages {
+        stage('Checkout source code') {
+            steps {
+                deleteDir()
+                checkout scmGit(
+                    branches: [[name: pullSha]],
+                    userRemoteConfigs: [[url: repoUrl, refspec: refspec]],
+                    extensions: [[$class: 'CleanCheckout'],
+                    [$class: 'CleanBeforeCheckout'],
+                    [$class: 'PreBuildMerge', options: [mergeTarget: pullBase, mergeRemote: 'origin']],
+                    cloneOption(honorRefspec: true)],
+                )
+            }
+        }
+        stage('Run Baremetal Operator e2e fixture test') {
+            options {
+                timeout(time: 1800, unit: 'SECONDS')
+                ansiColor('xterm')
+            }
+            steps {
+                timestamps {
+                    sh 'make docker'
+                    sh 'make test-e2e'
+                }
+            }
+            post {
+                always {
+                    archiveArtifacts 'test/e2e/_artifacts/**'
+                }
+            }
+        }
+    }
+}

--- a/prow/config/jobs/metal3-io/baremetal-operator.yaml
+++ b/prow/config/jobs/metal3-io/baremetal-operator.yaml
@@ -288,6 +288,15 @@ presubmits:
       jenkins_operator: oci
     always_run: false
     optional: true
+  - name: metal3-bmo-e2e-fixture-test-optional-pull
+    branches:
+    - main
+    agent: jenkins
+    labels:
+      jenkins_operator: oci
+    run_if_changed: '(test/e2e/.*|pkg/.*|internal/.*|cmd/.*|config/overlays/fixture/.*|Makefile|go\.(mod|sum))$'
+    always_run: false
+    optional: true
   # name: {job_prefix}-{image_os}-e2e-integration-k8s-pre-release-test-{capm3_target_branch}
   - name: metal3-centos-e2e-integration-k8s-pre-release-test-main
     branches:


### PR DESCRIPTION
Adds `metal3-bmo-e2e-fixture-test-optional-pull`, a new Jenkins-backed
Prow presubmit for baremetal-operator that runs the e2e fixture suite
(`make docker && make test-e2e` against `test/e2e/config/fixture.yaml`),
mirroring what `.github/workflows/e2e-fixture-test.yml` already does
on GitHub Actions.

Part of #1448 (move BMO e2e off GitHub Actions onto Jenkins/OCI).