### PR TITLE
add GH token to SCM steps in pipeline scripts

### DIFF
--- a/jenkins/jobs/bml_integration_tests.groovy
+++ b/jenkins/jobs/bml_integration_tests.groovy
@@ -52,7 +52,7 @@ pipeline {
                         [$class: 'CleanBeforeCheckout']
                         ],
                     submoduleCfg: [],
-                    userRemoteConfigs: [[url: ci_git_url, refspec: refspec]]
+                    userRemoteConfigs: [[url: ci_git_url, refspec: refspec, credentialsId: 'metal3-clusterctl-github-token']]
                 ])
                 script {
                     CURRENT_START_TIME = System.currentTimeMillis()

--- a/jenkins/jobs/bmo_e2e_optional_tests.groovy
+++ b/jenkins/jobs/bmo_e2e_optional_tests.groovy
@@ -39,7 +39,7 @@ pipeline {
                             deleteDir()
                             checkout scmGit(
                   branches: [[name: pullSha]],
-                  userRemoteConfigs: [[url: repoUrl, refspec: refspec]],
+                  userRemoteConfigs: [[url: repoUrl, refspec: refspec, credentialsId: 'metal3-clusterctl-github-token']],
                   extensions: [[$class: 'CleanCheckout'],
                   [$class: 'CleanBeforeCheckout'],
                   [$class: 'PreBuildMerge', options: [mergeTarget: pullBase, mergeRemote: 'origin']],

--- a/jenkins/jobs/capm3-e2e-tests.groovy
+++ b/jenkins/jobs/capm3-e2e-tests.groovy
@@ -103,7 +103,7 @@ pipeline {
                       [$class: 'CleanBeforeCheckout']
                       ],
                   submoduleCfg: [],
-                  userRemoteConfigs: [[url: ci_git_url, refspec: refspec]]
+                  userRemoteConfigs: [[url: ci_git_url, refspec: refspec, credentialsId: 'metal3-clusterctl-github-token']]
                   ])
                 withCredentials([string(credentialsId: 'metal3-clusterctl-github-token', variable: 'GITHUB_TOKEN'),
                     usernamePassword(credentialsId: 'metal3-ci-log-collector-push', usernameVariable: 'LOKI_USERNAME', passwordVariable: 'LOKI_PASSWORD')]) {

--- a/jenkins/jobs/clean_resources.groovy
+++ b/jenkins/jobs/clean_resources.groovy
@@ -29,7 +29,7 @@ pipeline {
                  extensions: [[$class: 'CleanCheckout'],
                  [$class: 'CleanBeforeCheckout']],
                  submoduleCfg: [],
-                 userRemoteConfigs: [[url: ci_git_url,  refspec: refspec]]])
+                 userRemoteConfigs: [[url: ci_git_url,  refspec: refspec, credentialsId: 'metal3-clusterctl-github-token']]])
             }
         }
         stage('Clean old integration test vms') {

--- a/jenkins/jobs/dev_env_integration_tests.groovy
+++ b/jenkins/jobs/dev_env_integration_tests.groovy
@@ -69,7 +69,7 @@ pipeline {
                     [$class: 'CleanBeforeCheckout']
                   ],
                   submoduleCfg: [],
-                  userRemoteConfigs: [[url: ci_git_url, refspec: refspec]]
+                  userRemoteConfigs: [[url: ci_git_url, refspec: refspec, credentialsId: 'metal3-clusterctl-github-token']]
                 ])
                 withCredentials([string(credentialsId: 'metal3-clusterctl-github-token', variable: 'GITHUB_TOKEN')]) {
                     ansiColor('xterm') {

--- a/jenkins/jobs/dynamic_fullstack_building.groovy
+++ b/jenkins/jobs/dynamic_fullstack_building.groovy
@@ -71,7 +71,7 @@ pipeline {
                         [$class: 'CleanBeforeCheckout']
                         ],
                     submoduleCfg: [],
-                    userRemoteConfigs: [[url: ci_git_url, refspec: refspec]]
+                    userRemoteConfigs: [[url: ci_git_url, refspec: refspec, credentialsId: 'metal3-clusterctl-github-token']]
                 ])
                 /* Pass all the credentials */
                 withCredentials([usernamePassword(credentialsId: 'infra-nordix-artifactory-api-key', usernameVariable: 'RT_USER', passwordVariable: 'RT_TOKEN'),

--- a/jenkins/jobs/image_building.groovy
+++ b/jenkins/jobs/image_building.groovy
@@ -70,7 +70,7 @@ pipeline {
                   [$class: 'CleanBeforeCheckout']
                 ],
                 submoduleCfg: [],
-                userRemoteConfigs: [[url: ci_git_url, refspec: refspec]]
+                userRemoteConfigs: [[url: ci_git_url, refspec: refspec, credentialsId: 'metal3-clusterctl-github-token']]
               ])
                         }
                     }

--- a/jenkins/jobs/osv_scanner_metal3.groovy
+++ b/jenkins/jobs/osv_scanner_metal3.groovy
@@ -209,7 +209,7 @@ pipeline {
                   [$class: 'CleanBeforeCheckout']
                 ],
                 submoduleCfg: [],
-                userRemoteConfigs: [[url: ci_git_url, refspec: refspec]]
+                userRemoteConfigs: [[url: ci_git_url, refspec: refspec, credentialsId: 'metal3-clusterctl-github-token']]
               ])
             }
         }

--- a/jenkins/jobs/pre_release_tests.groovy
+++ b/jenkins/jobs/pre_release_tests.groovy
@@ -68,7 +68,7 @@ pipeline {
                         [$class: 'CleanBeforeCheckout']
                     ],
                     submoduleCfg: [],
-                    userRemoteConfigs: [[url: ci_git_url, refspec: refspec]]
+                    userRemoteConfigs: [[url: ci_git_url, refspec: refspec, credentialsId: 'metal3-clusterctl-github-token']]
                 ])
             }
         }


### PR DESCRIPTION
This PR:

 - Introduces the use of an existing GitHub token for the declarative SCM steps in the pipeline scripts.

This change is needed to avoid hitting GitHub rate limit.