### PR TITLE
Bump CentOS Stream base image for image building workflow

### DIFF
--- a/jenkins/image_building/build-image.sh
+++ b/jenkins/image_building/build-image.sh
@@ -76,7 +76,7 @@ if [[ "${IMAGE_OS}" == "ubuntu" ]]; then
 elif [[ "${IMAGE_OS}" == "centos" ]]; then
   numeric_release=10
   # Setting upstrem Centos 10 stream image
-  centos_upstream_img="CentOS-Stream-GenericCloud-10-20251027.0.x86_64.qcow2"
+  centos_upstream_img="CentOS-Stream-GenericCloud-10-20260901.0.x86_64.qcow2"
 
   if [[ ! -f "${REPO_ROOT}/${centos_upstream_img}" ]]; then
     wget -O "${REPO_ROOT}/${centos_upstream_img}" "https://cloud.centos.org/centos/10-stream/x86_64/images/${centos_upstream_img}"

--- a/jenkins/scripts/dynamic_worker_workflow/build_ipa.sh
+++ b/jenkins/scripts/dynamic_worker_workflow/build_ipa.sh
@@ -59,7 +59,7 @@ IPA_BASE_OS="${IPA_BASE_OS:-centos}"
 IPA_BASE_OS_RELEASE="${IPA_BASE_OS_RELEASE:-9-stream}"
 
 if [[ "${IPA_BASE_OS}" == "centos" ]]; then
-  centos_upstream_img="CentOS-Stream-GenericCloud-9-20250812.1.x86_64.qcow2"
+  centos_upstream_img="CentOS-Stream-GenericCloud-9-20260902.0.x86_64.qcow2"
 
   if [[ ! -f "${centos_upstream_img}" ]]; then
     wget -O "${centos_upstream_img}" \


### PR DESCRIPTION
Use versions CentOS-Stream-GenericCloud-9-20260902.0.x86_64.qcow2 for IPA and CentOS-Stream-GenericCloud-10-20260901.0.x86_64.qcow2 for images.