### PR TITLE
Add Slack receiver for Alertmanager on Default and Critical

### DIFF
--- a/prow/bootstrap/clustersecretstore.yaml
+++ b/prow/bootstrap/clustersecretstore.yaml
@@ -18,3 +18,4 @@ spec:
     - kube-system # CPO runs here
     - prow # Prow components run here
     - test-pods # Pods for ProwJobs run here
+    - monitoring # Alertmanager Slack webhook secret

--- a/prow/infra/kube-prometheus/README.md
+++ b/prow/infra/kube-prometheus/README.md
@@ -10,6 +10,7 @@ This is how you apply it in the cluster:
 ```bash
 kubectl apply -f manifests/setup
 kubectl apply -f manifests
+kubectl apply -f alertmanager-slack-webhook-externalsecret.yaml
 kubectl apply -f prow-rules.yaml
 ```
 

--- a/prow/infra/kube-prometheus/alertmanager-slack-webhook-externalsecret.yaml
+++ b/prow/infra/kube-prometheus/alertmanager-slack-webhook-externalsecret.yaml
@@ -1,0 +1,16 @@
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: alertmanager-slack-webhook
+  namespace: monitoring
+spec:
+  secretStoreRef:
+    kind: ClusterSecretStore
+    name: onepassword
+  target:
+    creationPolicy: Owner
+  data:
+  - secretKey: url
+    remoteRef:
+      # <item-name>/[section-name/]<file-name>
+      key: "alertmanager-slack-webhook/url"

--- a/prow/infra/kube-prometheus/manifests/alertmanager-alertmanager.yaml
+++ b/prow/infra/kube-prometheus/manifests/alertmanager-alertmanager.yaml
@@ -29,7 +29,8 @@ spec:
     requests:
       cpu: 4m
       memory: 100Mi
-  secrets: []
+  secrets:
+  - alertmanager-slack-webhook
   securityContext:
     fsGroup: 2000
     runAsNonRoot: true

--- a/prow/infra/kube-prometheus/manifests/alertmanager-secret.yaml
+++ b/prow/infra/kube-prometheus/manifests/alertmanager-secret.yaml
@@ -36,8 +36,16 @@ stringData:
       - "severity = info"
     "receivers":
     - "name": "Default"
+      "slack_configs":
+      - "api_url_file": "/etc/alertmanager/secrets/alertmanager-slack-webhook/url"
+        "channel": "#cluster-api-baremetal"
+        "send_resolved": true
     - "name": "Watchdog"
     - "name": "Critical"
+      "slack_configs":
+      - "api_url_file": "/etc/alertmanager/secrets/alertmanager-slack-webhook/url"
+        "channel": "#cluster-api-baremetal"
+        "send_resolved": true
     - "name": "null"
     "route":
       "group_by":

--- a/prow/infra/kube-prometheus/metal3-kube-prometheus.jsonnet
+++ b/prow/infra/kube-prometheus/metal3-kube-prometheus.jsonnet
@@ -15,6 +15,62 @@ local kp =
       common+: {
         namespace: 'monitoring',
       },
+      alertmanager+: {
+        config: {
+          global: {
+            resolve_timeout: '5m',
+          },
+          inhibit_rules: [
+            {
+              source_matchers: ['severity = critical'],
+              target_matchers: ['severity =~ warning|info'],
+              equal: ['namespace', 'alertname'],
+            },
+            {
+              source_matchers: ['severity = warning'],
+              target_matchers: ['severity = info'],
+              equal: ['namespace', 'alertname'],
+            },
+            {
+              source_matchers: ['alertname = InfoInhibitor'],
+              target_matchers: ['severity = info'],
+              equal: ['namespace'],
+            },
+          ],
+          route: {
+            group_by: ['namespace'],
+            group_wait: '30s',
+            group_interval: '5m',
+            repeat_interval: '12h',
+            receiver: 'Default',
+            routes: [
+              { receiver: 'Watchdog', matchers: ['alertname = Watchdog'] },
+              { receiver: 'null', matchers: ['alertname = InfoInhibitor'] },
+              { receiver: 'Critical', matchers: ['severity = critical'] },
+            ],
+          },
+          receivers: [
+            {
+              name: 'Default',
+              slack_configs: [{
+                api_url_file: '/etc/alertmanager/secrets/alertmanager-slack-webhook/url',
+                channel: '#cluster-api-baremetal',
+                send_resolved: true,
+              }],
+            },
+            { name: 'Watchdog' },
+            {
+              name: 'Critical',
+              slack_configs: [{
+                api_url_file: '/etc/alertmanager/secrets/alertmanager-slack-webhook/url',
+                channel: '#cluster-api-baremetal',
+                send_resolved: true,
+              }],
+            },
+            { name: 'null' },
+          ],
+        },
+      },
       grafana+: {
         dashboards+:: {  // use this method to import your dashboards to Grafana
           'jobs.json': (import 'jobs.json'),
@@ -132,6 +188,7 @@ local kp =
           nodeSelector+: {
             "node-role.kubernetes.io/infra": "",
           },
+          secrets: ['alertmanager-slack-webhook'],
         },
       },
     },


### PR DESCRIPTION
Fixes #930

Wires up an actual notification destination for Prow's Alertmanager alerting stack, which has been deployed since #896 but never had anywhere to send alerts.