### PR TITLE
Split CAPM3 lint into two Prow jobs for release-1.13

### DIFF
--- a/prow/config/jobs/metal3-io/cluster-api-provider-metal3-release-1.13.yaml
+++ b/prow/config/jobs/metal3-io/cluster-api-provider-metal3-release-1.13.yaml
@@ -117,10 +117,28 @@ presubmits:
     - release-1.13
     skip_if_only_changed: '(((^|/)OWNERS)|((^|/)OWNERS_ALIASES)|(\.md))$'
     decorate: true
+    optional: true
     spec:
       containers:
       - args:
-        - lint
+        - golangci
+        command:
+        - make
+        env:
+        - name: IS_CONTAINER
+          value: "TRUE"
+        image: docker.io/golang:1.25
+        imagePullPolicy: Always
+  - name: kube-api-lint
+    branches:
+    - release-1.13
+    skip_if_only_changed: '(((^|/)OWNERS)|((^|/)OWNERS_ALIASES)|(\.md))$'
+    decorate: true
+    optional: true
+    spec:
+      containers:
+      - args:
+        - kube-api-lint
         command:
         - make
         env:


### PR DESCRIPTION
Update the CAPM3 presubmits so linting runs as two independent checks. The golangci-lint job now runs `make golangci` (golangci-lint across all modules no KAL) instead of `make lint`, and a new `kube-api-lint` job runs make `make kube-api-lint` (KAL only).

This avoids running KAL twice and keeps the two checks separate.

**NOTE**: This is PR(2) depends on PR(1) [#3703](https://github.com/metal3-io/cluster-api-provider-metal3/pull/3703) make targets existing on CAPM3 main. These jobs will fail until PR(1) is merge.