### PR TITLE
Add yamllint Prow presubmit for CAPM3 main, release-1.13, release-1.14

### DIFF
--- a/prow/config/jobs/metal3-io/cluster-api-provider-metal3-release-1.13.yaml
+++ b/prow/config/jobs/metal3-io/cluster-api-provider-metal3-release-1.13.yaml
@@ -162,6 +162,23 @@ presubmits:
         - sh
         image: docker.io/golang:1.25
         imagePullPolicy: Always
+  - name: yamllint
+    branches:
+    - release-1.13
+    run_if_changed: '((\.ya?ml)|(\.md)|(hack/yamllint\.sh))$'
+    decorate: true
+    optional: true
+    spec:
+      containers:
+      - args:
+        - ./hack/yamllint.sh
+        command:
+        - sh
+        env:
+        - name: IS_CONTAINER
+          value: "TRUE"
+        image: docker.io/pipelinecomponents/yamllint:0.35.13@sha256:5ab5eb7da0ed5e606b07c1723fc8b275e925189f70ac259b26b7329cb5f8f44d
+        imagePullPolicy: Always
   # name: {job_prefix}-{image_os}-e2e-basic-test-{capm3_target_branch}
   - name: metal3-centos-e2e-basic-test-release-1-13
     branches:

--- a/prow/config/jobs/metal3-io/cluster-api-provider-metal3-release-1.14.yaml
+++ b/prow/config/jobs/metal3-io/cluster-api-provider-metal3-release-1.14.yaml
@@ -128,6 +128,23 @@ presubmits:
           value: "TRUE"
         image: docker.io/golang:1.26
         imagePullPolicy: Always
+  - name: yamllint
+    branches:
+    - release-1.14
+    run_if_changed: '((\.ya?ml)|(\.md)|(hack/yamllint\.sh))$'
+    decorate: true
+    optional: true
+    spec:
+      containers:
+      - args:
+        - ./hack/yamllint.sh
+        command:
+        - sh
+        env:
+        - name: IS_CONTAINER
+          value: "TRUE"
+        image: docker.io/pipelinecomponents/yamllint:0.35.13@sha256:5ab5eb7da0ed5e606b07c1723fc8b275e925189f70ac259b26b7329cb5f8f44d
+        imagePullPolicy: Always
   # name: {job_prefix}-{image_os}-e2e-basic-test-{capm3_target_branch}
   - name: metal3-centos-e2e-basic-test-release-1-14
     branches:

--- a/prow/config/jobs/metal3-io/cluster-api-provider-metal3.yaml
+++ b/prow/config/jobs/metal3-io/cluster-api-provider-metal3.yaml
@@ -183,6 +183,23 @@ presubmits:
         - sh
         image: docker.io/golang:1.26
         imagePullPolicy: Always
+  - name: yamllint
+    branches:
+    - main
+    run_if_changed: '((\.ya?ml)|(\.md)|(hack/yamllint\.sh))$'
+    decorate: true
+    optional: true
+    spec:
+      containers:
+      - args:
+        - ./hack/yamllint.sh
+        command:
+        - sh
+        env:
+        - name: IS_CONTAINER
+          value: "TRUE"
+        image: docker.io/pipelinecomponents/yamllint:0.35.13@sha256:5ab5eb7da0ed5e606b07c1723fc8b275e925189f70ac259b26b7329cb5f8f44d
+        imagePullPolicy: Always
   # name: {job_prefix}-{image_os}-e2e-basic-test-{capm3_target_branch}
   - name: metal3-centos-e2e-basic-test-main
     branches:


### PR DESCRIPTION
This adds yamllint Prow presubmit for CAPM3 main, release-1.13, release-1.14

Part of https://github.com/metal3-io/project-infra/issues/1448.