### PR TITLE
Add clusterctl-upgrade e2e job for CAPI nightly build

### DIFF
--- a/prow/config/jobs/metal3-io/cluster-api-provider-metal3.yaml
+++ b/prow/config/jobs/metal3-io/cluster-api-provider-metal3.yaml
@@ -300,6 +300,15 @@ presubmits:
       jenkins_operator: oci
     always_run: false
     optional: true
+  # name: {job_prefix}-e2e-clusterctl-upgrade-test-{capm3_target_branch}-capi-nightly-build
+  - name: metal3-e2e-clusterctl-upgrade-test-main-capi-nightly-build
+    branches:
+    - main
+    agent: jenkins
+    labels:
+      jenkins_operator: oci
+    always_run: false
+    optional: true
   # name: {job_prefix}-e2e-{k8s_versions}-upgrade-test-{capm3_target_branch}
   - name: metal3-e2e-1-35-1-36-upgrade-test-main
     branches:


### PR DESCRIPTION
Adds a Prow presubmit entry for a clusterctl-upgrade e2e job that runs against the CAPI nightly build, mirroring the existing `*-integration-test-main-capi-nightly-build` jobs.

The nightly path is already supported e2e (`ci-e2e.sh` sets `CAPIRELEASE=v1.15.99` when `CAPI_NIGHTLY_BUILD=true`, and `e2e_conf.yaml` maps v1.15.99 to the nightly components), so this only wires up the job entry.

**NOTE**: executing depends on the corresponding Jenkins/JJB definition in the Nordix Gerrit `infra/cicd` repo. Please confirm that JJB job exist or add it so this presubmit resolves to a runnable job.