### PR TITLE
Split CAPM3 lint into two Prow jobs for release-1.14

### DIFF
--- a/prow/config/jobs/metal3-io/cluster-api-provider-metal3-release-1.14.yaml
+++ b/prow/config/jobs/metal3-io/cluster-api-provider-metal3-release-1.14.yaml
@@ -128,6 +128,40 @@ presubmits:
           value: "TRUE"
         image: docker.io/golang:1.26
         imagePullPolicy: Always
+  - name: golangci-lint
+    branches:
+    - release-1.14
+    skip_if_only_changed: '(((^|/)OWNERS)|((^|/)OWNERS_ALIASES)|(\.md))$'
+    decorate: true
+    optional: true
+    spec:
+      containers:
+      - args:
+        - golangci
+        command:
+        - make
+        env:
+        - name: IS_CONTAINER
+          value: "TRUE"
+        image: docker.io/golang:1.26
+        imagePullPolicy: Always
+  - name: kube-api-lint
+    branches:
+    - release-1.14
+    skip_if_only_changed: '(((^|/)OWNERS)|((^|/)OWNERS_ALIASES)|(\.md))$'
+    decorate: true
+    optional: true
+    spec:
+      containers:
+      - args:
+        - kube-api-lint
+        command:
+        - make
+        env:
+        - name: IS_CONTAINER
+          value: "TRUE"
+        image: docker.io/golang:1.26
+        imagePullPolicy: Always
   - name: yamllint
     branches:
     - release-1.14


### PR DESCRIPTION
Update the CAPM3 presubmits so linting runs as two independent checks. The golangci-lint job now runs `make golangci` (golangci-lint across all modules no KAL) instead of `make lint`, and a new `kube-api-lint` job runs make `make kube-api-lint` (KAL only).

This avoids running KAL twice and keeps the two checks separate.

**NOTE**: This is PR(2) depends on PR(1) [#3705 ](https://github.com/metal3-io/cluster-api-provider-metal3/pull/3705)make targets existing on CAPM3 main. These jobs will fail until PR(1) is merge.