### PR TITLE
ovs-scanner: update scanned irso version

### DIFF
--- a/jenkins/jobs/osv_scanner_metal3.groovy
+++ b/jenkins/jobs/osv_scanner_metal3.groovy
@@ -240,7 +240,7 @@ pipeline {
                     .findAll { branch -> branch }
 
                     IRSO_BRANCHES = sh(
-                      script: "jenkins/scripts/get_last_n_release_branches.sh ${IRSO_GIT_URL} 3",
+                      script: "jenkins/scripts/get_last_n_release_branches.sh ${IRSO_GIT_URL} 2",
                       returnStdout: true
                     ).trim()
                     .split('\\n')


### PR DESCRIPTION
IrSO v0.9.0 is no longer a supported version. No reason to scan it.