### PR TITLE
drop deprecated Git clean extensions, rely on deleteDir

### DIFF
--- a/jenkins/jobs/bml_integration_tests.groovy
+++ b/jenkins/jobs/bml_integration_tests.groovy
@@ -47,11 +47,6 @@ pipeline {
                         [name: ci_git_branch]
                         ],
                     doGenerateSubmoduleConfigurations: false,
-                    extensions: [
-                        [$class: 'CleanCheckout'],
-                        [$class: 'CleanBeforeCheckout']
-                        ],
-                    submoduleCfg: [],
                     userRemoteConfigs: [[url: ci_git_url, refspec: refspec, credentialsId: 'metal3-clusterctl-github-token']]
                 ])
                 script {

--- a/jenkins/jobs/bmo_e2e_optional_tests.groovy
+++ b/jenkins/jobs/bmo_e2e_optional_tests.groovy
@@ -40,12 +40,10 @@ pipeline {
                             checkout scmGit(
                   branches: [[name: pullSha]],
                   userRemoteConfigs: [[url: repoUrl, refspec: refspec, credentialsId: 'metal3-clusterctl-github-token']],
-                  extensions: [[$class: 'CleanCheckout'],
-                  [$class: 'CleanBeforeCheckout'],
+                  extensions: [
                   [$class: 'PreBuildMerge', options: [mergeTarget: pullBase, mergeRemote: 'origin']],
                   [$class: 'UserIdentity', name: 'Test', email: 'test@test.test'],
-                  cloneOption(honorRefspec: true)],
-                  submoduleCfg: [],)
+                  cloneOption(honorRefspec: true)])
                             script {
                                 CURRENT_START_TIME = System.currentTimeMillis()
                             }

--- a/jenkins/jobs/capm3-e2e-tests.groovy
+++ b/jenkins/jobs/capm3-e2e-tests.groovy
@@ -98,11 +98,6 @@ pipeline {
                     [name: ci_git_branch]
                     ],
                   doGenerateSubmoduleConfigurations: false,
-                  extensions: [
-                      [$class: 'CleanCheckout'],
-                      [$class: 'CleanBeforeCheckout']
-                      ],
-                  submoduleCfg: [],
                   userRemoteConfigs: [[url: ci_git_url, refspec: refspec, credentialsId: 'metal3-clusterctl-github-token']]
                   ])
                 withCredentials([string(credentialsId: 'metal3-clusterctl-github-token', variable: 'GITHUB_TOKEN'),

--- a/jenkins/jobs/clean_resources.groovy
+++ b/jenkins/jobs/clean_resources.groovy
@@ -26,9 +26,6 @@ pipeline {
                 checkout([$class: 'GitSCM',
                  branches: [[name: ci_git_branch]],
                  doGenerateSubmoduleConfigurations: false,
-                 extensions: [[$class: 'CleanCheckout'],
-                 [$class: 'CleanBeforeCheckout']],
-                 submoduleCfg: [],
                  userRemoteConfigs: [[url: ci_git_url,  refspec: refspec, credentialsId: 'metal3-clusterctl-github-token']]])
             }
         }

--- a/jenkins/jobs/dev_env_integration_tests.groovy
+++ b/jenkins/jobs/dev_env_integration_tests.groovy
@@ -64,11 +64,6 @@ pipeline {
                     [name: ci_git_branch]
                   ],
                   doGenerateSubmoduleConfigurations: false,
-                  extensions: [
-                    [$class: 'CleanCheckout'],
-                    [$class: 'CleanBeforeCheckout']
-                  ],
-                  submoduleCfg: [],
                   userRemoteConfigs: [[url: ci_git_url, refspec: refspec, credentialsId: 'metal3-clusterctl-github-token']]
                 ])
                 withCredentials([string(credentialsId: 'metal3-clusterctl-github-token', variable: 'GITHUB_TOKEN')]) {

--- a/jenkins/jobs/dynamic_fullstack_building.groovy
+++ b/jenkins/jobs/dynamic_fullstack_building.groovy
@@ -66,11 +66,6 @@ pipeline {
                         [name: ci_git_branch]
                         ],
                     doGenerateSubmoduleConfigurations: false,
-                    extensions: [
-                        [$class: 'CleanCheckout'],
-                        [$class: 'CleanBeforeCheckout']
-                        ],
-                    submoduleCfg: [],
                     userRemoteConfigs: [[url: ci_git_url, refspec: refspec, credentialsId: 'metal3-clusterctl-github-token']]
                 ])
                 /* Pass all the credentials */

--- a/jenkins/jobs/image_building.groovy
+++ b/jenkins/jobs/image_building.groovy
@@ -65,11 +65,6 @@ pipeline {
                 $class: 'GitSCM',
                 branches: [[name: ci_git_branch]],
                 doGenerateSubmoduleConfigurations: false,
-                extensions: [
-                  [$class: 'CleanCheckout'],
-                  [$class: 'CleanBeforeCheckout']
-                ],
-                submoduleCfg: [],
                 userRemoteConfigs: [[url: ci_git_url, refspec: refspec, credentialsId: 'metal3-clusterctl-github-token']]
               ])
                         }

--- a/jenkins/jobs/osv_scanner_metal3.groovy
+++ b/jenkins/jobs/osv_scanner_metal3.groovy
@@ -204,11 +204,6 @@ pipeline {
                 $class: 'GitSCM',
                 branches: [[name: ci_git_branch]],
                 doGenerateSubmoduleConfigurations: false,
-                extensions: [
-                  [$class: 'CleanCheckout'],
-                  [$class: 'CleanBeforeCheckout']
-                ],
-                submoduleCfg: [],
                 userRemoteConfigs: [[url: ci_git_url, refspec: refspec, credentialsId: 'metal3-clusterctl-github-token']]
               ])
             }

--- a/jenkins/jobs/pre_release_tests.groovy
+++ b/jenkins/jobs/pre_release_tests.groovy
@@ -63,11 +63,6 @@ pipeline {
                     $class: 'GitSCM',
                     branches: [[name: ci_git_branch]],
                     doGenerateSubmoduleConfigurations: false,
-                    extensions: [
-                        [$class: 'CleanCheckout'],
-                        [$class: 'CleanBeforeCheckout']
-                    ],
-                    submoduleCfg: [],
                     userRemoteConfigs: [[url: ci_git_url, refspec: refspec, credentialsId: 'metal3-clusterctl-github-token']]
                 ])
             }


### PR DESCRIPTION
This PR drops deprecated Git clean extensions, rely on deleteDir:

The warning from jenkins UI:
`DEPRECATED: The 'Wipe out repository & force clone' extension is deprecated for Pipeline jobs. Pipeline users should use the deleteDir() step instead.`
